### PR TITLE
make `resourceHandleSymbol` field configurable

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1223,7 +1223,7 @@ impl Bindgen for FunctionBindgen<'_> {
                             uwrite!(
                                 self.src,
                                 "const {rsc} = new.target === import_{prefix}{upper_camel} ? this : Object.create(import_{prefix}{upper_camel}.prototype);
-                                 Object.defineProperty({rsc}, {symbol_resource_handle}, {{ writable: true, value: {handle} }});
+                                 Object.defineProperty({rsc}, {symbol_resource_handle}, {{ writable: true, configurable: true, value: {handle} }});
                                 "
                             );
 


### PR DESCRIPTION
This helps to enable precise disposal of imported resource handles per https://github.com/bytecodealliance/componentize-js/issues/68.  Making the `resourceHandleSymbol` field configurable allows it to be deleted from resource objects, which we will do during disposal.