### PR TITLE
fix: http handle options can be null

### DIFF
--- a/packages/preview2-shim/lib/http/wasi-http.js
+++ b/packages/preview2-shim/lib/http/wasi-http.js
@@ -34,11 +34,7 @@ export class WasiHttp {
    * @param {RequestOptions | null} options
    * @returns {FutureIncomingResponse}
    */
-  handle = (requestId, {
-    connectTimeoutMs: _connectTimeoutMs = 600_000,
-    firstByteTimeoutMs: _firstByteTimeoutMs = 600_000,
-    betweenBytesTimeoutMs: _betweenBytesTimeoutMs = 600_000
-  } = {}) => {
+  handle = (requestId, _options) => {
     const request = this.requests.get(requestId);
     if (!request) throw Error("not found!");
 


### PR DESCRIPTION
Because the options parameter passed to the handle method can be `null`, we need to deconstruct it in a safer manner (or just leave that for later) in order to avoid error such as:
> TypeError: Cannot read properties of null (reading 'connectTimeoutMs') 