### PR TITLE
fix: disable wasiShim for instantiation

### DIFF
--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -79,7 +79,7 @@ async function wasm2Js (source) {
  */
 export async function transpileComponent (component, opts = {}) {
   await $init;
-  if (opts.noWasiShim) opts.wasiShim = false;
+  if (opts.noWasiShim || opts.instantiation) opts.wasiShim = false;
 
   let spinner;
   const showSpinner = getShowSpinner();


### PR DESCRIPTION
This always adds `--no-wasi-shim` when in instantiation mode.

This should avoid issues like https://github.com/tc39/proposal-import-attributes/issues/145, until we properly support TypeScript generation for map configuration.