### PR TITLE
Adding `.js` file extension to function type imports

### DIFF
--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -382,7 +382,7 @@ impl TsBindgen {
         if !local_exists {
             uwriteln!(
                 self.src,
-                "import {{ {} }} from './{}';",
+                "import {{ {} }} from './{}.js';",
                 if camel == local_name {
                     camel.to_string()
                 } else {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "outDir": "output",
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "nodenext",
     "target": "es2020",
     "strict": true,
     "strictNullChecks": true,


### PR DESCRIPTION
While testing `0.13.2` earlier today I realized that my change in #228 missed a case. While it covered type imports it missed importing functions in `.d.ts` files. This change fixes that and also updates the `moduleResolution` field in the test tsconfig to `nodenext` since the ts docs state: 
>"You probably won’t need to use `node10` (equivalent to `node`) in modern code." 

This means that the existing `Verify Typescript output` test now implicitly tests for the presence of the `.js` extensions because it would fail to compile without them. 

See ts docs for more info on the `nodenext` module resolution strategy and the deprecation of `node`:
https://www.typescriptlang.org/tsconfig#moduleResolution