### PR TITLE
Update to Wasmtime 12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,9 +51,8 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cranelift-entity"
-version = "0.97.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6565198b5684367371e2b946ceca721eb36965e75e3592fad12fc2e15f65d7b"
+version = "0.99.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-12.0.0#de4ede08265e8e984a8fd34be5c0986e13b646b0"
 dependencies = [
  "serde",
 ]
@@ -153,7 +152,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -179,7 +177,7 @@ version = "0.10.1"
 dependencies = [
  "anyhow",
  "js-component-bindgen",
- "wit-component 0.13.1 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
+ "wit-component",
 ]
 
 [[package]]
@@ -189,10 +187,10 @@ dependencies = [
  "anyhow",
  "base64",
  "heck",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "wasmtime-environ",
- "wit-component 0.13.1 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
- "wit-parser 0.9.2 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
+ "wit-component",
+ "wit-parser",
 ]
 
 [[package]]
@@ -225,9 +223,9 @@ checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "object"
-version = "0.30.4"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b4680b86d9cfafba8fc491dc9b6df26b68cf40e9e6cd73909194759a63c385"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
 dependencies = [
  "crc32fast",
  "hashbrown 0.13.2",
@@ -459,26 +457,9 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18c41dbd92eaebf3612a39be316540b8377c871cb9bde6b064af962984912881"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41763f20eafed1399fff1afb466496d3a959f58241436cfdc17e3f5ca954de16"
-dependencies = [
- "leb128",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.31.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd#5605721e5373015e70401962a5d381f6968e3fbd"
 dependencies = [
  "leb128",
 ]
@@ -494,22 +475,8 @@ dependencies = [
  "serde",
  "serde_json",
  "spdx",
- "wasm-encoder 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.110.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.10.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd#5605721e5373015e70401962a5d381f6968e3fbd"
-dependencies = [
- "anyhow",
- "indexmap 2.0.0",
- "serde",
- "serde_json",
- "spdx",
- "wasm-encoder 0.31.1 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
- "wasmparser 0.110.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
+ "wasm-encoder",
+ "wasmparser",
 ]
 
 [[package]]
@@ -517,24 +484,14 @@ name = "wasm-tools-js"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "wasm-encoder 0.31.1 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
- "wasm-metadata 0.10.1 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
- "wasmparser 0.110.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
- "wasmprinter 0.2.62 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wasmprinter",
  "wat",
  "wit-bindgen",
- "wit-component 0.13.1 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
- "wit-parser 0.9.2 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.107.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29e3ac9b780c7dda0cac7a52a5d6d2d6707cc6e3451c9db209b6c758f40d7acb"
-dependencies = [
- "indexmap 1.9.3",
- "semver",
+ "wit-component",
+ "wit-parser",
 ]
 
 [[package]]
@@ -548,88 +505,69 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmparser"
-version = "0.110.0"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd#5605721e5373015e70401962a5d381f6968e3fbd"
-dependencies = [
- "indexmap 2.0.0",
- "semver",
-]
-
-[[package]]
 name = "wasmprinter"
 version = "0.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42cd12ed4d96a984e4b598a17457f1126d01640cc7461afbb319642111ff9e7f"
 dependencies = [
  "anyhow",
- "wasmparser 0.110.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.2.62"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd#5605721e5373015e70401962a5d381f6968e3fbd"
-dependencies = [
- "anyhow",
- "wasmparser 0.110.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
+ "wasmparser",
 ]
 
 [[package]]
 name = "wasmtime-component-util"
-version = "10.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f20a5135ec5ef01080e674979b02d6fa5eebaa2b0c2d6660513ee9956a1bf624"
+version = "12.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-12.0.0#de4ede08265e8e984a8fd34be5c0986e13b646b0"
 
 [[package]]
 name = "wasmtime-environ"
-version = "10.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f9e58e0ee7d43ff13e75375c726b16bce022db798d3a099a65eeaa7d7a544b"
+version = "12.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-12.0.0#de4ede08265e8e984a8fd34be5c0986e13b646b0"
 dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli",
- "indexmap 1.9.3",
+ "indexmap 2.0.0",
  "log",
  "object",
  "serde",
  "target-lexicon",
  "thiserror",
- "wasm-encoder 0.29.0",
- "wasmparser 0.107.0",
- "wasmprinter 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-encoder",
+ "wasmparser",
+ "wasmprinter",
  "wasmtime-component-util",
  "wasmtime-types",
 ]
 
 [[package]]
 name = "wasmtime-types"
-version = "10.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb7c138f797192f46afdd3ec16f85ef007c3bb45fa8e5174031f17b0be4c4a"
+version = "12.0.0"
+source = "git+https://github.com/bytecodealliance/wasmtime?branch=release-12.0.0#de4ede08265e8e984a8fd34be5c0986e13b646b0"
 dependencies = [
  "cranelift-entity",
  "serde",
  "thiserror",
- "wasmparser 0.107.0",
+ "wasmparser",
 ]
 
 [[package]]
 name = "wast"
 version = "62.0.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd#5605721e5373015e70401962a5d381f6968e3fbd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8ae06f09dbe377b889fbd620ff8fa21e1d49d1d9d364983c0cdbf9870cb9f1f"
 dependencies = [
  "leb128",
  "memchr",
  "unicode-width",
- "wasm-encoder 0.31.1 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
+ "wasm-encoder",
 ]
 
 [[package]]
 name = "wat"
 version = "1.0.69"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd#5605721e5373015e70401962a5d381f6968e3fbd"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "842e15861d203fb4a96d314b0751cdeaf0f6f8b35e8d81d2953af2af5e44e637"
 dependencies = [
  "wast",
 ]
@@ -649,8 +587,8 @@ version = "0.9.0"
 source = "git+https://github.com/bytecodealliance/wit-bindgen#bf318b8ae4703586ae236a232f62813efc946df3"
 dependencies = [
  "anyhow",
- "wit-component 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wit-parser 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-component",
+ "wit-parser",
 ]
 
 [[package]]
@@ -660,10 +598,10 @@ source = "git+https://github.com/bytecodealliance/wit-bindgen#bf318b8ae4703586ae
 dependencies = [
  "anyhow",
  "heck",
- "wasm-metadata 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wasm-metadata",
  "wit-bindgen-core",
  "wit-bindgen-rust-lib",
- "wit-component 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-component",
 ]
 
 [[package]]
@@ -686,7 +624,7 @@ dependencies = [
  "wit-bindgen-core",
  "wit-bindgen-rust",
  "wit-bindgen-rust-lib",
- "wit-component 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "wit-component",
 ]
 
 [[package]]
@@ -699,26 +637,11 @@ dependencies = [
  "bitflags 2.3.3",
  "indexmap 2.0.0",
  "log",
- "wasm-encoder 0.31.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasm-metadata 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "wasmparser 0.110.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "wit-parser 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.13.1"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd#5605721e5373015e70401962a5d381f6968e3fbd"
-dependencies = [
- "anyhow",
- "bitflags 2.3.3",
- "indexmap 2.0.0",
- "log",
- "wasm-encoder 0.31.1 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
- "wasm-metadata 0.10.1 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
- "wasmparser 0.110.0 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
  "wat",
- "wit-parser 0.9.2 (git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd)",
+ "wit-parser",
 ]
 
 [[package]]
@@ -726,21 +649,6 @@ name = "wit-parser"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "541efa2046e544de53a9da1e2f6299e63079840360c9e106f1f8275a97771318"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.0.0",
- "log",
- "pulldown-cmark",
- "semver",
- "unicode-xid",
- "url",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.9.2"
-source = "git+https://github.com/bytecodealliance/wasm-tools?rev=5605721e5373015e70401962a5d381f6968e3fbd#5605721e5373015e70401962a5d381f6968e3fbd"
 dependencies = [
  "anyhow",
  "id-arena",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,13 +30,16 @@ version = "0.10.1"
 anyhow = "1.0.71"
 base64 = "0.21.2"
 heck =  { version = "0.4", features = ["unicode"] }
-indexmap = "1.9"
-wasm-encoder = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "5605721e5373015e70401962a5d381f6968e3fbd" }
-wasm-metadata = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "5605721e5373015e70401962a5d381f6968e3fbd" }
-wasmparser = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "5605721e5373015e70401962a5d381f6968e3fbd" }
-wasmprinter = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "5605721e5373015e70401962a5d381f6968e3fbd" }
-wasmtime-environ = { version = "10.0.1", features = ["component-model"] }
-wat = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "5605721e5373015e70401962a5d381f6968e3fbd" }
+indexmap = "2.0"
+wasm-encoder = "0.31.1"
+wasm-metadata = "0.10.1"
+wasmparser = "0.110.0"
+wasmprinter = "0.2.62"
+wasmtime-environ = { version = "12.0.0", features = ["component-model"] }
+wat = "1.0.69"
 wit-bindgen = { git = "https://github.com/bytecodealliance/wit-bindgen" }
-wit-component = { git = "https://github.com/bytecodealliance/wasm-tools", features = ["dummy-module"], rev = "5605721e5373015e70401962a5d381f6968e3fbd" }
-wit-parser = { git = "https://github.com/bytecodealliance/wasm-tools", rev = "5605721e5373015e70401962a5d381f6968e3fbd" }
+wit-component = { version = "0.13.1", features = ["dummy-module"] }
+wit-parser = "0.9.2"
+
+[patch.crates-io]
+wasmtime-environ = { git = 'https://github.com/bytecodealliance/wasmtime', branch = 'release-12.0.0' }


### PR DESCRIPTION
This commit updates the Wasmtime dependency to the, currently unreleased, Wasmtime 12.0.0 branch. A number of changes happened to component translation in Wasmtime 12 to account for resources which required changes here as well. Additionally Wasmtime 12 disallows empty types in components which WASI was previously using, so this additionally updates the preview1 shims and test components.