### PR TITLE
feat: ora browser shim

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
     "jco": "src/jco.js"
   },
   "exports": "./src/api.js",
+  "imports": {
+    "#ora": {
+      "browser": "./src/ora-shim.js",
+      "default": "ora"
+    }
+  },
   "type": "module",
   "dependencies": {
     "@bytecodealliance/preview2-shim": "0.0.10",

--- a/src/cmd/opt.js
+++ b/src/cmd/opt.js
@@ -3,7 +3,7 @@ import { writeFile } from 'fs/promises';
 import { fileURLToPath } from 'url';
 import c from 'chalk-template';
 import { readFile, sizeStr, fixedDigitDisplay, table, spawnIOTmp, setShowSpinner, getShowSpinner } from '../common.js';
-import ora from 'ora';
+import ora from '#ora';
 
 let WASM_OPT;
 try {

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -7,7 +7,7 @@ import { readFile, sizeStr, table, spawnIOTmp, setShowSpinner, getShowSpinner } 
 import { optimizeComponent } from './opt.js';
 import { minify } from 'terser';
 import { fileURLToPath } from 'url';
-import ora from 'ora';
+import ora from '#ora';
 
 export async function transpile (componentPath, opts, program) {
   const varIdx = program.parent.rawArgs.indexOf('--');

--- a/src/ora-shim.js
+++ b/src/ora-shim.js
@@ -1,0 +1,9 @@
+// browser shim for ora
+export default function ora () {
+  return new Ora();
+}
+
+class Ora {
+  start () {}
+  stop () {}
+}


### PR DESCRIPTION
Adds a shim for `ora` in the browser towards supporting jco in the browser.