### PR TITLE
fix: xtask weirdness

### DIFF
--- a/packages/preview2-shim/lib/nodejs/filesystem.js
+++ b/packages/preview2-shim/lib/nodejs/filesystem.js
@@ -217,7 +217,7 @@ export class FileSystem {
         const descriptor = fs.getDescriptor(fd);
         if (!descriptor.fullPath) throw 'bad-descriptor';
         const buf = new Uint8Array(length);
-        const bytesRead = readSync(descriptor.fd, buf, offset, length, 0);
+        const bytesRead = readSync(descriptor.fd, buf, Number(offset), length, 0);
         const out = new Uint8Array(buf.buffer, 0, bytesRead);
         return [out, bytesRead === 0 ? 'ended' : 'open'];
       },

--- a/packages/preview2-shim/lib/nodejs/filesystem.js
+++ b/packages/preview2-shim/lib/nodejs/filesystem.js
@@ -16,7 +16,7 @@ class ReadableFileStream {
     this.position += bytesRead;
     if (bytesRead < buf.byteLength)
       return [new Uint8Array(buf.buffer, 0, bytesRead), bytesRead === 0 ? 'ended' : 'open'];
-    return [buf, 'ended'];
+    return [buf, 'open'];
   }
 }
 
@@ -26,10 +26,13 @@ class WriteableFileStream {
     this.position = Number(position);
   }
   write (contents) {
-    const bytesWritten = writeSync(this.hostFd, contents, null, null, this.position);
-    this.position += bytesWritten;
-    if (bytesWritten !== contents.byteLength)
-      throw new Error('TODO: write buffering + flush');
+    let totalWritten = 0;
+    while (totalWritten !== contents.byteLength) {
+      const bytesWritten = writeSync(this.hostFd, contents, null, null, this.position);
+      totalWritten += bytesWritten;
+      contents = new Uint8Array(contents.buffer, bytesWritten);
+    }
+    this.position += contents.byteLength;
   }
 }
 
@@ -216,14 +219,13 @@ export class FileSystem {
         const buf = new Uint8Array(length);
         const bytesRead = readSync(descriptor.fd, buf, offset, length, 0);
         const out = new Uint8Array(buf.buffer, 0, bytesRead);
-        const done = bytesRead === 0;
-        return [out, done];
+        return [out, bytesRead === 0 ? 'ended' : 'open'];
       },
 
       write(fd, buffer, offset) {
         const descriptor = fs.getDescriptor(fd);
         if (!descriptor.fullPath) throw 'bad-descriptor';
-        return writeSync(descriptor.fd, buffer, offset);
+        return BigInt(writeSync(descriptor.fd, buffer, Number(offset), buffer.byteLength - offset, 0));
       },
 
       readDirectory(fd) {

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -3,13 +3,13 @@ use xshell::{cmd, Shell};
 pub(crate) fn run() -> anyhow::Result<()> {
     let sh = Shell::new()?;
     cmd!(sh, "cargo build --workspace --target wasm32-wasi --release").read()?;
-    sh.copy_file(
-        "lib/wasi_snapshot_preview1.command.wasm",
-        "node_modules/@bytecodealliance/jco/lib",
-    )?;
-    sh.copy_file(
-        "lib/wasi_snapshot_preview1.command.wasm",
-        "node_modules/@bytecodealliance/jco/lib",
-    )?;
+    // sh.copy_file(
+    //     "lib/wasi_snapshot_preview1.command.wasm",
+    //     "node_modules/@bytecodealliance/jco/lib",
+    // )?;
+    // sh.copy_file(
+    //     "lib/wasi_snapshot_preview1.reactor.wasm",
+    //     "node_modules/@bytecodealliance/jco/lib",
+    // )?;
     Ok(())
 }


### PR DESCRIPTION
This fixes a bug that was only reproducing locally where the xtask copy would delete the contents of the source file.

I initially thought this was due to the new filesystem work, so did a bunch of refactoring on edge cases of the implementation I could find, as a result the filesystem support in Node.js is now better and I actually did fix a bunch of bugs there even though we weren't hitting them :)