### PR TITLE
fix: remove engines field restriction in preview2-shim

### DIFF
--- a/packages/preview2-shim/package.json
+++ b/packages/preview2-shim/package.json
@@ -3,9 +3,6 @@
   "version": "0.0.15",
   "description": "WASI Preview2 shim for JS environments",
   "author": "Guy Bedford, Eduardo Rodrigues<16357187+eduardomourar@users.noreply.github.com>",
-  "engines" : { 
-    "node" : ">=18"
-  },
   "type": "module",
   "types": "./types/index.d.ts",
   "exports": {


### PR DESCRIPTION
This removes the `"engines"` field from the preview2-shim package.json, which unnecessarily restricts usage of the package.