### PR TITLE
Fix "dropping reference" warning

### DIFF
--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -388,10 +388,7 @@ impl TsBindgen {
         gen.gen.export_object.push_str(&gen.src);
     }
 
-    fn preprocess(&mut self, resolve: &Resolve, name: &str) {
-        drop(resolve);
-        drop(name);
-    }
+    fn preprocess(&mut self, _resolve: &Resolve, _name: &str) {}
 
     fn generate_interface(
         &mut self,


### PR DESCRIPTION
I'm assuming the `drop` call was to get rid of the "unused" warning, but this just generates "dropping references does nothing" warning instead.