### PR TITLE
feat: explicit componentize install

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ To componentize a JS file run:
 jco componentize app.js --world world.wit -o component.wasm
 ```
 
-Creates a component from a JS file and WIT world definition, via a Spidermonkey engine embedding.
+Creates a component from a JS module implementing a WIT world definition, via a Spidermonkey engine embedding.
 
 Currently requires an explicit install of the componentize-js engine via `npm install @bytecodealliance/componentize-js`.
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@
 
 Features include:
 
-* Creating WebAssembly Components from JavaScript sources and a WIT world
 * "Transpiling" Wasm Component binaries into ES modules that can run in any JS environment.
 * Optimization helpers for Components via Binaryen.
 * Component builds of [Wasm Tools](https://github.com/bytecodealliance/wasm-tools) helpers, available for use as a library or CLI commands for use in native JS environments.
+* "Componentize" for WebAssembly Components from JavaScript sources and a WIT world
 
 For creating components in other languages, see the [Cargo Component](https://github.com/bytecodealliance/cargo-Component) project for Rust and [Wit Bindgen](https://github.com/bytecodealliance/wit-bindgen) for various guest bindgen helpers.
 
@@ -65,15 +65,25 @@ Commands:
   help [command]                        display help for command
 ```
 
-## API
+### Componentize
 
-The below is an outline of the available API functions, see [api.d.ts](api.d.ts) file for the exact options.
+To componentize a JS file run:
 
-#### `componentize(jsSource: String, witWorld: String, opts?): Promise<{ component: Uint8Array }>`
+```
+jco componentize app.js --world world.wit -o component.wasm
+```
 
 Creates a component from a JS file and WIT world definition, via a Spidermonkey engine embedding.
 
+Currently requires an explicit install of the componentize-js engine via `npm install @bytecodealliance/componentize-js`.
+
 See [ComponentizeJS](https://github.com/bytecodealliance/componentize-js) for more details on this process.
+
+> Additional engines may be supported in future via an `--engine` field or otherwise.
+
+## API
+
+The below is an outline of the available API functions, see [api.d.ts](api.d.ts) file for the exact options.
 
 #### `transpile(component: Uint8Array, opts?): Promise<{ files: Record<string, Uint8Array> }>`
 

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   },
   "type": "module",
   "private": true,
-  "dependencies": {
-    "@bytecodealliance/componentize-js": "^0.0.1"
-  },
   "devDependencies": {
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.41.0",

--- a/src/api.js
+++ b/src/api.js
@@ -2,7 +2,6 @@ export { optimizeComponent as opt } from './cmd/opt.js';
 export { transpileComponent as transpile } from './cmd/transpile.js';
 import { exports } from '../obj/wasm-tools.js';
 export const { parse, print, componentNew, componentWit, componentEmbed, metadataAdd, metadataShow } = exports;
-export { componentize } from '@bytecodealliance/componentize-js';
 export function preview1AdapterCommandPath () {
   return new URL('../lib/wasi_snapshot_preview1.command.wasm', import.meta.url);
 }

--- a/src/cmd/componentize.js
+++ b/src/cmd/componentize.js
@@ -4,7 +4,7 @@ import c from 'chalk-template';
 export async function componentize (jsSource, opts) {
   let componentizeFn;
   try {
-    ({ componentize: componentizeFn } = await('@bytecodealliance/componentize-js'));
+    ({ componentize: componentizeFn } = await import('@bytecodealliance/componentize-js'));
   } catch (e) {
     throw new Error(`componentize-js must first be installed separately via "npm install @bytecodealliance/componentize-js".`);
   }

--- a/src/cmd/componentize.js
+++ b/src/cmd/componentize.js
@@ -1,8 +1,13 @@
 import { readFile, writeFile } from 'node:fs/promises';
-import { componentize as componentizeFn } from '@bytecodealliance/componentize-js';
 import c from 'chalk-template';
 
 export async function componentize (jsSource, opts) {
+  let componentizeFn;
+  try {
+    ({ componentize: componentizeFn } = await('@bytecodealliance/componentize-js'));
+  } catch (e) {
+    throw new Error(`componentize-js must first be installed separately via "npm install @bytecodealliance/componentize-js".`);
+  }
   const source = await readFile(jsSource, 'utf8');
   const wit = await readFile(opts.wit, 'utf8');
   const { component, imports } = await componentizeFn(source, wit);


### PR DESCRIPTION
This removes `@bytecodealliance/componentize-js` as a static dependency and instead requires it to be separately installed.

This way, we don't have a circular dependency between the packages, and also this allows a nicer path for multi-engine support.