### PR TITLE
fix(tests): fix eacces in WSL when creating virtualenvs

### DIFF
--- a/tests/virtualenvs/base.js
+++ b/tests/virtualenvs/base.js
@@ -2,10 +2,10 @@ import { _setEnv } from "@bytecodealliance/preview2-shim/cli";
 import { _setPreopens } from "@bytecodealliance/preview2-shim/filesystem";
 import { mkdtemp, writeFile, mkdir } from 'node:fs/promises';
 import { rmdirSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { resolve, sep } from 'node:path';
 import { tmpdir } from 'node:os';
 
-export const testDir = await mkdtemp(tmpdir());
+export const testDir = await mkdtemp(tmpdir() + sep);
 
 _setPreopens({ "/": testDir });
 


### PR DESCRIPTION
There was a missing OS separator `sep` in this line that failing with an `EACCESS` error when running tests on WSL:
 https://github.com/bytecodealliance/jco/blob/df1f3005cfcb3ea9fb7c89b8e756c18c53b65abc/tests/virtualenvs/base.js#L8

![image](https://github.com/bytecodealliance/jco/assets/1699357/007e5ccf-cd53-4376-84cc-3e65fd7ac285)
