### PR TITLE
feat: Symbol.dispose own-handle destructors

### DIFF
--- a/packages/preview2-shim/lib/common/io.js
+++ b/packages/preview2-shim/lib/common/io.js
@@ -1,5 +1,7 @@
 let id = 0;
 
+const symbolDispose = Symbol.dispose || Symbol.for('dispose');
+
 class Error {
   constructor (msg) {
     this.msg = msg;
@@ -73,7 +75,7 @@ class InputStream {
   subscribe() {
     console.log(`[streams] Subscribe to input stream ${this.id}`);
   }
-  drop () {
+  [symbolDispose] () {
     if (this.handler.drop)
       this.handler.drop.call(this);
   }
@@ -158,7 +160,7 @@ class OutputStream {
   subscribe() {
     console.log(`[streams] Subscribe to output stream ${this.id}`);
   }
-  drop() {
+  [symbolDispose]() {
   }
 }
 

--- a/packages/preview2-shim/lib/nodejs/cli.js
+++ b/packages/preview2-shim/lib/nodejs/cli.js
@@ -3,6 +3,7 @@ import { streams } from '../common/io.js';
 const { InputStream, OutputStream } = streams;
 
 let _env = Object.entries(env), _args = argv, _cwd = cwd();
+const symbolDispose = Symbol.dispose || Symbol.for('dispose');
 
 export const environment = {
   getEnvironment () {
@@ -29,7 +30,7 @@ const stdinStream = new InputStream({
   subscribe () {
     // TODO
   },
-  drop () {
+  [symbolDispose] () {
     // TODO
   }
 });
@@ -39,7 +40,7 @@ const stdoutStream = new OutputStream({
   },
   blockingFlush () {
   },
-  drop () {
+  [symbolDispose] () {
   }
 });
 const stderrStream = new OutputStream({
@@ -49,7 +50,7 @@ const stderrStream = new OutputStream({
   blockingFlush () {
 
   },
-  drop () {
+  [symbolDispose] () {
 
   }
 });

--- a/packages/preview2-shim/lib/nodejs/http.js
+++ b/packages/preview2-shim/lib/nodejs/http.js
@@ -308,5 +308,4 @@ export class WasiHttp {
   }
 }
 
-const http = new WasiHttp();
-export const { outgoingHandler, types } = http;
+export const { outgoingHandler, types } = new WasiHttp();

--- a/packages/preview2-shim/test/test.js
+++ b/packages/preview2-shim/test/test.js
@@ -17,6 +17,6 @@ suite('Node.js Preview2', async () => {
     const buf = stream.blockingRead(1_000_000);
     const source = new TextDecoder().decode(buf);
     ok(source.includes('UNIQUE STRING'));
-    stream.drop();
+    stream[Symbol.dispose]();
   });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,7 +6,7 @@ export const jcoPath = 'src/jco.js';
 export async function exec (cmd, ...args) {
   let stdout = '', stderr = '';
   await new Promise((resolve, reject) => {
-    const cp = spawn(argv[0], ['--no-warnings', cmd, ...args], { stdio: 'pipe' });
+    const cp = spawn(argv[0], [cmd, ...args], { stdio: 'pipe' });
     cp.stdout.on('data', chunk => {
       stdout += chunk;
     });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,7 +6,7 @@ export const jcoPath = 'src/jco.js';
 export async function exec (cmd, ...args) {
   let stdout = '', stderr = '';
   await new Promise((resolve, reject) => {
-    const cp = spawn(argv[0], [cmd, ...args], { stdio: 'pipe' });
+    const cp = spawn(argv[0], ['--no-warnings', cmd, ...args], { stdio: 'pipe' });
     cp.stdout.on('data', chunk => {
       stdout += chunk;
     });


### PR DESCRIPTION
This implements `Symbol.dispose` support as described in https://github.com/bytecodealliance/jco/issues/236.

The major feature enabled by this is the ability to use `Symbol.dispose` to define explicit deconstructors for JS classes that are imported by Wasm.

In addition, `Symbol.dispose` can be used to also eagerly drop own resources, which will cause handles to be immediately invalidated as if there was an explicit drop, as opposed to a GC based drop.

