### PR TITLE
Unify interface aliasing

### DIFF
--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -329,23 +329,30 @@ impl TsBindgen {
     ) -> String {
         let local_name =
             self.generate_interface(export_name, resolve, id, files, AbiVariant::GuestExport);
-        if instantiation {
-            uwriteln!(
-                self.export_object,
-                "{}: typeof {local_name},",
-                maybe_quote_id(export_name)
-            );
-        } else {
-            if export_name != maybe_quote_id(export_name) {
-                // TODO: TypeScript doesn't currently support
-                // non-identifier exports
-                // tracking in https://github.com/microsoft/TypeScript/issues/40594
-            } else {
+
+        // Only export the original interface name if it comes from an external interface,
+        // BUT export "inline" interface if the original and aliased names are the same,
+        // because it would be skipped later
+        // See https://github.com/bytecodealliance/jco/pull/111
+        if export_name.contains(":") || export_name == local_name {
+            if instantiation {
                 uwriteln!(
                     self.export_object,
-                    "export const {}: typeof {local_name};",
+                    "{}: typeof {local_name},",
                     maybe_quote_id(export_name)
                 );
+            } else {
+                if export_name != maybe_quote_id(export_name) {
+                    // TODO: TypeScript doesn't currently support
+                    // non-identifier exports
+                    // tracking in https://github.com/microsoft/TypeScript/issues/40594
+                } else {
+                    uwriteln!(
+                        self.export_object,
+                        "export const {}: typeof {local_name};",
+                        maybe_quote_id(export_name)
+                    );
+                }
             }
         }
         local_name


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/jco/issues/110

## Quick summary:

"Named" interface exports have both original name and aliased name in exports, but "local"/"inline" interfaces have only aliased export in the exported JS object.

```
interface guest-exports {
  run: func()
}

world my-world {
  export guest-exports // "named" interface

  export inline-exports: interface { // "local"/"inline" interface
    add-three: func(num: s32) -> s32
  }
}
```

TS bindings are already "correct" (according to what *should* be exported):
```ts
export interface Root {
  'example:protocol/guest-exports': typeof ExportsExampleProtocolGuestExports,
  'inline-exports': typeof ExportsInlineExports, // was missing in actual JS code
  guestExports: typeof ExportsExampleProtocolGuestExports,
  inlineExports: typeof ExportsInlineExports,
}
```

But the JS code did not export the non-aliased local interface export.