### PR TITLE
fix: reenable xtask copy

### DIFF
--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -3,13 +3,13 @@ use xshell::{cmd, Shell};
 pub(crate) fn run() -> anyhow::Result<()> {
     let sh = Shell::new()?;
     cmd!(sh, "cargo build --workspace --target wasm32-wasi --release").read()?;
-    // sh.copy_file(
-    //     "lib/wasi_snapshot_preview1.command.wasm",
-    //     "node_modules/@bytecodealliance/jco/lib",
-    // )?;
-    // sh.copy_file(
-    //     "lib/wasi_snapshot_preview1.reactor.wasm",
-    //     "node_modules/@bytecodealliance/jco/lib",
-    // )?;
+    sh.copy_file(
+        "lib/wasi_snapshot_preview1.command.wasm",
+        "node_modules/@bytecodealliance/jco/lib",
+    )?;
+    sh.copy_file(
+        "lib/wasi_snapshot_preview1.reactor.wasm",
+        "node_modules/@bytecodealliance/jco/lib",
+    )?;
     Ok(())
 }


### PR DESCRIPTION
Per https://github.com/bytecodealliance/jco/issues/188, this turned out to be a `node_modules` vestige.