### PR TITLE
fix: more conformance tests

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -5,6 +5,7 @@ use heck::*;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::mem;
+use wasmtime_environ::component::TypeResourceTableIndex;
 use wit_bindgen_core::abi::{Bindgen, Bitcast, Instruction};
 use wit_component::StringEncoding;
 use wit_parser::abi::WasmType;
@@ -20,7 +21,7 @@ pub enum ErrHandling {
 #[derive(Clone, Debug)]
 pub enum ResourceData {
     Host {
-        id: u32,
+        id: TypeResourceTableIndex,
         local_name: String,
         dtor_name: Option<String>,
     },
@@ -1157,6 +1158,7 @@ impl Bindgen for FunctionBindgen<'_> {
                         local_name,
                         dtor_name,
                     } => {
+                        let id = id.as_u32();
                         let symbol_dispose = self.intrinsic(Intrinsic::SymbolDispose);
                         if !imported {
                             let rep = format!("rep{}", self.tmp());
@@ -1264,6 +1266,7 @@ impl Bindgen for FunctionBindgen<'_> {
 
                 match data {
                     ResourceData::Host { id, local_name, .. } => {
+                        let id = id.as_u32();
                         if !imported {
                             uwriteln!(
                                 self.src,

--- a/crates/js-component-bindgen/src/intrinsics.rs
+++ b/crates/js-component-bindgen/src/intrinsics.rs
@@ -335,8 +335,7 @@ pub fn render_intrinsics(
                     let ptr = 0;
                     let writtenTotal = 0;
                     while (s.length > 0) {
-                        ptr = realloc(ptr, allocLen, 1, allocLen + s.length);
-                        allocLen += s.length;
+                        ptr = realloc(ptr, allocLen, 1, allocLen += s.length * 2);
                         const { read, written } = utf8Encoder.encodeInto(
                             s,
                             new Uint8Array(memory.buffer, ptr + writtenTotal, allocLen - writtenTotal),
@@ -344,8 +343,6 @@ pub fn render_intrinsics(
                         writtenTotal += written;
                         s = s.slice(read);
                     }
-                    if (allocLen > writtenTotal)
-                        ptr = realloc(ptr, allocLen, 1, writtenTotal);
                     utf8EncodedLen = writtenTotal;
                     return ptr;
                 }

--- a/packages/preview2-shim/lib/browser/cli.js
+++ b/packages/preview2-shim/lib/browser/cli.js
@@ -123,13 +123,11 @@ const terminalStderrInstance = new TerminalOutput();
 const terminalStdinInstance = new TerminalInput();
 
 export const terminalInput = {
-  TerminalInput,
-  dropTerminalInput () {}
+  TerminalInput
 };
 
 export const terminalOutput = {
-  TerminalOutput,
-  dropTerminalOutput () {}
+  TerminalOutput
 };
 
 export const terminalStderr = {

--- a/packages/preview2-shim/lib/io/calls.js
+++ b/packages/preview2-shim/lib/io/calls.js
@@ -12,7 +12,7 @@ export const INPUT_STREAM_BLOCKING_READ = ++call_id << CALL_SHIFT;
 export const INPUT_STREAM_SKIP = ++call_id << CALL_SHIFT;
 export const INPUT_STREAM_BLOCKING_SKIP = ++call_id << CALL_SHIFT;
 export const INPUT_STREAM_SUBSCRIBE = ++call_id << CALL_SHIFT;
-export const INPUT_STREAM_DROP = ++call_id << CALL_SHIFT;
+export const INPUT_STREAM_DISPOSE = ++call_id << CALL_SHIFT;
 
 // Io Output Stream
 export const OUTPUT_STREAM_CREATE = ++call_id << CALL_SHIFT;
@@ -27,7 +27,7 @@ export const OUTPUT_STREAM_BLOCKING_WRITE_ZEROES_AND_FLUSH =
 export const OUTPUT_STREAM_SPLICE = ++call_id << CALL_SHIFT;
 export const OUTPUT_STREAM_BLOCKING_SPLICE = ++call_id << CALL_SHIFT;
 export const OUTPUT_STREAM_SUBSCRIBE = ++call_id << CALL_SHIFT;
-export const OUTPUT_STREAM_DROP = ++call_id << CALL_SHIFT;
+export const OUTPUT_STREAM_DISPOSE = ++call_id << CALL_SHIFT;
 
 // Io Poll
 export const POLL_POLLABLE_READY = ++call_id << CALL_SHIFT;
@@ -35,8 +35,8 @@ export const POLL_POLLABLE_BLOCK = ++call_id << CALL_SHIFT;
 export const POLL_POLL_LIST = ++call_id << CALL_SHIFT;
 
 // Futures
-export const FUTURE_DROP_AND_GET_VALUE = ++call_id << CALL_SHIFT;
-export const FUTURE_DROP = ++call_id << CALL_SHIFT;
+export const FUTURE_DISPOSE_AND_GET_VALUE = ++call_id << CALL_SHIFT;
+export const FUTURE_DISPOSE = ++call_id << CALL_SHIFT;
 
 // Http
 export const HTTP_CREATE_REQUEST = ++call_id << 24;

--- a/packages/preview2-shim/lib/io/worker-thread.js
+++ b/packages/preview2-shim/lib/io/worker-thread.js
@@ -10,13 +10,13 @@ import {
   CLOCKS_DURATION_SUBSCRIBE,
   CLOCKS_INSTANT_SUBSCRIBE,
   CLOCKS_NOW,
-  FUTURE_DROP_AND_GET_VALUE,
-  FUTURE_DROP,
+  FUTURE_DISPOSE_AND_GET_VALUE,
+  FUTURE_DISPOSE,
   HTTP_CREATE_REQUEST,
   INPUT_STREAM_BLOCKING_READ,
   INPUT_STREAM_BLOCKING_SKIP,
   INPUT_STREAM_CREATE,
-  INPUT_STREAM_DROP,
+  INPUT_STREAM_DISPOSE,
   INPUT_STREAM_READ,
   INPUT_STREAM_SKIP,
   INPUT_STREAM_SUBSCRIBE,
@@ -26,7 +26,7 @@ import {
   OUTPUT_STREAM_BLOCKING_WRITE_ZEROES_AND_FLUSH,
   OUTPUT_STREAM_CHECK_WRITE,
   OUTPUT_STREAM_CREATE,
-  OUTPUT_STREAM_DROP,
+  OUTPUT_STREAM_DISPOSE,
   OUTPUT_STREAM_FLUSH,
   OUTPUT_STREAM_SPLICE,
   OUTPUT_STREAM_SUBSCRIBE,
@@ -123,9 +123,9 @@ function handle(call, id, payload) {
     }
 
     // Stdio
-    case OUTPUT_STREAM_DROP | STDOUT:
-    case OUTPUT_STREAM_DROP | STDERR:
-    case INPUT_STREAM_DROP | STDIN:
+    case OUTPUT_STREAM_DISPOSE | STDOUT:
+    case OUTPUT_STREAM_DISPOSE | STDERR:
+    case INPUT_STREAM_DISPOSE | STDIN:
       return;
 
     // Clocks
@@ -214,7 +214,7 @@ function handle(call, id, payload) {
             )
           );
         }
-        case INPUT_STREAM_DROP:
+        case INPUT_STREAM_DISPOSE:
           unfinishedStreams.delete(id);
           return;
 
@@ -371,7 +371,7 @@ function handle(call, id, payload) {
           }
           return promise.then(() => handle(OUTPUT_STREAM_SPLICE, id, payload));
         }
-        case OUTPUT_STREAM_DROP: {
+        case OUTPUT_STREAM_DISPOSE: {
           const stream = unfinishedStreams.get(id);
           if (stream) {
             stream.stream.end();
@@ -401,7 +401,7 @@ function handle(call, id, payload) {
           });
         }
 
-        case FUTURE_DROP_AND_GET_VALUE: {
+        case FUTURE_DISPOSE_AND_GET_VALUE: {
           const future = unfinishedFutures.get(id);
           if (!future) {
             // future not ready yet
@@ -411,7 +411,7 @@ function handle(call, id, payload) {
           unfinishedFutures.delete(id);
           return future;
         }
-        case FUTURE_DROP:
+        case FUTURE_DISPOSE:
           return void unfinishedFutures.delete(id);
 
         default:

--- a/packages/preview2-shim/lib/nodejs/cli.js
+++ b/packages/preview2-shim/lib/nodejs/cli.js
@@ -7,6 +7,16 @@ import {
 import { STDIN, STDOUT, STDERR } from "../io/stream-types.js";
 const { InputStream, OutputStream } = streams;
 
+export const _setEnv = env => void (_env = Object.entries(env));
+export const _setArgs = args => void (_args = args);
+export const _setCwd = cwd => void (_cwd = cwd);
+export const _setStdin = stdin => void (stdinStream = stdin);
+export const _setStdout = stdout => void (stdoutStream = stdout);
+export const _setStderr = stderr => void (stderrStream = stderr);
+export const _setTerminalStdin = terminalStdin => void (terminalStdinInstance = terminalStdin);
+export const _setTerminalStdout = terminalStdout => void (terminalStdoutInstance = terminalStdout);
+export const _setTerminalStderr = terminalStderr => void (terminalStderrInstance = terminalStderr);
+
 let _env = Object.entries(env),
   _args = argv.slice(1),
   _cwd = cwd();
@@ -29,9 +39,9 @@ export const exit = {
   },
 };
 
-const stdinStream = inputStreamCreate(STDIN, 1);
-const stdoutStream = outputStreamCreate(STDOUT, 2);
-const stderrStream = outputStreamCreate(STDERR, 3);
+let stdinStream = inputStreamCreate(STDIN, 1);
+let stdoutStream = outputStreamCreate(STDOUT, 2);
+let stderrStream = outputStreamCreate(STDERR, 3);
 
 export const stdin = {
   InputStream,
@@ -57,18 +67,16 @@ export const stderr = {
 class TerminalInput {}
 class TerminalOutput {}
 
-const terminalStdoutInstance = new TerminalOutput();
-const terminalStderrInstance = new TerminalOutput();
-const terminalStdinInstance = new TerminalInput();
+let terminalStdoutInstance = new TerminalOutput();
+let terminalStderrInstance = new TerminalOutput();
+let terminalStdinInstance = new TerminalInput();
 
 export const terminalInput = {
   TerminalInput,
-  dropTerminalInput() {},
 };
 
 export const terminalOutput = {
   TerminalOutput,
-  dropTerminalOutput() {},
 };
 
 export const terminalStderr = {

--- a/packages/preview2-shim/lib/nodejs/http.js
+++ b/packages/preview2-shim/lib/nodejs/http.js
@@ -1,9 +1,9 @@
 import {
-  INPUT_STREAM_DROP,
+  INPUT_STREAM_DISPOSE,
   HTTP_CREATE_REQUEST,
   OUTPUT_STREAM_CREATE,
-  FUTURE_DROP_AND_GET_VALUE,
-  FUTURE_DROP,
+  FUTURE_DISPOSE_AND_GET_VALUE,
+  FUTURE_DISPOSE,
 } from "../io/calls.js";
 import {
   ioCall,
@@ -48,7 +48,7 @@ export class WasiHttp {
         return futureTrailersCreate(new Fields([]), false);
       }
       [symbolDispose]() {
-        if (!this.#finished) ioCall(INPUT_STREAM_DROP, this.#streamId);
+        if (!this.#finished) ioCall(INPUT_STREAM_DISPOSE, this.#streamId);
       }
       static _create(streamId) {
         const incomingBody = new IncomingBody();
@@ -204,7 +204,7 @@ export class WasiHttp {
         return incomingBodyCreate(bodyStreamId);
       }
       [symbolDispose]() {
-        if (this.#bodyStreamId) ioCall(INPUT_STREAM_DROP, this.#bodyStreamId);
+        if (this.#bodyStreamId) ioCall(INPUT_STREAM_DISPOSE, this.#bodyStreamId);
       }
       static _create(status, headers, bodyStreamId) {
         const res = new IncomingResponse();
@@ -229,7 +229,7 @@ export class WasiHttp {
       get() {
         // already taken
         if (!this.#pollId) return { tag: "err" };
-        const ret = ioCall(FUTURE_DROP_AND_GET_VALUE, this.#pollId);
+        const ret = ioCall(FUTURE_DISPOSE_AND_GET_VALUE, this.#pollId);
         if (!ret) return;
         this.#pollId = undefined;
         if (ret.error)
@@ -251,7 +251,7 @@ export class WasiHttp {
         };
       }
       [symbolDispose]() {
-        if (this.#pollId) ioCall(FUTURE_DROP, this.#pollId);
+        if (this.#pollId) ioCall(FUTURE_DISPOSE, this.#pollId);
       }
       static _create(method, url, headers, body) {
         const res = new FutureIncomingResponse();

--- a/src/jco.js
+++ b/src/jco.js
@@ -53,7 +53,10 @@ program.command('transpile')
 program.command('run')
   .description('Run a WebAssembly Command component')
   .usage('<command.wasm> <args...>')
+  .helpOption(false)
   .argument('<command>', 'Wasm command binary to run')
+  .option('--jco-debug', 'Enable call tracing debug output and retain output for debugging')
+  .option('--jco-import <module>', 'Custom module to import before the run executes to support custom environment setup')
   .argument('[args...]', 'Any CLI arguments to provide to the command')
   .action(asyncAction(run));
 

--- a/tests/generated/api_proxy.rs
+++ b/tests/generated/api_proxy.rs
@@ -10,6 +10,7 @@ fn api_proxy() -> anyhow::Result<()> {
     let file_name = "api_proxy";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/api_proxy_streaming.rs
+++ b/tests/generated/api_proxy_streaming.rs
@@ -10,6 +10,7 @@ fn api_proxy_streaming() -> anyhow::Result<()> {
     let file_name = "api_proxy_streaming";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/api_reactor.rs
+++ b/tests/generated/api_reactor.rs
@@ -10,6 +10,7 @@ fn api_reactor() -> anyhow::Result<()> {
     let file_name = "api_reactor";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/api_read_only.rs
+++ b/tests/generated/api_read_only.rs
@@ -10,6 +10,7 @@ fn api_read_only() -> anyhow::Result<()> {
     let file_name = "api_read_only";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/api_time.rs
+++ b/tests/generated/api_time.rs
@@ -10,6 +10,7 @@ fn api_time() -> anyhow::Result<()> {
     let file_name = "api_time";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/fakeclocks.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_args.rs
+++ b/tests/generated/cli_args.rs
@@ -10,6 +10,7 @@ fn cli_args() -> anyhow::Result<()> {
     let file_name = "cli_args";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_default_clocks.rs
+++ b/tests/generated/cli_default_clocks.rs
@@ -10,6 +10,7 @@ fn cli_default_clocks() -> anyhow::Result<()> {
     let file_name = "cli_default_clocks";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_directory_list.rs
+++ b/tests/generated/cli_directory_list.rs
@@ -10,6 +10,7 @@ fn cli_directory_list() -> anyhow::Result<()> {
     let file_name = "cli_directory_list";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_env.rs
+++ b/tests/generated/cli_env.rs
@@ -10,6 +10,7 @@ fn cli_env() -> anyhow::Result<()> {
     let file_name = "cli_env";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_exit_default.rs
+++ b/tests/generated/cli_exit_default.rs
@@ -10,6 +10,7 @@ fn cli_exit_default() -> anyhow::Result<()> {
     let file_name = "cli_exit_default";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_exit_failure.rs
+++ b/tests/generated/cli_exit_failure.rs
@@ -10,6 +10,7 @@ fn cli_exit_failure() -> anyhow::Result<()> {
     let file_name = "cli_exit_failure";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run().expect_err("test should exit with code 1");
     Ok(())
 }

--- a/tests/generated/cli_exit_panic.rs
+++ b/tests/generated/cli_exit_panic.rs
@@ -10,6 +10,7 @@ fn cli_exit_panic() -> anyhow::Result<()> {
     let file_name = "cli_exit_panic";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run().expect_err("test should exit with code 1");
     Ok(())
 }

--- a/tests/generated/cli_exit_success.rs
+++ b/tests/generated/cli_exit_success.rs
@@ -10,6 +10,7 @@ fn cli_exit_success() -> anyhow::Result<()> {
     let file_name = "cli_exit_success";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_export_cabi_realloc.rs
+++ b/tests/generated/cli_export_cabi_realloc.rs
@@ -10,6 +10,7 @@ fn cli_export_cabi_realloc() -> anyhow::Result<()> {
     let file_name = "cli_export_cabi_realloc";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_file_append.rs
+++ b/tests/generated/cli_file_append.rs
@@ -10,6 +10,7 @@ fn cli_file_append() -> anyhow::Result<()> {
     let file_name = "cli_file_append";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_file_dir_sync.rs
+++ b/tests/generated/cli_file_dir_sync.rs
@@ -10,6 +10,7 @@ fn cli_file_dir_sync() -> anyhow::Result<()> {
     let file_name = "cli_file_dir_sync";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_file_read.rs
+++ b/tests/generated/cli_file_read.rs
@@ -10,6 +10,7 @@ fn cli_file_read() -> anyhow::Result<()> {
     let file_name = "cli_file_read";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_hello_stdout.rs
+++ b/tests/generated/cli_hello_stdout.rs
@@ -10,6 +10,7 @@ fn cli_hello_stdout() -> anyhow::Result<()> {
     let file_name = "cli_hello_stdout";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_splice_stdin.rs
+++ b/tests/generated/cli_splice_stdin.rs
@@ -10,6 +10,7 @@ fn cli_splice_stdin() -> anyhow::Result<()> {
     let file_name = "cli_splice_stdin";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_stdin.rs
+++ b/tests/generated/cli_stdin.rs
@@ -10,6 +10,7 @@ fn cli_stdin() -> anyhow::Result<()> {
     let file_name = "cli_stdin";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/cli_stdio_write_flushes.rs
+++ b/tests/generated/cli_stdio_write_flushes.rs
@@ -10,6 +10,7 @@ fn cli_stdio_write_flushes() -> anyhow::Result<()> {
     let file_name = "cli_stdio_write_flushes";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_content_length.rs
+++ b/tests/generated/http_outbound_request_content_length.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_content_length() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_content_length";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_get.rs
+++ b/tests/generated/http_outbound_request_get.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_get() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_get";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_invalid_dnsname.rs
+++ b/tests/generated/http_outbound_request_invalid_dnsname.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_invalid_dnsname() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_invalid_dnsname";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_invalid_header.rs
+++ b/tests/generated/http_outbound_request_invalid_header.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_invalid_header() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_invalid_header";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_invalid_port.rs
+++ b/tests/generated/http_outbound_request_invalid_port.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_invalid_port() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_invalid_port";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_invalid_version.rs
+++ b/tests/generated/http_outbound_request_invalid_version.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_invalid_version() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_invalid_version";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_large_post.rs
+++ b/tests/generated/http_outbound_request_large_post.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_large_post() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_large_post";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_post.rs
+++ b/tests/generated/http_outbound_request_post.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_post() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_post";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_put.rs
+++ b/tests/generated/http_outbound_request_put.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_put() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_put";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_response_build.rs
+++ b/tests/generated/http_outbound_request_response_build.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_response_build() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_response_build";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_unknown_method.rs
+++ b/tests/generated/http_outbound_request_unknown_method.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_unknown_method() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_unknown_method";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/http_outbound_request_unsupported_scheme.rs
+++ b/tests/generated/http_outbound_request_unsupported_scheme.rs
@@ -10,6 +10,7 @@ fn http_outbound_request_unsupported_scheme() -> anyhow::Result<()> {
     let file_name = "http_outbound_request_unsupported_scheme";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_big_random_buf.rs
+++ b/tests/generated/preview1_big_random_buf.rs
@@ -10,6 +10,7 @@ fn preview1_big_random_buf() -> anyhow::Result<()> {
     let file_name = "preview1_big_random_buf";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_clock_time_get.rs
+++ b/tests/generated/preview1_clock_time_get.rs
@@ -10,6 +10,7 @@ fn preview1_clock_time_get() -> anyhow::Result<()> {
     let file_name = "preview1_clock_time_get";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_close_preopen.rs
+++ b/tests/generated/preview1_close_preopen.rs
@@ -10,6 +10,7 @@ fn preview1_close_preopen() -> anyhow::Result<()> {
     let file_name = "preview1_close_preopen";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_dangling_fd.rs
+++ b/tests/generated/preview1_dangling_fd.rs
@@ -10,6 +10,7 @@ fn preview1_dangling_fd() -> anyhow::Result<()> {
     let file_name = "preview1_dangling_fd";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_dangling_symlink.rs
+++ b/tests/generated/preview1_dangling_symlink.rs
@@ -10,6 +10,7 @@ fn preview1_dangling_symlink() -> anyhow::Result<()> {
     let file_name = "preview1_dangling_symlink";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_dir_fd_op_failures.rs
+++ b/tests/generated/preview1_dir_fd_op_failures.rs
@@ -10,6 +10,7 @@ fn preview1_dir_fd_op_failures() -> anyhow::Result<()> {
     let file_name = "preview1_dir_fd_op_failures";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_directory_seek.rs
+++ b/tests/generated/preview1_directory_seek.rs
@@ -10,6 +10,7 @@ fn preview1_directory_seek() -> anyhow::Result<()> {
     let file_name = "preview1_directory_seek";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_fd_advise.rs
+++ b/tests/generated/preview1_fd_advise.rs
@@ -10,6 +10,7 @@ fn preview1_fd_advise() -> anyhow::Result<()> {
     let file_name = "preview1_fd_advise";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_fd_filestat_get.rs
+++ b/tests/generated/preview1_fd_filestat_get.rs
@@ -10,6 +10,7 @@ fn preview1_fd_filestat_get() -> anyhow::Result<()> {
     let file_name = "preview1_fd_filestat_get";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_fd_filestat_set.rs
+++ b/tests/generated/preview1_fd_filestat_set.rs
@@ -10,6 +10,7 @@ fn preview1_fd_filestat_set() -> anyhow::Result<()> {
     let file_name = "preview1_fd_filestat_set";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_fd_flags_set.rs
+++ b/tests/generated/preview1_fd_flags_set.rs
@@ -10,6 +10,7 @@ fn preview1_fd_flags_set() -> anyhow::Result<()> {
     let file_name = "preview1_fd_flags_set";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_fd_readdir.rs
+++ b/tests/generated/preview1_fd_readdir.rs
@@ -10,6 +10,7 @@ fn preview1_fd_readdir() -> anyhow::Result<()> {
     let file_name = "preview1_fd_readdir";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_file_allocate.rs
+++ b/tests/generated/preview1_file_allocate.rs
@@ -10,6 +10,7 @@ fn preview1_file_allocate() -> anyhow::Result<()> {
     let file_name = "preview1_file_allocate";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_file_pread_pwrite.rs
+++ b/tests/generated/preview1_file_pread_pwrite.rs
@@ -10,6 +10,7 @@ fn preview1_file_pread_pwrite() -> anyhow::Result<()> {
     let file_name = "preview1_file_pread_pwrite";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_file_seek_tell.rs
+++ b/tests/generated/preview1_file_seek_tell.rs
@@ -10,6 +10,7 @@ fn preview1_file_seek_tell() -> anyhow::Result<()> {
     let file_name = "preview1_file_seek_tell";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_file_truncation.rs
+++ b/tests/generated/preview1_file_truncation.rs
@@ -10,6 +10,7 @@ fn preview1_file_truncation() -> anyhow::Result<()> {
     let file_name = "preview1_file_truncation";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_file_unbuffered_write.rs
+++ b/tests/generated/preview1_file_unbuffered_write.rs
@@ -10,6 +10,7 @@ fn preview1_file_unbuffered_write() -> anyhow::Result<()> {
     let file_name = "preview1_file_unbuffered_write";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_file_write.rs
+++ b/tests/generated/preview1_file_write.rs
@@ -10,6 +10,7 @@ fn preview1_file_write() -> anyhow::Result<()> {
     let file_name = "preview1_file_write";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_interesting_paths.rs
+++ b/tests/generated/preview1_interesting_paths.rs
@@ -10,6 +10,7 @@ fn preview1_interesting_paths() -> anyhow::Result<()> {
     let file_name = "preview1_interesting_paths";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_nofollow_errors.rs
+++ b/tests/generated/preview1_nofollow_errors.rs
@@ -10,6 +10,7 @@ fn preview1_nofollow_errors() -> anyhow::Result<()> {
     let file_name = "preview1_nofollow_errors";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_overwrite_preopen.rs
+++ b/tests/generated/preview1_overwrite_preopen.rs
@@ -10,6 +10,7 @@ fn preview1_overwrite_preopen() -> anyhow::Result<()> {
     let file_name = "preview1_overwrite_preopen";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_exists.rs
+++ b/tests/generated/preview1_path_exists.rs
@@ -10,6 +10,7 @@ fn preview1_path_exists() -> anyhow::Result<()> {
     let file_name = "preview1_path_exists";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_filestat.rs
+++ b/tests/generated/preview1_path_filestat.rs
@@ -10,6 +10,7 @@ fn preview1_path_filestat() -> anyhow::Result<()> {
     let file_name = "preview1_path_filestat";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_link.rs
+++ b/tests/generated/preview1_path_link.rs
@@ -10,6 +10,7 @@ fn preview1_path_link() -> anyhow::Result<()> {
     let file_name = "preview1_path_link";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_open_create_existing.rs
+++ b/tests/generated/preview1_path_open_create_existing.rs
@@ -10,6 +10,7 @@ fn preview1_path_open_create_existing() -> anyhow::Result<()> {
     let file_name = "preview1_path_open_create_existing";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_open_dirfd_not_dir.rs
+++ b/tests/generated/preview1_path_open_dirfd_not_dir.rs
@@ -10,6 +10,7 @@ fn preview1_path_open_dirfd_not_dir() -> anyhow::Result<()> {
     let file_name = "preview1_path_open_dirfd_not_dir";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_open_missing.rs
+++ b/tests/generated/preview1_path_open_missing.rs
@@ -10,6 +10,7 @@ fn preview1_path_open_missing() -> anyhow::Result<()> {
     let file_name = "preview1_path_open_missing";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_open_nonblock.rs
+++ b/tests/generated/preview1_path_open_nonblock.rs
@@ -10,6 +10,7 @@ fn preview1_path_open_nonblock() -> anyhow::Result<()> {
     let file_name = "preview1_path_open_nonblock";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_open_preopen.rs
+++ b/tests/generated/preview1_path_open_preopen.rs
@@ -10,6 +10,7 @@ fn preview1_path_open_preopen() -> anyhow::Result<()> {
     let file_name = "preview1_path_open_preopen";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_open_read_write.rs
+++ b/tests/generated/preview1_path_open_read_write.rs
@@ -10,6 +10,7 @@ fn preview1_path_open_read_write() -> anyhow::Result<()> {
     let file_name = "preview1_path_open_read_write";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_rename.rs
+++ b/tests/generated/preview1_path_rename.rs
@@ -10,6 +10,7 @@ fn preview1_path_rename() -> anyhow::Result<()> {
     let file_name = "preview1_path_rename";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_rename_dir_trailing_slashes.rs
+++ b/tests/generated/preview1_path_rename_dir_trailing_slashes.rs
@@ -10,6 +10,7 @@ fn preview1_path_rename_dir_trailing_slashes() -> anyhow::Result<()> {
     let file_name = "preview1_path_rename_dir_trailing_slashes";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_rename_file_trailing_slashes.rs
+++ b/tests/generated/preview1_path_rename_file_trailing_slashes.rs
@@ -10,6 +10,7 @@ fn preview1_path_rename_file_trailing_slashes() -> anyhow::Result<()> {
     let file_name = "preview1_path_rename_file_trailing_slashes";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_path_symlink_trailing_slashes.rs
+++ b/tests/generated/preview1_path_symlink_trailing_slashes.rs
@@ -10,6 +10,7 @@ fn preview1_path_symlink_trailing_slashes() -> anyhow::Result<()> {
     let file_name = "preview1_path_symlink_trailing_slashes";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_poll_oneoff_files.rs
+++ b/tests/generated/preview1_poll_oneoff_files.rs
@@ -10,6 +10,7 @@ fn preview1_poll_oneoff_files() -> anyhow::Result<()> {
     let file_name = "preview1_poll_oneoff_files";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_poll_oneoff_stdio.rs
+++ b/tests/generated/preview1_poll_oneoff_stdio.rs
@@ -10,6 +10,7 @@ fn preview1_poll_oneoff_stdio() -> anyhow::Result<()> {
     let file_name = "preview1_poll_oneoff_stdio";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_readlink.rs
+++ b/tests/generated/preview1_readlink.rs
@@ -10,6 +10,7 @@ fn preview1_readlink() -> anyhow::Result<()> {
     let file_name = "preview1_readlink";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_regular_file_isatty.rs
+++ b/tests/generated/preview1_regular_file_isatty.rs
@@ -10,6 +10,7 @@ fn preview1_regular_file_isatty() -> anyhow::Result<()> {
     let file_name = "preview1_regular_file_isatty";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_remove_directory_trailing_slashes.rs
+++ b/tests/generated/preview1_remove_directory_trailing_slashes.rs
@@ -10,6 +10,7 @@ fn preview1_remove_directory_trailing_slashes() -> anyhow::Result<()> {
     let file_name = "preview1_remove_directory_trailing_slashes";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_remove_nonempty_directory.rs
+++ b/tests/generated/preview1_remove_nonempty_directory.rs
@@ -10,6 +10,7 @@ fn preview1_remove_nonempty_directory() -> anyhow::Result<()> {
     let file_name = "preview1_remove_nonempty_directory";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_renumber.rs
+++ b/tests/generated/preview1_renumber.rs
@@ -10,6 +10,7 @@ fn preview1_renumber() -> anyhow::Result<()> {
     let file_name = "preview1_renumber";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_sched_yield.rs
+++ b/tests/generated/preview1_sched_yield.rs
@@ -10,6 +10,7 @@ fn preview1_sched_yield() -> anyhow::Result<()> {
     let file_name = "preview1_sched_yield";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_stdio.rs
+++ b/tests/generated/preview1_stdio.rs
@@ -10,6 +10,7 @@ fn preview1_stdio() -> anyhow::Result<()> {
     let file_name = "preview1_stdio";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_stdio_isatty.rs
+++ b/tests/generated/preview1_stdio_isatty.rs
@@ -10,6 +10,7 @@ fn preview1_stdio_isatty() -> anyhow::Result<()> {
     let file_name = "preview1_stdio_isatty";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_stdio_not_isatty.rs
+++ b/tests/generated/preview1_stdio_not_isatty.rs
@@ -10,6 +10,7 @@ fn preview1_stdio_not_isatty() -> anyhow::Result<()> {
     let file_name = "preview1_stdio_not_isatty";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/notty.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_symlink_create.rs
+++ b/tests/generated/preview1_symlink_create.rs
@@ -10,6 +10,7 @@ fn preview1_symlink_create() -> anyhow::Result<()> {
     let file_name = "preview1_symlink_create";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_symlink_filestat.rs
+++ b/tests/generated/preview1_symlink_filestat.rs
@@ -10,6 +10,7 @@ fn preview1_symlink_filestat() -> anyhow::Result<()> {
     let file_name = "preview1_symlink_filestat";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_symlink_loop.rs
+++ b/tests/generated/preview1_symlink_loop.rs
@@ -10,6 +10,7 @@ fn preview1_symlink_loop() -> anyhow::Result<()> {
     let file_name = "preview1_symlink_loop";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_unicode_output.rs
+++ b/tests/generated/preview1_unicode_output.rs
@@ -10,6 +10,7 @@ fn preview1_unicode_output() -> anyhow::Result<()> {
     let file_name = "preview1_unicode_output";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview1_unlink_file_trailing_slashes.rs
+++ b/tests/generated/preview1_unlink_file_trailing_slashes.rs
@@ -10,6 +10,7 @@ fn preview1_unlink_file_trailing_slashes() -> anyhow::Result<()> {
     let file_name = "preview1_unlink_file_trailing_slashes";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_ip_name_lookup.rs
+++ b/tests/generated/preview2_ip_name_lookup.rs
@@ -10,6 +10,7 @@ fn preview2_ip_name_lookup() -> anyhow::Result<()> {
     let file_name = "preview2_ip_name_lookup";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_random.rs
+++ b/tests/generated/preview2_random.rs
@@ -10,6 +10,7 @@ fn preview2_random() -> anyhow::Result<()> {
     let file_name = "preview2_random";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_sleep.rs
+++ b/tests/generated/preview2_sleep.rs
@@ -10,6 +10,7 @@ fn preview2_sleep() -> anyhow::Result<()> {
     let file_name = "preview2_sleep";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_stream_pollable_correct.rs
+++ b/tests/generated/preview2_stream_pollable_correct.rs
@@ -10,6 +10,7 @@ fn preview2_stream_pollable_correct() -> anyhow::Result<()> {
     let file_name = "preview2_stream_pollable_correct";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_stream_pollable_traps.rs
+++ b/tests/generated/preview2_stream_pollable_traps.rs
@@ -10,6 +10,7 @@ fn preview2_stream_pollable_traps() -> anyhow::Result<()> {
     let file_name = "preview2_stream_pollable_traps";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run().expect_err("test should exit with code 1");
     Ok(())
 }

--- a/tests/generated/preview2_tcp_bind.rs
+++ b/tests/generated/preview2_tcp_bind.rs
@@ -10,6 +10,7 @@ fn preview2_tcp_bind() -> anyhow::Result<()> {
     let file_name = "preview2_tcp_bind";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_tcp_connect.rs
+++ b/tests/generated/preview2_tcp_connect.rs
@@ -10,6 +10,7 @@ fn preview2_tcp_connect() -> anyhow::Result<()> {
     let file_name = "preview2_tcp_connect";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_tcp_sample_application.rs
+++ b/tests/generated/preview2_tcp_sample_application.rs
@@ -10,6 +10,7 @@ fn preview2_tcp_sample_application() -> anyhow::Result<()> {
     let file_name = "preview2_tcp_sample_application";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_tcp_sockopts.rs
+++ b/tests/generated/preview2_tcp_sockopts.rs
@@ -10,6 +10,7 @@ fn preview2_tcp_sockopts() -> anyhow::Result<()> {
     let file_name = "preview2_tcp_sockopts";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_tcp_states.rs
+++ b/tests/generated/preview2_tcp_states.rs
@@ -10,6 +10,7 @@ fn preview2_tcp_states() -> anyhow::Result<()> {
     let file_name = "preview2_tcp_states";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_udp_bind.rs
+++ b/tests/generated/preview2_udp_bind.rs
@@ -10,6 +10,7 @@ fn preview2_udp_bind() -> anyhow::Result<()> {
     let file_name = "preview2_udp_bind";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_udp_connect.rs
+++ b/tests/generated/preview2_udp_connect.rs
@@ -10,6 +10,7 @@ fn preview2_udp_connect() -> anyhow::Result<()> {
     let file_name = "preview2_udp_connect";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_udp_sample_application.rs
+++ b/tests/generated/preview2_udp_sample_application.rs
@@ -10,6 +10,7 @@ fn preview2_udp_sample_application() -> anyhow::Result<()> {
     let file_name = "preview2_udp_sample_application";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_udp_sockopts.rs
+++ b/tests/generated/preview2_udp_sockopts.rs
@@ -10,6 +10,7 @@ fn preview2_udp_sockopts() -> anyhow::Result<()> {
     let file_name = "preview2_udp_sockopts";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/generated/preview2_udp_states.rs
+++ b/tests/generated/preview2_udp_states.rs
@@ -10,6 +10,7 @@ fn preview2_udp_states() -> anyhow::Result<()> {
     let file_name = "preview2_udp_states";
     let tempdir = TempDir::new("{file_name}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {wasi_file}").run()?;
+    cmd!(sh, "./src/jco.js run  --jco-import ./tests/virtualenvs/base.js {wasi_file} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run()?;
     Ok(())
 }

--- a/tests/virtualenvs/base.js
+++ b/tests/virtualenvs/base.js
@@ -1,0 +1,6 @@
+import { _setEnv } from "@bytecodealliance/preview2-shim/cli";
+
+_setEnv({
+  callooh: "callay",
+  frabjous: "day",
+});

--- a/tests/virtualenvs/fakeclocks.js
+++ b/tests/virtualenvs/fakeclocks.js
@@ -1,0 +1,17 @@
+import "./base.js";
+import {
+  monotonicClock,
+  wallClock,
+} from "@bytecodealliance/preview2-shim/clocks";
+
+let now = 0n;
+
+monotonicClock.resolution = () => 1_000_000_000n;
+monotonicClock.now = () => {
+  const then = now;
+  now += 42n * 1_000_000_000n;
+  return now;
+};
+
+wallClock.resolution = () => 1_000_000_000n;
+wallClock.now = () => ({ seconds: 1431648000n, nanoseconds: 100 });

--- a/tests/virtualenvs/notty.js
+++ b/tests/virtualenvs/notty.js
@@ -1,0 +1,11 @@
+import {
+  _setEnv,
+  _setTerminalStdin,
+  _setTerminalStdout,
+  _setTerminalStderr,
+} from "@bytecodealliance/preview2-shim/cli";
+import './base.js';
+
+_setTerminalStderr();
+_setTerminalStdin();
+_setTerminalStdout();

--- a/xtask/src/generate/tests.rs
+++ b/xtask/src/generate/tests.rs
@@ -1,6 +1,8 @@
 use std::fs;
 use xshell::{cmd, Shell};
 
+const DEBUG: bool = false;
+
 pub fn run() -> anyhow::Result<()> {
     let sh = Shell::new()?;
 
@@ -47,6 +49,15 @@ pub fn run() -> anyhow::Result<()> {
 
 /// Generate an individual test
 fn generate_test(test_name: &str) -> String {
+    let virtual_env = match test_name {
+        "api_time" => "fakeclocks",
+        "preview1_stdio_not_isatty" => "notty",
+        _ => "base",
+    };
+    let should_error = match test_name {
+        "cli_exit_failure" | "cli_exit_panic" | "preview2_stream_pollable_traps" => true,
+        _ => false,
+    };
     format!(
         r##"//! This file has been auto-generated, please do not modify manually
 //! To regenerate this file re-run `cargo xtask generate tests` from the project root
@@ -60,10 +71,17 @@ fn {test_name}() -> anyhow::Result<()> {{
     let file_name = "{test_name}";
     let tempdir = TempDir::new("{{file_name}}")?;
     let wasi_file = test_utils::compile(&sh, &tempdir, &file_name)?;
-    cmd!(sh, "./src/jco.js run {{wasi_file}}").run()?;
+    cmd!(sh, "./src/jco.js run {} --jco-import ./tests/virtualenvs/{virtual_env}.js {{wasi_file}} hello this '' 'is an argument' 'with 🚩 emoji'")
+        .run(){};
     Ok(())
 }}
-"##
+"##,
+        if DEBUG { "--jco-debug" } else { "" },
+        if !should_error {
+            "?"
+        } else {
+            ".expect_err(\"test should exit with code 1\")"
+        }
     )
 }
 


### PR DESCRIPTION
This adds 8 new passing tests (I've already crossed them off in the corresponding issues).

* Resolves https://github.com/bytecodealliance/jco/issues/201.
* Resolves most of the CLI tests, with just the `stdin` tests remaining to do which I'll post as a follow-up PR.
* Adds a custom `--jco-import` option to `jco run` to allow for custom environment virtualization which should work as a pattern to be able to ensure the right environment for testing.
* Adds a new `--jco-debug` option to `jco run` which doesn't delete the temporary files (so they can be debugged) and also outputs the trace calls.
* Resolves a resources bug I hit on one of the cases, where the resource table wasn't being initialized.
* Updates the utf8 encoder to avoid reallocations, since these are unsupported in the test binaries.

_Going to start adding this to my PRs:_ **Progress: 27/98 tests**