### PR TITLE
fix: jco componentize for latest ComponentizeJS

### DIFF
--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -306,7 +306,7 @@ impl Instantiator<'_, '_> {
         // To avoid uncaught promise rejection errors, we attach an intermediate
         // Promise.all with a rejection handler, if there are multiple promises.
         for i in 0..self.component.num_runtime_component_instances {
-            uwriteln!(self.src.js_init, "const instance_flags{i} = new WebAssembly.Global({{value: \"i32\", mutable: true}}, {})", wasmtime_environ::component::FLAG_MAY_LEAVE | wasmtime_environ::component::FLAG_MAY_ENTER);
+            uwriteln!(self.src.js_init, "const instanceFlags{i} = new WebAssembly.Global({{ value: \"i32\", mutable: true }}, {});", wasmtime_environ::component::FLAG_MAY_LEAVE | wasmtime_environ::component::FLAG_MAY_ENTER);
         }
         if self.modules.len() > 1 {
             self.src.js_init.push_str("Promise.all([");

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "terser": "^5.16.1"
   },
   "devDependencies": {
-    "@bytecodealliance/componentize-js": "^0.1.0",
+    "@bytecodealliance/componentize-js": "^0.1.1",
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",

--- a/src/cmd/componentize.js
+++ b/src/cmd/componentize.js
@@ -14,7 +14,8 @@ export async function componentize (jsSource, opts) {
   const source = await readFile(jsSource, 'utf8');
   const { component, imports } = await componentizeFn(source, {
     witPath: resolve(opts.wit),
-    worldName: opts.worldName
+    worldName: opts.worldName,
+    enableStdout: opts.enableStdout,
   });
   await writeFile(opts.out, component);
   console.log(c`{green OK} Successfully written {bold ${opts.out}} with imports (${imports.join(', ')}).`);

--- a/src/jco.js
+++ b/src/jco.js
@@ -22,7 +22,7 @@ program.command('componentize')
   .argument('<js-source>', 'JS source file to build')
   .requiredOption('-w, --wit <path>', 'WIT path to build with')
   .option('-n, --world-name <name>', 'WIT world to build')
-  .option('-enable-stdout', 'Allow console.log to output to stdout')
+  .option('--enable-stdout', 'Allow console.log to output to stdout')
   .requiredOption('-o, --out <out>', 'output component file')
   .action(asyncAction(componentize));
 

--- a/src/jco.js
+++ b/src/jco.js
@@ -22,6 +22,7 @@ program.command('componentize')
   .argument('<js-source>', 'JS source file to build')
   .requiredOption('-w, --wit <path>', 'WIT path to build with')
   .option('-n, --world-name <name>', 'WIT world to build')
+  .option('-enable-stdout', 'Allow console.log to output to stdout')
   .requiredOption('-o, --out <out>', 'output component file')
   .action(asyncAction(componentize));
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -181,7 +181,7 @@ export async function cliTest (fixtures) {
       }
     });
 
-    test.skip('Componentize', async () => {
+    test('Componentize', async () => {
       try {
         const { stdout, stderr } = await exec(jcoPath,
             'componentize',


### PR DESCRIPTION
This upgrades `jco componentize` to the latest ComponentizeJS build, which now removes WASI imports by default so that we are back to having simple components. Stdout can be enabled for console logging via `jco componentize --enable-stdout` which will then include the WASI interfaces again.