### PR TITLE
point mdbook deploy to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: github pages
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:


### PR DESCRIPTION
mdbook wasn't deploying because the main branch is called `main`, not `master`.