### PR TITLE
Update js wasi clocks

### DIFF
--- a/packages/preview2-shim/lib/browser/clocks.js
+++ b/packages/preview2-shim/lib/browser/clocks.js
@@ -1,5 +1,6 @@
 function _hrtimeBigint () {
-  return BigInt(Math.floor(performance.now() * 1e9));
+  // performance.now() is in milliseconds, but we want nanoseconds
+  return BigInt(Math.floor(performance.now() * 1e6));
 }
 
 let _hrStart = _hrtimeBigint();

--- a/packages/preview2-shim/lib/browser/clocks.js
+++ b/packages/preview2-shim/lib/browser/clocks.js
@@ -33,8 +33,9 @@ export const timezone = {
 
 export const wallClock = {
   now() {
-    const seconds = BigInt(Math.floor(Date.now() / 1e3));
-    const nanoseconds = (Date.now() % 1e3) * 1e6;
+    let now = Date.now(); // in milliseconds
+    const seconds = BigInt(Math.floor(now / 1e3));
+    const nanoseconds = (now % 1e3) * 1e6;
     return { seconds, nanoseconds };
   },
 


### PR DESCRIPTION
performance.now() returns milliseconds, and we want nanoseconds, so we need to multiply by a million, not a billion.

Using one `Date.now()` prevents a "bad" case when one first Date.now() call returns a different date than the second Date.now() call, which can be especially bad if the two dates "cross over" the millisecond boundary.