### PR TITLE
fix: missing wasi-shim mappings

### DIFF
--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -491,7 +491,7 @@ impl Instantiator<'_, '_> {
                 self.gen.esm_bindgen.add_import_func(
                     &[
                         import_specifier,
-                        iface_member,
+                        iface_member.to_lower_camel_case(),
                         func_name.to_lower_camel_case(),
                     ],
                     callee_name,

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -91,9 +91,14 @@ export async function transpileComponent (component, opts = {}) {
   if (opts.wasiShim !== false) {
     opts.map = Object.assign({
       'wasi:cli-base/*': '@bytecodealliance/preview2-shim/cli-base#*',
+      'wasi:clocks/*': '@bytecodealliance/preview2-shim/clocks#*',
       'wasi:filesystem/*': '@bytecodealliance/preview2-shim/filesystem#*',
+      'wasi:http/*': '@bytecodealliance/preview2-shim/http#*',
       'wasi:io/*': '@bytecodealliance/preview2-shim/io#*',
+      'wasi:logging/*': '@bytecodealliance/preview2-shim/logging#*',
+      'wasi:poll/*': '@bytecodealliance/preview2-shim/poll#*',
       'wasi:random/*': '@bytecodealliance/preview2-shim/random#*',
+      'wasi:sockets/*': '@bytecodealliance/preview2-shim/sockets#*',
     }, opts.map || {});
   }
 


### PR DESCRIPTION
Adds missing WASI mappings when using the wasi shim default mappings to the preview2 shims package.