### PR TITLE
feat: Allow `--instantiation` to generate non-async code

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Options include:
 * `--no-wasi-shim`: Disable the WASI shim mapping to `@bytecodealliance/preview2-shim`.
 * `--map`: Provide custom mappings for world imports. Supports both wildcard mappings (`*` similarly as in the package.json "exports" field) as well as `#` mappings for targetting exported interfaces. For example, the WASI mappings are internally defined with mappings like `--map wasi:filesystem/*=@bytecodealliance/preview2-shim/filesystem#*` to map `import as * filesystem from 'wasi:filesystem/types'` to `import { types } from '@bytecodealliance/preview2-shim/filesystem`.
 * `--no-nodejs-compat`: Disables Node.js compat in the output to load core Wasm with FS methods.
-* `--instantiation`: Instead of a direct ES module, export an `instantiate` function which can take the imports as an argument instead of implicit imports.
+* `--instantiation [mode]`: Instead of a direct ES module, export an `instantiate` function which can take the imports as an argument instead of implicit imports. The `instantiate` function can be async (with `--instantiation` or `--instantiation async`), or sync (with `--instantiation sync`).
 * `--valid-lifting-optimization`: Internal validations are removed assuming that core Wasm binaries are valid components, providing a minor output size saving.
 
 #### Bindgen Crate

--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -40,6 +40,15 @@ wit_bindgen::generate!({
     }
 });
 
