### PR TITLE
Use `--js` with `--instantiation`

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics.rs
+++ b/crates/js-component-bindgen/src/intrinsics.rs
@@ -171,18 +171,10 @@ pub fn render_intrinsics(
                 const i64ToF64 = i => (i64ToF64I[0] = i, i64ToF64F[0]);
             "),
 
-            Intrinsic::InstantiateCore => match instantiation {
-                Some(InstantiationMode::Async) | None =>  {
-                    output.push_str("
-                        const instantiateCore = WebAssembly.instantiate;
-                    ")
-                }
-
-                Some(InstantiationMode::Sync) =>  {
-                    output.push_str("
-                        const instantiateCore = WebAssembly.Instance;
-                    ")
-                }
+            Intrinsic::InstantiateCore => if instantiation.is_none() {
+                output.push_str("
+                    const instantiateCore = WebAssembly.instantiate;
+                ")
             },
 
             Intrinsic::IsLE => output.push_str("

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -180,7 +180,7 @@ export async function transpileComponent (component, opts = {}) {
 
       const outSource = `${
         imports.map((impt, i) => `import * as import${i} from '${impt}';`).join('\n')}
-${source.replace('export async function instantiate', 'async function instantiate')}
+${source.replace(/export (async )?function instantiate/, '$1function instantiate')}
 
 let ${exports.filter(([, ty]) => ty === 'function').map(([name]) => '_' + name).join(', ')};
 

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -106,9 +106,12 @@ export async function transpileComponent (component, opts = {}) {
 
   let instantiation = null;
 
+  // Let's define `instantiation` from `--instantiation` if it's present.
   if (opts.instantiation) {
     instantiation = { tag: opts.instantiation };
-  } else if (opts.js) {
+  }
+  // Otherwise, if `--js` is present, an `instantiate` function is required.
+  else if (opts.js) {
     instantiation = { tag: 'async' };
   }
 

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -178,9 +178,7 @@ export async function transpileComponent (component, opts = {}) {
         .trim()
       }`).join(',\n');
 
-      const outSource = `${
-        imports.map((impt, i) => `import * as import${i} from '${impt}';`).join('\n')}
-${source.replace(/export (async )?function instantiate/, '$1function instantiate')}
+      const outSource = `${source.replace(/export (async )?function instantiate/, '$1function instantiate')}
 
 let ${exports.filter(([, ty]) => ty === 'function').map(([name]) => '_' + name).join(', ')};
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -86,7 +86,7 @@ export async function cliTest (fixtures) {
       ok(source.includes('./wasi.js'));
       ok(source.includes('testwasi'));
       ok(source.includes('FUNCTION_TABLE'));
-      ok(source.includes('export const $init'));
+      ok(source.includes('export {\n  $init'));
     });
 
     test('Transpile without namespaced exports', async () => {

--- a/test/runtime/strings.async+js.ts
+++ b/test/runtime/strings.async+js.ts
@@ -1,13 +1,13 @@
-// Flags: --instantiation sync --js
+// Flags: --instantiation --js
 
 import * as helpers from './helpers.js';
-import { instantiate } from '../output/strings.sync+js/strings.sync+js.js';
+import { instantiate } from '../output/strings.async+js/strings.async+js.js';
 
 // @ts-ignore
 import * as assert from 'assert';
 
-function run() {
-  const wasm = instantiate(helpers.loadWasmSync, {
+async function run() {
+  const wasm = await instantiate(helpers.loadWasm, {
     testwasi: helpers,
     'test:strings/imports': {
       takeBasic(s: string) {
@@ -24,4 +24,4 @@ function run() {
   assert.strictEqual(wasm.roundtrip('🚀🚀🚀 𠈄𓀀'), '🚀🚀🚀 𠈄𓀀');
 }
 
-run()
+await run()

--- a/test/runtime/strings.sync+js.ts
+++ b/test/runtime/strings.sync+js.ts
@@ -1,0 +1,27 @@
+// Flags: --js --instantiation sync
+
+import * as helpers from './helpers.js';
+import { instantiate } from '../output/strings.sync+js/strings.sync+js.js';
+
+// @ts-ignore
+import * as assert from 'assert';
+
+function run() {
+  const wasm = instantiate(helpers.loadWasmSync, {
+    testwasi: helpers,
+    'test:strings/imports': {
+      takeBasic(s: string) {
+        assert.strictEqual(s, 'latin utf16');
+      },
+      returnUnicode() {
+        return '🚀🚀🚀 𠈄𓀀';
+      }
+    }
+  });
+
+  wasm.testImports();
+  assert.strictEqual(wasm.roundtrip('str'), 'str');
+  assert.strictEqual(wasm.roundtrip('🚀🚀🚀 𠈄𓀀'), '🚀🚀🚀 𠈄𓀀');
+}
+
+run()


### PR DESCRIPTION
This patch aims at supporting `--js` with `--instantiation`.

`--js` needs an `instantiate` function to work, so it might look like
`--instantiation` is always implied, but actually no. It is correct
that when `--js` is present, an `instantiate` function _is_ generated,
but it doesn't mean that we expect the function to be used, it's simply
not exported, plus `instantiate` is automatically called (if `--tla-compat`
is `false`). When `--instantiation` is missing, functions are exported
with the `export` directive, and imports are imported with the `import`
directive. When `--instantiation` is present, there is no `export` and no
`import`: only a single exported `instantiate` function.

Basically, we get this:

* `--js` only:
  * `instantiate` is renamed to `_instantiate`,
  * A new `instantiate` function is created, that calls `_instantiate` with
    the correct imports (which are ASM.js code) and returns the exports,
  * A new `$init` function is created, that calls `instantiate` and maps
    the returned exports to their respective trampolines,
  * Trampolines are exported,
  * `$init` is called automatically.
  * ```js
    import * as import0 from '../flavorful.js';
    import * as import1 from '../helpers.js';

    // …

    // The “old” `instantiate` function.
    async function _instantiate() { … }

    // The “export trampolines”.
    let _testImports;

    function testImports() {
      return _testImports.apply(this, arguments);
    }

    // The new `instantiate` function (not exported).
    async function instantiate(imports) {
      const wasm_file_to_asm_index = {
        'flavorful.core.wasm': 0,
        'flavorful.core2.wasm': 1,
        'flavorful.core3.wasm': 2,
        'flavorful.core4.wasm': 3
      };

      return await _instantiate(
          module_name => wasm_file_to_asm_index[module_name],
          imports,
          (module_index, imports) => ({ exports: asmInit[module_index](imports) })
      );
    }

    // Exporting the trampolines.
    export {
      test,
      test_flavorful_test as 'test:flavorful/test',
      testImports,
    }
     
    // The `$init` function.
    async function $init() {
      ( {
        test,
        'test:flavorful/test': test_flavorful_test,
        'testImports': _testImports,
      } = await instantiate(
        {
          '../flavorful.js': import0,
          '../helpers.js': import1,
        }
      ) )
    }
     
    // Calling `$init`.
    await $init();
    ```

* `--js` with `--tla-compat`:
  * Same as with `--js` only, except that `$init` is exported instead of
    being called immediately.
  * ```js
    // …

    export {
      // Because of `--tla-compat`, `$init` is exported!
      $init,
      test,
      test_flavorful_test as 'test:flavorful/test',
      testImports,
    }

    async function $init() {
      ( {
        test,
        'test:flavorful/test': test_flavorful_test,
        'testImports': _testImports,
      } = await instantiate(
        {
          '../flavorful.js': import0,
          '../helpers.js': import1,
        }
      ) )
    }

    // `$init` isn't called.
    ```

* `--js` with `--instantiation[=async]`:
  * `instantiate` is renamed to `_instantiate`,
  * A new `instantiate` function is created, that calls `_instantiate` with
    the correct imports (which are ASM.js code) and returns the exports,
  * `instantiate` is exported.

* `--js` with `--instantiation=sync`:
  * Same as `--js` with `--instantiation[=async]`, except that
    `_instantiate` and `instantiate` are non-async:
  * ```js
    // …

    // The “old” `instantiate` function.
    function _instantiate(…) { … }

    // The new `instantiate` function.
    export function instantiate(imports) {
      const wasm_file_to_asm_index = {
        'strings.sync+js.core.wasm': 0,
        'strings.sync+js.core2.wasm': 1,
        'strings.sync+js.core3.wasm': 2,
        'strings.sync+js.core4.wasm': 3
      };

      return _instantiate(
          module_name => wasm_file_to_asm_index[module_name],
          imports,
          (module_index, imports) => ({ exports: asmInit[module_index](imports) })
      );
    }
    ```

This patch adds the relevant tests too. The code has been revamped a little
bit for the sake of clarity. Hope you like it.

Also please, note the new `wasm_file_to_asm_index` variable inside `instantiate`. Previously, the code was:

```js
    { … } = await instantiate(n => idx++, …, …)
```

Now it is:

```js
    { … } = await instantiate(module_name => wasm_file_to_asm_index[module_name], …, …)
```

The Wasm module name was never taken into account: only the order in which the `getCoreModule` function argument was called was relevant. It was fragile. I prefered to add a layer of safety by having a mapping from Wasm file names to ASM.js function indices.

---

* Fix https://github.com/bytecodealliance/jco/issues/269