### PR TITLE
fix: http headers support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "terser": "^5.16.1"
   },
   "devDependencies": {
-    "@bytecodealliance/componentize-js": "^0.4.0",
+    "@bytecodealliance/componentize-js": "^0.4.1",
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",

--- a/test/fixtures/componentize/wasi-http-proxy/source.js
+++ b/test/fixtures/componentize/wasi-http-proxy/source.js
@@ -44,12 +44,10 @@ const sendRequest = (
     }
 
     const status = incomingResponse.status();
-    // const h = incomingResponse.headers();
-    // const responseHeaders = incomingResponse.headers().entries();
+    const responseHeaders = incomingResponse.headers().entries();
 
     const decoder = new TextDecoder();
-    // const headers = responseHeaders.map(([k, v]) => [k, decoder.decode(v)]);
-    const headers = [];
+    const headers = responseHeaders.map(([k, v]) => [k, decoder.decode(v)]);
 
     let responseBody;
     const incomingBody = incomingResponse.consume();

--- a/test/runtime/wasi-http-proxy.ts
+++ b/test/runtime/wasi-http-proxy.ts
@@ -5,12 +5,12 @@ import { commands, incomingHandler } from '../output/wasi-http-proxy/wasi-http-p
 // const { IncomingRequest, ResponseOutparam } = types;
 
 const defaultHeaders: [string, string][] = [
-  // ['connection', 'keep-alive'],
-  // ['content-type', 'text/plain'],
-  // ['date', 'null'],
-  // ['keep-alive', 'timeout=5'],
-  // ['transfer-encoding', 'chunked'],
-  // ['x-wasi', 'mock-server'],
+  ['connection', 'keep-alive'],
+  ['content-type', 'text/plain'],
+  ['date', 'null'],
+  ['keep-alive', 'timeout=5'],
+  ['transfer-encoding', 'chunked'],
+  ['x-wasi', 'mock-server'],
 ];
 
 assert.equal(


### PR DESCRIPTION
Thanks to the fix by @dicej, this gets headers working for `wasi-http` reenabling the previous tests.