### PR TITLE
fix: default import function instantiation

### DIFF
--- a/crates/js-component-bindgen/src/esm_bindgen.rs
+++ b/crates/js-component-bindgen/src/esm_bindgen.rs
@@ -256,7 +256,11 @@ impl EsmBindgen {
                 }
                 Binding::Local(local_name) => {
                     if let Some(imports_object) = imports_object {
-                        uwriteln!(output, "{local_name} = {imports_object}.default;");
+                        uwriteln!(
+                            output,
+                            "{local_name} = {imports_object}{}.default;",
+                            maybe_quote_member(specifier)
+                        );
                     } else {
                         uwriteln!(output, "{local_name} from '{specifier}';");
                     }

--- a/test/fixtures/component-gen/import-fn.js
+++ b/test/fixtures/component-gen/import-fn.js
@@ -1,0 +1,11 @@
+import print from 'print';
+import importPoint from 'import-point';
+
+export function run () {
+  
+}
+
+export function movePoint (pnt) {
+  const mapPoint = importPoint(pnt);
+  print(`x: ${mapPoint.x}, y: ${mapPoint.y}`);
+}

--- a/test/fixtures/component-gen/import-fn.wit
+++ b/test/fixtures/component-gen/import-fn.wit
@@ -1,0 +1,14 @@
+package example:protocol
+
+world my-world {
+  record point {
+    x: s32,
+    y: s32,
+  }
+
+  import print: func(msg: string)
+  import import-point: func(pnt: point) -> point
+
+  export run: func()
+  export move-point: func(pnt: point) -> point
+}

--- a/test/runtime/import-fn.ts
+++ b/test/runtime/import-fn.ts
@@ -1,0 +1,1 @@
+// Flags: --instantiation

--- a/update-tests.sh
+++ b/update-tests.sh
@@ -14,3 +14,5 @@ done
 
 # copy flavorful wit case
 cp tests/runtime/flavorful/world.wit ../test/fixtures/wit/flavorful.wit
+
+./src/jco.js componentize test/fixtures/component-gen/import-fn.js --wit test/fixtures/component-gen/import-fn.wit -o test/fixtures/components/import-fn.component.wasm


### PR DESCRIPTION
Resolves the JS output case described in https://github.com/bytecodealliance/jco/issues/103.

When using `--instantiation`, with kebab function imports of a world of the form `import x: func () -> ()`, instead of outputting:

```js
const x = imports.x.default;
```

we were outputting:

```js
const x = imports.default;
```