### PR TITLE
fix: treat synckit as an optional dependency

### DIFF
--- a/packages/preview2-shim/lib/nodejs/http.js
+++ b/packages/preview2-shim/lib/nodejs/http.js
@@ -1,12 +1,13 @@
-import { createSyncFn } from "synckit";
-import path from "node:path";
+import { createRequire } from 'node:module';
 import { fileURLToPath } from "node:url";
 import { UnexpectedError } from "../http/error.js";
 
+const require = createRequire(fileURLToPath(import.meta.url));
+
 export function send(req) {
   console.log(`[http] Send (nodejs) ${req.uri}`);
-  const dirname = path.dirname(fileURLToPath(import.meta.url));
-  const syncFn = createSyncFn(path.resolve(dirname, "../http/make-request.js"));
+  const { createSyncFn } = require('synckit');
+  const syncFn = createSyncFn(fileURLToPath(new URL('../http/make-request.js'), import.meta.url));
   let rawResponse = syncFn(req);
   let response = JSON.parse(rawResponse);
   if (response.status) {


### PR DESCRIPTION
This treats `synckit` used in the Node.js http shim as an optional dependency.

@eduardomourar ideally I think we should fully inline any dependency usage if we can, as it would be great to have no dependencies for this.