### PR TITLE
fix: Remove a useless `if` to `setShowSpinner(true)`

### DIFF
--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -86,7 +86,7 @@ export async function transpileComponent (component, opts = {}) {
   let spinner;
   const showSpinner = getShowSpinner();
   if (opts.optimize) {
-    if (showSpinner) setShowSpinner(true);
+    setShowSpinner(true);
     ({ component } = await optimizeComponent(component, opts));
   }
 


### PR DESCRIPTION
The code says: if the spinner must be shown, then let's set the spinner to be shown. This is redundant.

This patch removes the `if (showSpinner)` to keep only the `setShowSpinner(true)`, as it will have the same behaviour. Even if the intend was to call `setShowSpinner` when `showSpinner` was `false`, it wasn't working before but will work now.