### PR TITLE
Refactor `src/cmd/run.js`

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -24,8 +24,7 @@ export async function run (componentPath, args) {
       });
     }
     catch (e) {
-      console.error(c`{red ERR}: Unable to transpile command for execution`);
-      throw e;
+      throw new Error('Unable to transpile command for execution', { cause: e });
     }
 
     await writeFile(resolve(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
@@ -41,9 +40,7 @@ export async function run (componentPath, args) {
       let len = preview2ShimPath.length;
       preview2ShimPath = resolve(preview2ShimPath, '..', '..', '..', 'node_modules', '@bytecodealliance', 'preview2-shim');
       if (preview2ShimPath.length === len) {
-        console.error(c`{red ERR}: Unable to locate the {bold @bytecodealliance/preview2-shim} package, make sure it is installed.`);
-        process.exitCode = 1;
-        return;
+        throw c`Unable to locate the {bold @bytecodealliance/preview2-shim} package, make sure it is installed.`;
       }
     }
 

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -4,7 +4,6 @@ import { rm, stat, mkdir, writeFile, symlink } from 'node:fs/promises';
 import { basename, resolve, extname } from 'node:path';
 import { fork } from 'node:child_process';
 import process from 'node:process';
-const { argv0 } = process;
 import { fileURLToPath } from 'node:url';
 import c from 'chalk-template';
 

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -77,7 +77,7 @@ export async function run (componentPath, args) {
     `);
 
     process.exitCode = await new Promise((resolve, reject) => {
-      const cp = fork(runPath, args);
+      const cp = fork(runPath, args, { stdio: 'inherit' });
 
       cp.on('error', reject);
       cp.on('exit', resolve);

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -43,6 +43,7 @@ export async function run (componentPath, args) {
       if (preview2ShimPath.length === len) {
         console.error(c`{red ERR}: Unable to locate the {bold @bytecodealliance/preview2-shim} package, make sure it is installed.`);
         process.exitCode = 1;
+        return;
       }
     }
 

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -3,8 +3,8 @@ import { transpile } from './transpile.js';
 import { rm, stat, mkdir, writeFile, symlink } from 'node:fs/promises';
 import { basename, resolve, extname } from 'node:path';
 import { spawn } from 'node:child_process';
-import { argv0 } from 'node:process';
 import * as process from 'node:process';
+const { argv0 } = process;
 import { fileURLToPath } from 'node:url';
 import c from 'chalk-template';
 
@@ -28,7 +28,7 @@ export async function run (componentPath, args) {
 
     await writeFile(resolve(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
 
-    let preview2ShimPath = fileURLToPath(new URL('..', '..', 'node_modules', '@bytecodealliance', 'preview2-shim', import.meta.url));
+    let preview2ShimPath = fileURLToPath(new URL('../../node_modules/@bytecodealliance/preview2-shim', import.meta.url));
     while (true) {
       try {
         if ((await stat(preview2ShimPath)).isDirectory()) {


### PR DESCRIPTION
`src/cmd/run.js` is poorly structured. In particular:

* `await rm(outDir, ...)` appears in two places, neither of which will be reached if the `spawn()` call is successful but the `ChildProcess` then emits an `error` event.
* If it is unable to locate the `@bytecodealliance/preview2-shim` package, it simply returns without setting a non-zero exit code (fixed here by setting the exit code to `1`).

This pull request fixes all this. It also fixes #180.