### PR TITLE
feat: allow arbitrary post calls

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1132,7 +1132,7 @@ impl Bindgen for FunctionBindgen<'_> {
 
             Instruction::Return { amt, .. } => {
                 if let Some(f) = &self.post_return {
-                    uwriteln!(self.src, "{f}(ret);");
+                    uwriteln!(self.src, "{f}({});", if *amt > 0 { "ret" } else { "" });
                 }
 
                 if self.err == ErrHandling::ThrowResultErr {


### PR DESCRIPTION
WIT component now has the ability to support arbitrary post calls and not just post calls when there is allocation to be freed.

This updates the post call output to not assume a `ret` parameter in those cases.