### PR TITLE
feat: --wasi-command / --wasi-reactor flags for component new

### DIFF
--- a/src/jco.js
+++ b/src/jco.js
@@ -94,6 +94,8 @@ program.command('new')
   .requiredOption('-o, --output <output-file>', 'Wasm component output filepath')
   .option('--name <name>', 'custom output name')
   .option('--adapt <[NAME=]adapter...>', 'component adapters to apply')
+  .option('--wasi-reactor', 'build with the WASI Reactor adapter')
+  .option('--wasi-command', 'build with the WASI Command adapter')
   .action(asyncAction(componentNew));
 
 program.command('embed')

--- a/test/cli.js
+++ b/test/cli.js
@@ -154,8 +154,7 @@ export async function cliTest (fixtures) {
         const { stderr } = await exec(jcoPath,
             'new',
             'test/fixtures/modules/exitcode.wasm',
-            '--adapt',
-            'wasi_snapshot_preview1=lib/wasi_snapshot_preview1.reactor.wasm',
+            '--wasi-reactor',
             '-o', outFile);
         strictEqual(stderr, '');
         {


### PR DESCRIPTION
Running `jco new app.wasm -o app.component.wasm --adapt wasi_snapshot_preview1=lib/wasi_snapshot_preview1.reactor.wasm` etc is such a mouthful to type.

This adds a new `jco new app.wasm --wasi-comand -o app.command-component.wasm` to make it easier to create components in one liners (and for `--wasi-reactor`). Easy to do in jco since we already host the adapters.