### PR TITLE
fix: dispose definition value

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1166,7 +1166,7 @@ impl Bindgen for FunctionBindgen<'_> {
                                 uwriteln!(
                                     self.src,
                                     "finalizationRegistry{id}.register({rsc}, {handle}, {rsc});
-                                    Object.defineProperty({rsc}, {symbol_dispose}, function () {{{}}});
+                                    Object.defineProperty({rsc}, {symbol_dispose}, {{ writable: true, value: function () {{{}}} }});
                                     ",
                                     match dtor_name {
                                         Some(dtor) => format!("


### PR DESCRIPTION
Fixes a bug where the symbol dispose function was not applying the descriptor call property including not setting the value as writable. I believe this was the root cause of the bug that prompted https://github.com/bytecodealliance/jco/pull/242 @dicej.