### PR TITLE
fix: stdio thread in addition to main thread

### DIFF
--- a/packages/preview2-shim/lib/nodejs/cli.js
+++ b/packages/preview2-shim/lib/nodejs/cli.js
@@ -29,9 +29,9 @@ export const exit = {
   },
 };
 
-const stdinStream = inputStreamCreate(STDIN, null);
-const stdoutStream = outputStreamCreate(STDOUT, null);
-const stderrStream = outputStreamCreate(STDERR, null);
+const stdinStream = inputStreamCreate(STDIN, 1);
+const stdoutStream = outputStreamCreate(STDOUT, 2);
+const stderrStream = outputStreamCreate(STDERR, 3);
 
 export const stdin = {
   InputStream,


### PR DESCRIPTION
This enables stdio in the thread in addition to the main thread stdio.

This way operations like splicing for stdio can still happen in the thread, while normal write operations short-circuit in the main thread for the better blocking behaviours.