### PR TITLE
feat: componentize command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@
 
 Features include:
 
+* Creating WebAssembly Components from JavaScript sources and a WIT world
 * "Transpiling" Wasm Component binaries into ES modules that can run in any JS environment.
-* Optimization helpers for Components via Binaryen
+* Optimization helpers for Components via Binaryen.
 * Component builds of [Wasm Tools](https://github.com/bytecodealliance/wasm-tools) helpers, available for use as a library or CLI commands for use in native JS environments.
 
-For creating components, see the [Cargo Component](https://github.com/bytecodealliance/cargo-Component) project for Rust and [Wit Bindgen](https://github.com/bytecodealliance/wit-bindgen) for various guest bindgen helpers.
+For creating components in other languages, see the [Cargo Component](https://github.com/bytecodealliance/cargo-Component) project for Rust and [Wit Bindgen](https://github.com/bytecodealliance/wit-bindgen) for various guest bindgen helpers.
 
 > **Note**: This is an experimental project, no guarantees are provided for stability or support and breaking changes may be made in future.
 
@@ -38,9 +39,41 @@ jco can be used as either a library or as a CLI via the `jco` CLI command.
 
 See the [example workflow](EXAMPLE.md) page for a full usage example.
 
+## CLI
+
+```shell
+Usage: jco <command> [options]
+
+jco - WebAssembly JS Component Tools
+      JS Component Transpilation Bindgen & Wasm Tools for JS
+
+Options:
+  -V, --version                         output the version number
+  -h, --help                            display help for command
+
+Commands:
+  componentize [options] <js-source>    Create a component from a JavaScript module
+  transpile [options] <component-path>  Transpile a WebAssembly Component to JS + core Wasm for JavaScript execution
+  opt [options] <component-file>        optimizes a Wasm component, including running wasm-opt Binaryen optimizations
+  wit [options] <component-path>        extract the WIT from a WebAssembly Component [wasm-tools component wit]
+  print [options] <input>               print the WebAssembly WAT text for a binary file [wasm-tools print]
+  metadata-show [options] [module]      extract the producer metadata for a Wasm binary [wasm-tools metadata show]
+  metadata-add [options] [module]       add producer metadata for a Wasm binary [wasm-tools metadata add]
+  parse [options] <input>               parses the Wasm text format into a binary file [wasm-tools parse]
+  new [options] <core-module>           create a WebAssembly component adapted from a component core Wasm [wasm-tools component new]
+  embed [options] [core-module]         embed the component typing section into a core Wasm module [wasm-tools component embed]
+  help [command]                        display help for command
+```
+
 ## API
 
 The below is an outline of the available API functions, see [api.d.ts](api.d.ts) file for the exact options.
+
+#### `componentize(jsSource: String, witWorld: String, opts?): Promise<{ component: Uint8Array }>`
+
+Creates a component from a JS file and WIT world definition, via a Spidermonkey engine embedding.
+
+See [ComponentizeJS](https://github.com/bytecodealliance/componentize-js) for more details on this process.
 
 #### `transpile(component: Uint8Array, opts?): Promise<{ files: Record<string, Uint8Array> }>`
 
@@ -91,31 +124,6 @@ Parse a compoment WAT to output a Component binary.
 #### `metadataAdd(wasm: Uint8Array, metadata): Uint8Array`
 
 Add new producer metadata to a component or core Wasm binary.
-
-## CLI
-
-```shell
-Usage: jco <command> [options]
-
-jco - WebAssembly JS Component Tools
-       JS Component Transpilation Bindgen & Wasm Tools for JS
-
-Options:
-  -V, --version                         output the version number
-  -h, --help                            display help for command
-
-Commands:
-  transpile [options] <component-path>  Transpile a WebAssembly Component to JS + core Wasm for JavaScript execution
-  opt [options] <component-file>        optimizes a Wasm component, including running wasm-opt Binaryen optimizations
-  wit [options] <component-path>        extract the WIT from a WebAssembly Component [wasm-tools component wit]
-  print [options] <input>               print the WebAssembly WAT text for a binary file [wasm-tools print]
-  metadata-show [options] [module]      extract the producer metadata for a Wasm binary [wasm-tools metadata show]
-  metadata-add [options] [module]       add producer metadata for a Wasm binary [wasm-tools metadata add]
-  parse [options] <input>               parses the Wasm text format into a binary file [wasm-tools parse]
-  new [options] <core-module>           create a WebAssembly component adapted from a component core Wasm [wasm-tools component new]
-  embed [options] [core-module]         embed the component typing section into a core Wasm module [wasm-tools component embed]
-  help [command]                        display help for command
-```
 
 ## Contributing
 

--- a/build-dist.sh
+++ b/build-dist.sh
@@ -1,9 +1,9 @@
-./node_modules/.bin/ncc build src/jco.js -o dist-cli
+./node_modules/.bin/ncc build src/jco.js -o dist-cli --external @bytecodealliance/componentize-js
 chmod +x dist-cli/wasm2js dist-cli/wasm-opt
 echo {} > dist-cli/package.json
 mv dist-cli/index.js dist-cli/cli.mjs
 
-./node_modules/.bin/ncc build src/api.js -o dist-api
+./node_modules/.bin/ncc build src/api.js -o dist-api --external @bytecodealliance/componentize-js
 chmod +x dist-api/wasm2js dist-api/wasm-opt
 mv dist-api/index.js dist-api/api.mjs
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "type": "module",
   "private": true,
   "devDependencies": {
+    "@bytecodealliance/componentize-js": "^0.0.1",
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",

--- a/src/api.js
+++ b/src/api.js
@@ -2,3 +2,4 @@ export { optimizeComponent as opt } from './cmd/opt.js';
 export { transpileComponent as transpile } from './cmd/transpile.js';
 import { exports } from '../obj/wasm-tools.js';
 export const { parse, print, componentNew, componentWit, componentEmbed, metadataAdd, metadataShow } = exports;
+export { componentize } from '@bytecodealliance/componentize-js';

--- a/src/cmd/componentize.js
+++ b/src/cmd/componentize.js
@@ -1,0 +1,11 @@
+import { readFile, writeFile } from 'node:fs/promises';
+import { componentize as componentizeFn } from '../../../componentize-js/lib/componentize.js';
+import c from 'chalk-template';
+
+export async function componentize (jsSource, opts) {
+  const source = await readFile(jsSource, 'utf8');
+  const wit = await readFile(opts.wit, 'utf8');
+  const { component, imports } = await componentizeFn(source, wit);
+  await writeFile(opts.out, component);
+  console.log(c`{green OK} Successfully written {bold ${opts.out}} with imports (${imports.join(', ')}).`);
+}

--- a/src/cmd/componentize.js
+++ b/src/cmd/componentize.js
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from 'node:fs/promises';
-import { componentize as componentizeFn } from '../../../componentize-js/lib/componentize.js';
+import { componentize as componentizeFn } from '@bytecodealliance/componentize-js';
 import c from 'chalk-template';
 
 export async function componentize (jsSource, opts) {

--- a/src/cmd/opt.js
+++ b/src/cmd/opt.js
@@ -138,7 +138,7 @@ export async function optimizeComponent (componentBytes, opts) {
  * @param {Uint8Array} source 
  * @returns {Promise<Uint8Array>}
  */
-async function wasmOpt (source, args = ['-tnh', '--gufa', '--flatten', '--rereloop', '-Oz', '-Oz', '--low-memory-unused', '--enable-bulk-memory']) {
+async function wasmOpt (source, args = ['-O1', '--low-memory-unused', '--enable-bulk-memory']) {
   try {
     return await spawnIOTmp(WASM_OPT, source, [
       ...args, '-o'

--- a/src/jco.js
+++ b/src/jco.js
@@ -8,7 +8,7 @@ import c from 'chalk-template';
 
 program
   .name('jco')
-  .description(c`{bold jco - WebAssembly JS Component Tools}\n       JS Component Transpilation Bindgen & Wasm Tools for JS`)
+  .description(c`{bold jco - WebAssembly JS Component Tools}\n      JS Component Transpilation Bindgen & Wasm Tools for JS`)
   .usage('<command> [options]')
   .version('0.1.0');
 

--- a/src/jco.js
+++ b/src/jco.js
@@ -3,6 +3,7 @@ import { program } from 'commander';
 import { opt } from './cmd/opt.js';
 import { transpile } from './cmd/transpile.js';
 import { parse, print, componentNew, componentEmbed, metadataAdd, metadataShow, componentWit } from './cmd/wasm-tools.js';
+import { componentize } from './cmd/componentize.js';
 import c from 'chalk-template';
 
 program
@@ -15,6 +16,14 @@ function myParseInt(value) {
   return parseInt(value, 10);
 }
 
+program.command('componentize')
+  .description('Create a component from a JavaScript module')
+  .usage('<js-source> -o <component-path>')
+  .argument('<js-source>', 'JS source file to build')
+  .requiredOption('-w, --wit <world>', 'WIT world to build with')
+  .requiredOption('-o, --out <out>', 'output component file')
+  .action(asyncAction(componentize));
+
 program.command('transpile')
   .description('Transpile a WebAssembly Component to JS + core Wasm for JavaScript execution')
   .usage('<component-path> -o <out-dir>')
@@ -23,7 +32,6 @@ program.command('transpile')
   .requiredOption('-o, --out-dir <out-dir>', 'output directory')
   .option('-m, --minify', 'minify the JS output (--optimize / opt cmd still required)')
   .option('-O, --optimize', 'optimize the component first')
-  .option('-a, --args', 'when using --optimize, custom binaryen argument flags to pass')
   .option('--no-typescript', 'do not output TypeScript .d.ts types')
   .option('--valid-lifting-optimization', 'optimize component binary validations assuming all lifted values are valid')
   .option('-b, --base64-cutoff <bytes>', 'set the byte size under which core Wasm binaries will be inlined as base64', myParseInt)

--- a/test/fixtures/source.js
+++ b/test/fixtures/source.js
@@ -1,0 +1,3 @@
+export function hello () {
+  return 'world';
+}

--- a/test/fixtures/source.wit
+++ b/test/fixtures/source.wit
@@ -1,0 +1,3 @@
+default world test {
+  export hello: func() -> string
+}


### PR DESCRIPTION
This adds a `jco componentize source.js -w world.wit -o component.wasm` command to `jco` as a wrapper around `ComponentizeJS`.

We could support alternative componentization projects in this CLI work, via an `--engine` field as appropriate, so this doesn't necessarily tie us to this specific approach entirely, but instead an overall toolchain contract for now.