+impl From<InstantiationMode> for js_component_bindgen::InstantiationMode {
+    fn from(value: InstantiationMode) -> Self {
+        match value {
+            InstantiationMode::Async => js_component_bindgen::InstantiationMode::Async,
+            InstantiationMode::Sync => js_component_bindgen::InstantiationMode::Sync,
+        }
+    }
+}
+
 struct JsComponentBindgenComponent;
 
 impl Guest for JsComponentBindgenComponent {
@@ -48,7 +57,7 @@ impl Guest for JsComponentBindgenComponent {
         let opts = js_component_bindgen::TranspileOpts {
             name: options.name,
             no_typescript: options.no_typescript.unwrap_or(false),
-            instantiation: options.instantiation.unwrap_or(false),
+            instantiation: options.instantiation.map(Into::into),
             map: options.map.map(|map| map.into_iter().collect()),
             no_nodejs_compat: options.no_nodejs_compat.unwrap_or(false),
             base64_cutoff: options.base64_cutoff.unwrap_or(5000) as usize,
@@ -116,7 +125,7 @@ impl Guest for JsComponentBindgenComponent {
             name: "component".to_string(),
             no_typescript: false,
             no_nodejs_compat: false,
-            instantiation: opts.instantiation.unwrap_or(false),
+            instantiation: opts.instantiation.map(Into::into),
             map: opts.map.map(|map| map.into_iter().collect()),
             tla_compat: opts.tla_compat.unwrap_or(false),
             valid_lifting_optimization: false,

--- a/crates/js-component-bindgen-component/wit/js-component-bindgen.wit
+++ b/crates/js-component-bindgen-component/wit/js-component-bindgen.wit
@@ -4,6 +4,11 @@ world js-component-bindgen {
   type files = list<tuple<string, list<u8>>>
   type maps = list<tuple<string, string>>
 
+  variant instantiation-mode {
+    async,
+    sync,
+  }
+
   record generate-options {
     /// Name to use for the generated component
     name: string,
@@ -14,7 +19,7 @@ world js-component-bindgen {
 
     /// Provide a custom JS instantiation API for the component instead
     /// of the direct importable native ESM output.
-    instantiation: option<bool>,
+    instantiation: option<instantiation-mode>,
 
     /// Mappings of component import specifiers to JS import specifiers.
     map: option<maps>,
@@ -56,7 +61,7 @@ world js-component-bindgen {
     /// world to generate typing for
     %world: option<string>,
     tla-compat: option<bool>,
-    instantiation: option<bool>,
+    instantiation: option<instantiation-mode>,
     map: option<maps>,
   }
 

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -497,9 +497,9 @@ impl Bindgen for FunctionBindgen<'_> {
                 let variant_name = name.to_upper_camel_case();
                 uwriteln!(
                     self.src,
-                    "default: {{
-                        throw new TypeError(`invalid variant ${{JSON.stringify({expr_to_match})}} specified for {variant_name}`);
-                    }}",
+                    r#"default: {{
+                        throw new TypeError(`invalid variant tag value \`${{JSON.stringify({expr_to_match})}}\` (received \`${{variant{tmp}}}\`) specified for \`{variant_name}\``);
+                    }}"#,
                 );
                 uwriteln!(self.src, "}}");
             }

--- a/crates/js-component-bindgen/src/lib.rs
+++ b/crates/js-component-bindgen/src/lib.rs
@@ -8,7 +8,7 @@ pub mod function_bindgen;
 pub mod intrinsics;
 pub mod names;
 pub mod source;
-pub use transpile_bindgen::TranspileOpts;
+pub use transpile_bindgen::{InstantiationMode, TranspileOpts};
 
 use anyhow::Result;
 use transpile_bindgen::transpile_bindgen;

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -184,7 +184,7 @@ impl<'a> JsBindgen<'a> {
             if self.opts.instantiation.is_some() {
                 uwriteln!(
                     compilation_promises,
-                    "const {local_name} = compileCore('{name_idx}');"
+                    "const {local_name} = getCoreModule('{name_idx}');"
                 );
             } else if files.get_size(&name_idx).unwrap() < self.opts.base64_cutoff {
                 assert!(removed.insert(i));
@@ -224,7 +224,7 @@ impl<'a> JsBindgen<'a> {
                     output,
                     "\
                         {}
-                        export async function instantiate(compileCore, imports, instantiateCore = WebAssembly.instantiate) {{
+                        export async function instantiate(getCoreModule, imports, instantiateCore = WebAssembly.instantiate) {{
                             {}
                     ",
                     &js_intrinsics as &str,
@@ -237,7 +237,7 @@ impl<'a> JsBindgen<'a> {
                     output,
                     "\
                         {}
-                        export function instantiate(compileCore, imports, instantiateCore = WebAssembly.Instance) {{
+                        export function instantiate(getCoreModule, imports, instantiateCore = WebAssembly.Instance) {{
                             {}
                     ",
                     &js_intrinsics as &str,

--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -228,26 +228,26 @@ pub fn ts_bindgen(
                 bindgen.src,
                 "
                     /**
-                    * Instantiates this component with the provided imports and
-                    * returns a map of all the exports of the component.
-                    *
-                    * This function is intended to be similar to the
-                    * `WebAssembly.instantiate` function. The second `imports`
-                    * argument is the \"import object\" for wasm, except here it
-                    * uses component-model-layer types instead of core wasm
-                    * integers/numbers/etc.
-                    *
-                    * The first argument to this function, `compileCore`, is
-                    * used to compile core wasm modules within the component.
-                    * Components are composed of core wasm modules and this callback
-                    * will be invoked per core wasm module. The caller of this
-                    * function is responsible for reading the core wasm module
-                    * identified by `path` and returning its compiled
-                    * `WebAssembly.Module` object. This would use `compileStreaming`
-                    * on the web, for example.
-                    */
+                     * Instantiates this component with the provided imports and
+                     * returns a map of all the exports of the component.
+                     *
+                     * This function is intended to be similar to the
+                     * `WebAssembly.instantiate` function. The second `imports`
+                     * argument is the \"import object\" for wasm, except here it
+                     * uses component-model-layer types instead of core wasm
+                     * integers/numbers/etc.
+                     *
+                     * The first argument to this function, `getCoreModule`, is
+                     * used to compile core wasm modules within the component.
+                     * Components are composed of core wasm modules and this callback
+                     * will be invoked per core wasm module. The caller of this
+                     * function is responsible for reading the core wasm module
+                     * identified by `path` and returning its compiled
+                     * `WebAssembly.Module` object. This would use `compileStreaming`
+                     * on the web, for example.
+                     */
                     export function instantiate(
-                        compileCore: (path: string, imports: Record<string, any>) => Promise<WebAssembly.Module>,
+                        getCoreModule: (path: string) => Promise<WebAssembly.Module>,
                         imports: ImportObject,
                         instantiateCore?: (module: WebAssembly.Module, imports: Record<string, any>) => Promise<WebAssembly.Instance>
                     ): Promise<{camel}>;
@@ -260,26 +260,26 @@ pub fn ts_bindgen(
                 bindgen.src,
                 "
                     /**
-                    * Instantiates this component with the provided imports and
-                    * returns a map of all the exports of the component.
-                    *
-                    * This function is intended to be similar to the
-                    * `WebAssembly.Instantiate` constructor. The second `imports`
-                    * argument is the \"import object\" for wasm, except here it
-                    * uses component-model-layer types instead of core wasm
-                    * integers/numbers/etc.
-                    *
-                    * The first argument to this function, `compileCore`, is
-                    * used to compile core wasm modules within the component.
-                    * Components are composed of core wasm modules and this callback
-                    * will be invoked per core wasm module. The caller of this
-                    * function is responsible for reading the core wasm module
-                    * identified by `path` and returning its compiled
-                    * `WebAssembly.Module` object. This would use the
-                    * `WebAssembly.Module` constructor on the web, for example.
-                    */
+                     * Instantiates this component with the provided imports and
+                     * returns a map of all the exports of the component.
+                     *
+                     * This function is intended to be similar to the
+                     * `WebAssembly.Instantiate` constructor. The second `imports`
+                     * argument is the \"import object\" for wasm, except here it
+                     * uses component-model-layer types instead of core wasm
+                     * integers/numbers/etc.
+                     *
+                     * The first argument to this function, `getCoreModule`, is
+                     * used to compile core wasm modules within the component.
+                     * Components are composed of core wasm modules and this callback
+                     * will be invoked per core wasm module. The caller of this
+                     * function is responsible for reading the core wasm module
+                     * identified by `path` and returning its compiled
+                     * `WebAssembly.Module` object. This would use the
+                     * `WebAssembly.Module` constructor on the web, for example.
+                     */
                     export function instantiate(
-                        compileCore: (path: string, imports: Record<string, any>) => WebAssembly.Module,
+                        getCoreModule: (path: string) => WebAssembly.Module,
                         imports: ImportObject,
                         instantiateCore?: (module: WebAssembly.Module, imports: Record<string, any>) => WebAssembly.Instance
                     ): {camel};

--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -2,7 +2,7 @@ use crate::files::Files;
 use crate::function_bindgen::{array_ty, as_nullable, maybe_null};
 use crate::names::{maybe_quote_id, LocalNames, RESERVED_KEYWORDS};
 use crate::source::Source;
-use crate::transpile_bindgen::{parse_world_key, TranspileOpts};
+use crate::transpile_bindgen::{parse_world_key, InstantiationMode, TranspileOpts};
 use crate::{uwrite, uwriteln};
 use heck::*;
 use std::collections::btree_map::Entry;
@@ -153,8 +153,13 @@ pub fn ts_bindgen(
                     }
                 };
                 seen_names.insert(export_name.to_string());
-                let local_name =
-                    bindgen.export_interface(resolve, export_name, *id, files, opts.instantiation);
+                let local_name = bindgen.export_interface(
+                    resolve,
+                    export_name,
+                    *id,
+                    files,
+                    opts.instantiation.is_some(),
+                );
                 export_aliases.push((iface_name.to_lower_camel_case(), local_name));
             }
             WorldItem::Type(_) => unimplemented!("type exports"),
@@ -162,7 +167,7 @@ pub fn ts_bindgen(
     }
     for (alias, local_name) in export_aliases {
         if !seen_names.contains(&alias) {
-            if opts.instantiation {
+            if opts.instantiation.is_some() {
                 uwriteln!(
                     bindgen.export_object,
                     "{}: typeof {},",
@@ -180,7 +185,7 @@ pub fn ts_bindgen(
         }
     }
     if !funcs.is_empty() {
-        bindgen.export_funcs(resolve, id, &funcs, files, !opts.instantiation);
+        bindgen.export_funcs(resolve, id, &funcs, files, opts.instantiation.is_none());
     }
 
     let camel = world.name.to_upper_camel_case();
@@ -191,7 +196,7 @@ pub fn ts_bindgen(
     // With the current representation of a "world" this is an import object
     // per-imported-interface where the type of that field is defined by the
     // interface itbindgen.
-    if opts.instantiation {
+    if opts.instantiation.is_some() {
         uwriteln!(bindgen.src, "export interface ImportObject {{");
         bindgen.src.push_str(&bindgen.import_object);
         uwriteln!(bindgen.src, "}}");
@@ -199,7 +204,7 @@ pub fn ts_bindgen(
 
     // Generate a type definition for the export object from instantiating
     // the component.
-    if opts.instantiation {
+    if opts.instantiation.is_some() {
         uwriteln!(bindgen.src, "export interface {camel} {{",);
         bindgen.src.push_str(&bindgen.export_object);
         uwriteln!(bindgen.src, "}}");
@@ -217,36 +222,72 @@ pub fn ts_bindgen(
 
     // Generate the TypeScript definition of the `instantiate` function
     // which is the main workhorse of the generated bindings.
-    if opts.instantiation {
-        uwriteln!(
-            bindgen.src,
-            "
-            /**
-                * Instantiates this component with the provided imports and
-                * returns a map of all the exports of the component.
-                *
-                * This function is intended to be similar to the
-                * `WebAssembly.instantiate` function. The second `imports`
-                * argument is the \"import object\" for wasm, except here it
-                * uses component-model-layer types instead of core wasm
-                * integers/numbers/etc.
-                *
-                * The first argument to this function, `compileCore`, is
-                * used to compile core wasm modules within the component.
-                * Components are composed of core wasm modules and this callback
-                * will be invoked per core wasm module. The caller of this
-                * function is responsible for reading the core wasm module
-                * identified by `path` and returning its compiled
-                * WebAssembly.Module object. This would use `compileStreaming`
-                * on the web, for example.
-                */
-                export function instantiate(
-                    compileCore: (path: string, imports: Record<string, any>) => Promise<WebAssembly.Module>,
-                    imports: ImportObject,
-                    instantiateCore?: (module: WebAssembly.Module, imports: Record<string, any>) => Promise<WebAssembly.Instance>
-                ): Promise<{camel}>;
-            ",
-        );
+    match opts.instantiation {
+        Some(InstantiationMode::Async) => {
+            uwriteln!(
+                bindgen.src,
+                "
+                    /**
+                    * Instantiates this component with the provided imports and
+                    * returns a map of all the exports of the component.
+                    *
+                    * This function is intended to be similar to the
+                    * `WebAssembly.instantiate` function. The second `imports`
+                    * argument is the \"import object\" for wasm, except here it
+                    * uses component-model-layer types instead of core wasm
+                    * integers/numbers/etc.
+                    *
+                    * The first argument to this function, `compileCore`, is
+                    * used to compile core wasm modules within the component.
+                    * Components are composed of core wasm modules and this callback
+                    * will be invoked per core wasm module. The caller of this
+                    * function is responsible for reading the core wasm module
+                    * identified by `path` and returning its compiled
+                    * `WebAssembly.Module` object. This would use `compileStreaming`
+                    * on the web, for example.
+                    */
+                    export function instantiate(
+                        compileCore: (path: string, imports: Record<string, any>) => Promise<WebAssembly.Module>,
+                        imports: ImportObject,
+                        instantiateCore?: (module: WebAssembly.Module, imports: Record<string, any>) => Promise<WebAssembly.Instance>
+                    ): Promise<{camel}>;
+                ",
+            )
+        }
+
+        Some(InstantiationMode::Sync) => {
+            uwriteln!(
+                bindgen.src,
+                "
+                    /**
+                    * Instantiates this component with the provided imports and
+                    * returns a map of all the exports of the component.
+                    *
+                    * This function is intended to be similar to the
+                    * `WebAssembly.Instantiate` constructor. The second `imports`
+                    * argument is the \"import object\" for wasm, except here it
+                    * uses component-model-layer types instead of core wasm
+                    * integers/numbers/etc.
+                    *
+                    * The first argument to this function, `compileCore`, is
+                    * used to compile core wasm modules within the component.
+                    * Components are composed of core wasm modules and this callback
+                    * will be invoked per core wasm module. The caller of this
+                    * function is responsible for reading the core wasm module
+                    * identified by `path` and returning its compiled
+                    * `WebAssembly.Module` object. This would use the
+                    * `WebAssembly.Module` constructor on the web, for example.
+                    */
+                    export function instantiate(
+                        compileCore: (path: string, imports: Record<string, any>) => WebAssembly.Module,
+                        imports: ImportObject,
+                        instantiateCore?: (module: WebAssembly.Module, imports: Record<string, any>) => WebAssembly.Instance
+                    ): {camel};
+                ",
+            )
+        }
+
+        None => {}
     }
 
     files.push(&format!("{name}.d.ts"), bindgen.src.as_bytes());

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -64,7 +64,7 @@ async function wasm2Js (source) {
  * @param {Uint8Array} component 
  * @param {{
  *   name: string,
- *   instantiation?: bool,
+ *   instantiation?: 'async' | 'sync',
  *   map?: Record<string, string>,
  *   validLiftingOptimization?: bool,
  *   tracing?: bool,
@@ -103,10 +103,18 @@ export async function transpileComponent (component, opts = {}) {
     }, opts.map || {});
   }
 
+  let instantiation = null;
+
+  if (opts.instantiation) {
+    instantiation = { tag: opts.instantiation };
+  } else if (opts.js) {
+    instantiation = { tag: 'async' };
+  }
+
   let { files, imports, exports } = generate(component, {
     name: opts.name ?? 'component',
     map: Object.entries(opts.map ?? {}),
-    instantiation: opts.instantiation || opts.js,
+    instantiation,
     validLiftingOptimization: opts.validLiftingOptimization ?? false,
     tracing: opts.tracing ?? false,
     noNodejsCompat: !(opts.nodejsCompat ?? true),

--- a/src/jco.js
+++ b/src/jco.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { program } from 'commander';
+import { program, Option } from 'commander';
 import { opt } from './cmd/opt.js';
 import { transpile } from './cmd/transpile.js';
 import { run } from './cmd/run.js';
@@ -45,12 +45,12 @@ program.command('transpile')
   .option('-M, --map <mappings...>', 'specifier=./output custom mappings for the component imports')
   .option('--no-wasi-shim', 'disable automatic rewriting of WASI imports to use @bytecodealliance/preview2-shim')
   .option('--js', 'output JS instead of core WebAssembly')
-  .option('-I, --instantiation', 'output for custom module instantiation')
+  .addOption(new Option('-I, --instantiation [mode]', 'output for custom module instantiation').choices(['async', 'sync']).preset('async'))
   .option('-q, --quiet', 'disable logging')
   .option('--', 'for --optimize, custom wasm-opt arguments (defaults to best size optimization)')
   .action(asyncAction(transpile));
 
-  program.command('run')
+program.command('run')
   .description('Run a WebAssembly Command component')
   .usage('<command.wasm> <args...>')
   .argument('<command>', 'Wasm command binary to run')

--- a/test/browser.html
+++ b/test/browser.html
@@ -24,7 +24,7 @@
     name: 'test',
     noTypescript: true,
     noNodejsCompat: true,
-    instantiation: true,
+    instantiation: 'async',
     // force baseurls
     // todo: support a hook for inline blob url construction
     base64Cutoff: 1000000,

--- a/test/runtime/helpers.ts
+++ b/test/runtime/helpers.ts
@@ -1,6 +1,8 @@
 // @ts-ignore
 import { readFile } from 'node:fs/promises';
 // @ts-ignore
+import { readFileSync } from 'node:fs';
+// @ts-ignore
 import { stdout, stderr } from 'node:process';
 // @ts-ignore
 import { basename } from 'node:path';
@@ -15,6 +17,12 @@ import { basename } from 'node:path';
 export async function loadWasm(path: string) {
   const name = basename(path).replace(/\.core\d*\.wasm$/, '');
   return await WebAssembly.compile(await readFile(new URL(`./${name}/${path}`, import.meta.url)));
+}
+
+// Just like `loadWasm`, but not async :-).
+export function loadWasmSync(path: string) {
+  const name = basename(path).replace(/\.core\d*\.wasm$/, '');
+  return new WebAssembly.Module(readFileSync(new URL(`./${name}/${path}`, import.meta.url)));
 }
 
 // Export a WASI interface directly for instance imports

--- a/test/runtime/strings.sync.ts
+++ b/test/runtime/strings.sync.ts
@@ -1,0 +1,27 @@
+// Flags: --instantiation sync
+
+import * as helpers from './helpers.js';
+import { instantiate } from '../output/strings.sync/strings.sync.js';
+
+// @ts-ignore
+import * as assert from 'assert';
+
+function run() {
+  const wasm = instantiate(helpers.loadWasmSync, {
+    testwasi: helpers,
+    'test:strings/imports': {
+      takeBasic(s: string) {
+        assert.strictEqual(s, 'latin utf16');
+      },
+      returnUnicode() {
+        return '🚀🚀🚀 𠈄𓀀';
+      }
+    }
+  });
+
+  wasm.testImports();
+  assert.strictEqual(wasm.roundtrip('str'), 'str');
+  assert.strictEqual(wasm.roundtrip('🚀🚀🚀 𠈄𓀀'), '🚀🚀🚀 𠈄𓀀');
+}
+
+run()

--- a/test/test.js
+++ b/test/test.js
@@ -27,7 +27,7 @@ import { preview2Test } from './preview2.js';
 import { tsTest } from './typescript.js';
 
 await codegenTest(componentFixtures);
-await tsTest();
+tsTest();
 await preview2Test();
 await runtimeTest(componentFixtures);
 await apiTest(componentFixtures);

--- a/xtask/src/build/jco.rs
+++ b/xtask/src/build/jco.rs
@@ -60,7 +60,7 @@ fn transpile(component_path: &str, name: String) -> Result<()> {
     let opts = js_component_bindgen::TranspileOpts {
         name,
         no_typescript: false,
-        instantiation: false,
+        instantiation: None,
         map: Some(import_map),
         no_nodejs_compat: false,
         base64_cutoff: 5000_usize,

--- a/xtask/src/generate/wasi_types.rs
+++ b/xtask/src/generate/wasi_types.rs
@@ -29,7 +29,7 @@ pub(crate) fn run() -> Result<()> {
             name: "component".to_string(),
             no_typescript: false,
             no_nodejs_compat: false,
-            instantiation: false,
+            instantiation: None,
             map: None,
             tla_compat: false,
             valid_lifting_optimization: false,


### PR DESCRIPTION
This code should ideally be reviewed patch by patch.

The idea is to implement the feature described in https://github.com/bytecodealliance/jco/issues/245.

First off, this patch updates the `--instantiation` option to receive a string value instead of a being a switch. The possible values are `async` (the default) or `sync`. The fact that `async` is the default value ensures the backward compatibility.

Next, this patch updates the `TranspileOpts::instantiation` field to be `Option<InstantiationMode>` instead of `bool`. `InstantiationMode` is a enum with 2 variants: `Async` and `Sync`. The code is updated accordingly.

Next, the same patch adds non-async code during the bindgen pass.

The next patches are about improving the test framework, and adds a new test case for non-async generated code.