### PR TITLE
feat: --preview2-adapter option for componentizeJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "terser": "^5.16.1"
   },
   "devDependencies": {
-    "@bytecodealliance/componentize-js": "^0.2.0",
+    "@bytecodealliance/componentize-js": "^0.3.0",
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",

--- a/src/cmd/componentize.js
+++ b/src/cmd/componentize.js
@@ -16,6 +16,7 @@ export async function componentize (jsSource, opts) {
     witPath: resolve(opts.wit),
     worldName: opts.worldName,
     enableStdout: opts.enableStdout,
+    preview2Adapter: opts.preview2Adapter,
   });
   await writeFile(opts.out, component);
   console.log(c`{green OK} Successfully written {bold ${opts.out}} with imports (${imports.join(', ')}).`);

--- a/src/jco.js
+++ b/src/jco.js
@@ -24,6 +24,7 @@ program.command('componentize')
   .requiredOption('-w, --wit <path>', 'WIT path to build with')
   .option('-n, --world-name <name>', 'WIT world to build')
   .option('--enable-stdout', 'Allow console.log to output to stdout')
+  .option('--preview2-adapter <adapter>', 'provide a custom preview2 adapter path')
   .requiredOption('-o, --out <out>', 'output component file')
   .action(asyncAction(componentize));
 


### PR DESCRIPTION
Adds a new `--preview2-adapter` for customizing the adapter when running ComponentizeJS. This is useful when using different WIT versions than the JCO release version.