### PR TITLE
fix: local resources handle refs

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1148,15 +1148,13 @@ impl Bindgen for FunctionBindgen<'_> {
                         self.src,
                         "let {handle} = {}[{resource_symbol}];
                         if ({handle} === null) {{
-                            throw new Error('\"{}\" resource handle lifetime expired / transferred.');
+                            throw new Error('\"{class_name}\" resource handle lifetime expired / transferred.');
                         }}
                         if ({handle} === undefined) {{
-                            throw new Error('Not a valid \"{}\" resource.');
+                            throw new Error('Not a valid \"{class_name}\" resource.');
                         }}
                         ",
                         operands[0],
-                        class_name,
-                        class_name,
                     );
 
                     // lowered own handles have their finalizers deregistered
@@ -1177,8 +1175,12 @@ impl Bindgen for FunctionBindgen<'_> {
                     // their assigned rep is deduped across usage though
                     uwriteln!(
                         self.src,
-                        "const {handle} = handleCnt{id}++;
+                        "if (!({} instanceof {class_name})) {{
+                            throw new Error('Not a valid \"{class_name}\" resource.');
+                        }}
+                        const {handle} = handleCnt{id}++;
                         handleTable{id}.set({handle}, {{ rep: {}, own: {} }});",
+                        operands[0],
                         operands[0],
                         is_own,
                     );

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1143,24 +1143,20 @@ impl Bindgen for FunctionBindgen<'_> {
                 let class_name = name.to_upper_camel_case();
                 let handle = format!("handle{}", self.tmp());
                 if !imported {
-                    let rep = format!("rep{}", self.tmp());
                     let resource_symbol = self.intrinsic(Intrinsic::ResourceSymbol);
                     uwriteln!(
                         self.src,
-                        "let {rep} = {}[{resource_symbol}];
-                        if ({rep} === null) {{
+                        "let {handle} = {}[{resource_symbol}];
+                        if ({handle} === null) {{
                             throw new Error('\"{}\" resource handle lifetime expired / transferred.');
                         }}
-                        if ({rep} === undefined) {{
+                        if ({handle} === undefined) {{
                             throw new Error('Not a valid \"{}\" resource.');
                         }}
-                        const {handle} = handleCnt{id}++;
-                        handleTable{id}.set({handle}, {{ rep: {rep}, own: {} }});
                         ",
                         operands[0],
                         class_name,
                         class_name,
-                        is_own
                     );
 
                     // lowered own handles have their finalizers deregistered


### PR DESCRIPTION
Fixes a bug where local component resources handles are already handles so don't need to be re-registered.