### PR TITLE
fix: resource connections

### DIFF
--- a/crates/js-component-bindgen/src/esm_bindgen.rs
+++ b/crates/js-component-bindgen/src/esm_bindgen.rs
@@ -25,7 +25,7 @@ impl EsmBindgen {
     /// first segment
     /// arbitrary nesting of interfaces is supported in order to support virtual WASI interfaces
     /// only two-level nesting supports serialization into imports currently
-    pub fn add_import_binding(&mut self, path: &[String], func_name: String) {
+    pub fn add_import_binding(&mut self, path: &[String], binding_name: String) {
         let mut iface = &mut self.imports;
         for i in 0..path.len() - 1 {
             if !iface.contains_key(&path[i]) {
@@ -39,7 +39,10 @@ impl EsmBindgen {
                 ),
             };
         }
-        iface.insert(path[path.len() - 1].to_string(), Binding::Local(func_name));
+        iface.insert(
+            path[path.len() - 1].to_string(),
+            Binding::Local(binding_name),
+        );
     }
 
     /// add an exported function binding, optionally on an interface id or kebab name

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -17,6 +17,7 @@ pub enum ErrHandling {
     ResultCatchHandler,
 }
 
+#[derive(Clone, Debug)]
 pub enum ResourceData {
     Host {
         id: u32,
@@ -52,6 +53,8 @@ pub enum ResourceData {
 /// In the case of an imported resource tables, in place of "rep" we just store
 /// the direct JS object being referenced, since in JS the object is its own handle.
 ///
+///
+#[derive(Clone, Debug)]
 pub struct ResourceTable {
     pub imported: bool,
     pub data: ResourceData,

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -114,17 +114,6 @@ pub fn transpile_bindgen(
 
     // bindings is the actual `instantiate` method itself, created by this
     // structure.
-    // populate reverse map from import names to world items
-    let mut exports = BTreeMap::new();
-    let mut imports = BTreeMap::new();
-    for (key, _) in &resolve.worlds[id].imports {
-        let name = &resolve.name_world_key(key);
-        imports.insert(name.to_string(), key.clone());
-    }
-    for (key, _) in &resolve.worlds[id].exports {
-        let name = &resolve.name_world_key(key);
-        exports.insert(name.to_string(), key.clone());
-    }
 
     let mut instantiator = Instantiator {
         src: Source::default(),
@@ -137,8 +126,8 @@ pub fn transpile_bindgen(
         translation: component,
         component: &component.component,
         types,
-        imports,
-        exports,
+        imports: BTreeMap::new(),
+        exports: BTreeMap::new(),
         lowering_options: Default::default(),
         imports_resource_map: Default::default(),
         exports_resource_map: Default::default(),
@@ -343,6 +332,7 @@ impl<'a> Instantiator<'a, '_> {
         // as well as the full resource map for the world
         for (key, item) in &self.resolve.worlds[self.world].imports {
             let name = &self.resolve.name_world_key(key);
+            self.imports.insert(name.to_string(), key.clone());
             let Some((_, (_, import))) = self
                 .component
                 .import_types
@@ -408,6 +398,7 @@ impl<'a> Instantiator<'a, '_> {
         self.exports_resource_map = self.imports_resource_map.clone();
         for (key, item) in &self.resolve.worlds[self.world].exports {
             let name = &self.resolve.name_world_key(key);
+            self.exports.insert(name.to_string(), key.clone());
             let (_, export) = self
                 .component
                 .exports


### PR DESCRIPTION
This fixes a remaining bug with connecting resources.

Basically, the current `connect_resources` implementation only walks the resources references by the current function. So when you have a resource that only has a static function that doesn't take a resource as an argument you never actually end up connecting that resource. Instead this moves the entire connect resources phase to a phase before initialization.

Thanks to @alexcrichton for helping me work through this case.