### PR TITLE
doc: Fix API documentation of `transpileComponent`

### DIFF
--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -68,13 +68,13 @@ async function wasm2Js (source) {
  *   map?: Record<string, string>,
  *   validLiftingOptimization?: bool,
  *   tracing?: bool,
- *   noNodejsCompat?: bool,
+ *   nodejsCompat?: bool,
  *   tlaCompat?: bool,
  *   base64Cutoff?: bool,
  *   js?: bool,
  *   minify?: bool,
  *   optimize?: bool,
- *   noNamespacedExports?: bool,
+ *   namespacedExports?: bool,
  *   optArgs?: string[],
  * }} opts 
  * @returns {Promise<{ files: { [filename: string]: Uint8Array }, imports: string[], exports: [string, 'function' | 'instance'][] }>}


### PR DESCRIPTION
The API documentation of `transpileComponent` was incorrect, leading to false-negative warnings in the code when an appropriated IDE is used.

This patch corrects the API documentation.