### PR TITLE
test: reenable componentize test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "terser": "^5.16.1"
   },
   "devDependencies": {
-    "@bytecodealliance/componentize-js": "0.0.7",
+    "@bytecodealliance/componentize-js": "0.0.8",
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",

--- a/test/cli.js
+++ b/test/cli.js
@@ -181,7 +181,7 @@ export async function cliTest (fixtures) {
       }
     });
 
-    test.skip('Componentize', async () => {
+    test('Componentize', async () => {
       try {
         const { stdout, stderr } = await exec(jcoPath,
             'componentize',


### PR DESCRIPTION
Reenables the componentize test that was disabled during the recent WIT upgrades. This doesn't affect the release as it is already supported.