### PR TITLE
Adding file extension to interface imports

### DIFF
--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -860,7 +860,7 @@ impl<'a> TsInterface<'a> {
             Some(owned_interface_name) => {
                 uwriteln!(
                     self.src,
-                    "import type {{ {type_name} }} from '../interfaces/{owned_interface_name}';",
+                    "import type {{ {type_name} }} from '../interfaces/{owned_interface_name}.js';",
                 );
                 self.src.push_str(&format!("export {{ {} }};\n", type_name));
             }


### PR DESCRIPTION
Adding the file extension will allow the interface imports to work for typescript packages using both `moduleResolution` `bundler` as well as `nodenext`. This is also more closely aligned with the node spec for imports so should be better supported. Closes #223 