### PR TITLE
Add README.md files to rust crates

### DIFF
--- a/crates/js-component-bindgen-component/README.md
+++ b/crates/js-component-bindgen-component/README.md
@@ -1,0 +1,19 @@
+<h1 align="center">js-component-bindgen-component</h1>
+<div align="center">
+  <strong>
+    Packages <a href="../js-component-bindgen"><code>js-component-bindgen</code></a> as a WebAssembly Component.
+  </strong>
+</div>
+
+<br />
+
+# License
+
+This project is licensed under the Apache 2.0 license with the LLVM exception.
+See [LICENSE](LICENSE) for more details.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this project by you, as defined in the Apache-2.0 license,
+shall be licensed as above, without any additional terms or conditions.

--- a/crates/js-component-bindgen/README.md
+++ b/crates/js-component-bindgen/README.md
@@ -1,0 +1,42 @@
+<h1 align="center">js-component-bindgen</h1>
+<div align="center">
+  <strong>
+      Transpile WebAssembly components into JavaScript
+  </strong>
+</div>
+
+<br />
+
+<div align="center">
+  <!-- Crates version -->
+  <a href="https://crates.io/crates/js-component-bindgen">
+    <img src="https://img.shields.io/crates/v/js-component-bindgen.svg?style=flat-square"
+    alt="Crates.io version" />
+  </a>
+  <!-- Downloads -->
+  <a href="https://crates.io/crates/js-component-bindgen">
+    <img src="https://img.shields.io/crates/d/js-component-bindgen.svg?style=flat-square"
+      alt="Download" />
+  </a>
+  <!-- docs.rs docs -->
+  <a href="https://docs.rs/js-component-bindgen">
+    <img src="https://img.shields.io/badge/docs-latest-blue.svg?style=flat-square"
+      alt="docs.rs docs" />
+  </a>
+</div>
+
+## Installation
+```sh
+$ cargo add js-component-bindgen
+```
+
+# License
+
+This project is licensed under the Apache 2.0 license with the LLVM exception.
+See [LICENSE](LICENSE) for more details.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this project by you, as defined in the Apache-2.0 license,
+shall be licensed as above, without any additional terms or conditions.

--- a/crates/wasm-tools-component/README.md
+++ b/crates/wasm-tools-component/README.md
@@ -1,0 +1,19 @@
+<h1 align="center">wasm-tools-component</h1>
+<div align="center">
+  <strong>
+    Packages <a href="https://github.com/bytecodealliance/wasm-tools"><code>wasm-tools</code></a> as a WebAssembly Component.
+  </strong>
+</div>
+
+<br />
+
+# License
+
+This project is licensed under the Apache 2.0 license with the LLVM exception.
+See [LICENSE](LICENSE) for more details.
+
+### Contribution
+
+Unless you explicitly state otherwise, any contribution intentionally submitted
+for inclusion in this project by you, as defined in the Apache-2.0 license,
+shall be licensed as above, without any additional terms or conditions.


### PR DESCRIPTION
Makes progress towards #165. This adds basic README.md files to the Rust crates. Thanks!

## Screenshot

<img width="961" alt="Screenshot 2023-10-09 at 12 01 00" src="https://github.com/bytecodealliance/jco/assets/2467194/68014300-ad22-4ba9-85f8-09f673f66e82">
