### PR TITLE
doc: update readmes, better contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <h1><code>jco</code></h1>
 
   <p>
-    <strong>JavaScript component toolchain for working with <a href="https://github.com/WebAssembly/component-model">WebAssembly Components</a></strong>
+    <strong>JavaScript toolchain for working with <a href="https://github.com/WebAssembly/component-model">WebAssembly Components</a></strong>
   </p>
 
   <strong>A <a href="https://bytecodealliance.org/">Bytecode Alliance</a> project</strong>
@@ -14,14 +14,14 @@
 
 ## Overview
 
-`jco` is a fully native JS tool for working with the emerging [WebAssembly Components](https://github.com/WebAssembly/component-model) specification in JavaScript.
+`jco` is a fully native JS tool for working with [WebAssembly Components](https://github.com/WebAssembly/component-model) in JavaScript.
 
 Features include:
 
 * "Transpiling" Wasm Component binaries into ES modules that can run in any JS environment.
-* Optimization helpers for Components via Binaryen.
-* Component builds of [Wasm Tools](https://github.com/bytecodealliance/wasm-tools) helpers, available for use as a library or CLI commands for use in native JS environments.
-* "Componentize" for WebAssembly Components from JavaScript sources and a WIT world
+* WASI Preview2 support in Node.js ([undergoing stabilization](https://github.com/bytecodealliance/jco/milestone/1)) & browsers (experimental).
+* Component builds of [Wasm Tools](https://github.com/bytecodealliance/wasm-tools) helpers, available for use as a library or CLI commands for use in native JS environments, as well as optimization helper for Components via Binaryen.
+* "Componentize" command to easily create components written in JavaScript (wrapper of [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS)).
 
 For creating components in other languages, see the [Cargo Component](https://github.com/bytecodealliance/cargo-Component) project for Rust and [Wit Bindgen](https://github.com/bytecodealliance/wit-bindgen) for various guest bindgen helpers.
 
@@ -103,10 +103,23 @@ Options include:
 * `--no-nodejs-compat`: Disables Node.js compat in the output to load core Wasm with FS methods.
 * `--instantiation [mode]`: Instead of a direct ES module, export an `instantiate` function which can take the imports as an argument instead of implicit imports. The `instantiate` function can be async (with `--instantiation` or `--instantiation async`), or sync (with `--instantiation sync`).
 * `--valid-lifting-optimization`: Internal validations are removed assuming that core Wasm binaries are valid components, providing a minor output size saving.
+* `--tracing`: Emit tracing calls for all function entry and exits.
 
 #### Bindgen Crate
 
 To directly call into the transpilation in Rust, the bindgen used in jco is also available on crates.io as [js-component-bindgen](https://crates.io/crates/js-component-bindgen).
+
+### Run
+
+For Wasm components that implement the WASI Command world, a `jco run` utility is provided to run these applications in Node.js:
+
+```
+jco run cowasy.component.wasm hello
+```
+
+Using the preview2-shim WASI implementation, full access to the underlying system primitives is provided, including filesystem and environment variable permissions.
+
+> [preview2-shim](packages/preview2-shim) is currently being stabilized in Node.js, tracking in https://github.com/bytecodealliance/jco/milestone/1.
 
 ### Componentize
 
@@ -122,19 +135,7 @@ Currently requires an explicit install of the componentize-js engine via `npm in
 
 See [ComponentizeJS](https://github.com/bytecodealliance/componentize-js) for more details on this process.
 
-> Additional engines may be supported in future via an `--engine` field or otherwise.
-
-### Run
-
-For Wasm components that implement the WASI Command world, a `jco run` utility is provided to run these applications in Node.js:
-
-```
-jco run cowasy.component.wasm hello
-```
-
-Using the preview2-shim WASI implementation, full access to the underlying system primitives is provided, including filesystem and environment variable permissions.
-
-> Since [preview2-shim](packages/preview2-shim) is an experimental work-in-progress implementation, there will likely be bugs.
+> Additional engines might be supported in future via an `--engine` field or otherwise.
 
 ## API
 

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -4,4 +4,50 @@ Development is based on a standard `npm install && npm run build && npm run test
 
 Tests can be run without bundling via `npm run build:dev && npm run test:dev`.
 
-Specific tests can be run adding the mocha `--grep` flag, for example: `npm run test:dev -- --grep exports_only`.
+Specific tests can be run adding the mocha `--grep` / `-g` flag, for example: `npm run test:dev -- --grep exports_only`.
+
+## Prerequisites
+
+Required prerequisites for building jco include:
+
+* Latest stable Rust with the `wasm32-wasi` target
+* Node.js 18+ & npm (https://nodejs.org/en)
+
+### Rust Toolchain
+
+The latest Rust stable toolchain can be installed using [rustup](https://rustup.rs/).
+
+Specifically:
+
+```
+rustup toolchain install stable
+rustup target add wasm32-wasi
+```
+
+## Project Structure
+
+jco is effectively a monorepo consisting of the following projects:
+
+* `crates/js-component-bindgen`: Rust crate for creating JS component bindgen, published under https://crates.io/crates/js-component-bindgen.
+* `crates/js-component-bindgen-component`: Component wrapper crate for the component bindgen. This allows bindgen to be self-hosted in JS.
+* `crates/wasm-tools-component`: Component wrapper crate for wasm-tools, allowing jco to invoke various Wasm toolchain functionality and also make it available through the jco API.
+* `src/api.js`: The jco API which can be used as a library dependency on npm. Published as https://npmjs.org/package/@bytecodealliance/jco.
+* `src/jco.js`: The jco CLI. Published as https://npmjs.org/package/@bytecodealliance/jco.
+* `packages/preview2-shim`: The WASI Preview2 host implementations for Node.js & browsers. Published as https://www.npmjs.com/package/@bytecodealliance/preview2-shim.
+
+## Building
+
+To build jco, run:
+
+```
+npm install
+npm run build
+```
+
+## Testing
+
+There are three test suites in jco:
+* `npm run test`: Project-level transpilation, CLI & API tests.
+* `npm run test --workspace packages/preview2-shim`: `preview2-shim` unit tests.
+* `test/browser.html`: Bare-minimum browser validation test.
+* `cargo test`: Wasmtime preview2 conformance tests (not currently passing).

--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -29,11 +29,10 @@ world cowsay {
       elephant-in-snake,
       elephant,
       eyes,
-      flaming-sheep,
-      ...
+      flaming-sheep
     }
 
-    say: func(text: string, cow: option<cows>) -> string
+    say: func(text: string, cow: option<cows>) -> string;
   }
 }
 ```

--- a/packages/preview2-shim/README.md
+++ b/packages/preview2-shim/README.md
@@ -1,20 +1,10 @@
-# WASI Preview2 JavaScript Shim
+# Preview2 Shim
 
-_**Experimental**_ shim modules for the [WASI Preview2](https://github.com/bytecodealliance/preview2-prototyping) component interfaces in JS environments.
+WASI Preview2 implementations for Node.js & browsers.
 
-Currently supports Node.js and browser versions, but alternative implementations for any JS environments can be supported.
+Browser support is considered experimental, and not currently suitable for production applications.
 
-## Implementation Status
-
-| Interface       | Node.js                      | Browser                      |
-| --------------- | ----------------------------:|-----------------------------:|
-| Clocks          | Pending timezone, poll       | Pending timezone, poll       |
-| Filesystem      | Basic read support           | _N/A_                        |
-| HTTP            | Experimental support         | :x:                          |
-| IO              | Experimental support         | Experimental support         |
-| Random          | :heavy_check_mark:           | :heavy_check_mark:           |
-| Sockets         | :x:                          | _N/A_                        |
-| CLI             | :heavy_check_mark:           | :heavy_check_mark:           |
+Node.js support is currently being stabilized, which can be tracked in https://github.com/bytecodealliance/jco/milestone/1.
 
 # License
 


### PR DESCRIPTION
Updates the readmes for the latest status and improves the contribution guide.

This should resolve https://github.com/bytecodealliance/jco/issues/62 and https://github.com/bytecodealliance/jco/issues/184.