### PR TITLE
fix: component new adapter null bug

### DIFF
--- a/src/cmd/wasm-tools.js
+++ b/src/cmd/wasm-tools.js
@@ -37,7 +37,7 @@ export async function componentWit(file, opts) {
 export async function componentNew(file, opts) {
   await $init;
   const source = file ? await readFile(file) : null;
-  let adapters = null;
+  let adapters = [];
   if (opts.wasiReactor && opts.wasiCommand)
     throw new Error('Must select one of --wasi-command or --wasi-reactor');
   if (opts.wasiReactor)


### PR DESCRIPTION
This fixes a bug with the `componentNew` implementation where passing an adapter without using one of the new `--wasi-reactor` or `--wasi-command` flags would bail on a null property access.