### PR TITLE
fix toml errors in editor

### DIFF
--- a/crates/js-component-bindgen-component/Cargo.toml
+++ b/crates/js-component-bindgen-component/Cargo.toml
@@ -3,8 +3,8 @@ name = "js-component-bindgen-component"
 authors = ["Alex Crichton <alex@alexcrichton.com>", "Guy Bedford <gbedford@fastly.com>"]
 publish = false
 
-version.workspace = true
-edition.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/js-component-bindgen/Cargo.toml
+++ b/crates/js-component-bindgen/Cargo.toml
@@ -5,13 +5,12 @@ authors = [
   "Guy Bedford <gbedford@fastly.com>",
 ]
 description = "JS component bindgen for transpiling WebAssembly components into JavaScript"
-version.workspace = true
 license = "Apache-2.0 WITH LLVM-exception"
 categories = ["wasm"]
 keywords = ["webassembly", "wasm"]
 homepage = "https://github.com/bytecodealliance/jco/tree/main/crates/js-component-bindgen"
-
-edition.workspace = true
+version = { workspace = true }
+edition = { workspace = true }
 
 [lib]
 crate-type = ["lib"]


### PR DESCRIPTION
For some reason my local workspace was giving errors for the dot notation in toml; this fixes that by using toml maps instead. Thanks!