### PR TITLE
Updating jco documentation

### DIFF
--- a/docs/src/#
+++ b/docs/src/#
@@ -1,0 +1,1 @@
+# Contributor Guide

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -1,4 +1,5 @@
 # Summary
 
+- [Introduction](./introduction.md)
 - [Example](./example.md)
 - [Contributing](./contributing.md)

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -2,4 +2,6 @@
 
 - [Introduction](./introduction.md)
 - [Example](./example.md)
-- [Contributing](./contributing.md)
+- [Contributor Guide](#)
+    - [Contributing to the Codebase](./contributing.md)
+    - [Contributing to Docs](./contributing-docs.md)

--- a/docs/src/contributing-docs.md
+++ b/docs/src/contributing-docs.md
@@ -1,0 +1,33 @@
+`jco` is a [Bytecode Alliance](https://bytecodealliance.org/) project and follows the Bytecode Alliance's [Code of Conduct](../../CODE_OF_CONDUCT.md) and [Organizational Code of Conduct](../../ORG_CODE_OF_CONDUCT.md).
+
+## Using this repository
+
+You can run the website locally using the [mdBook](https://rust-lang.github.io/mdBook/index.html) command line tool.
+
+## Prerequisites
+
+To use this repository, you need [mdBook](https://rust-lang.github.io/mdBook/guide/installation.html) installed on your workstation.
+
+## Running the website locally
+
+After installing mdBook, on GitHub, click the `Fork` button in the upper-right area of the screen to create a copy of the jco repository in your account. This copy is called a fork.
+
+Next, clone it locally by executing the command below.
+
+```shell
+git clone https://github.com/bytecodealliance/jco/
+cd docs
+```
+
+To build and test the site locally, run:
+
+```shell
+mdbook serve --open
+```
+
+## Submitting Changes
+
+- Follow the instructions above to [make changes to your website locally](./contributing-docs.md#running-the-website-locally).
+- When you are ready to submit those changes, go to your fork and create a new pull request to let us know about it.
+
+Everyone is welcome to submit a pull request! Once your pull request is created, we'll try to get to reviewing it or responding to it in at most a few days. As the owner of the pull request, it is your responsibility to modify your pull request to address the feedback that has been provided to you by the reviewer.

--- a/docs/src/contributing-docs.md
+++ b/docs/src/contributing-docs.md
@@ -1,4 +1,4 @@
-`jco` is a [Bytecode Alliance](https://bytecodealliance.org/) project and follows the Bytecode Alliance's [Code of Conduct](../../CODE_OF_CONDUCT.md) and [Organizational Code of Conduct](../../ORG_CODE_OF_CONDUCT.md).
+`jco` is a [Bytecode Alliance](https://bytecodealliance.org/) project and follows the Bytecode Alliance's [Code of Conduct](https://raw.githubusercontent.com/bytecodealliance/jco/main/CODE_OF_CONDUCT.md) and [Organizational Code of Conduct](https://raw.githubusercontent.com/bytecodealliance/jco/main/ORG_CODE_OF_CONDUCT.md).
 
 ## Using this repository
 

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -1,4 +1,4 @@
-# Contributing
+# Contributing to the Codebase
 
 Development is based on a standard `npm install && npm run build && npm run test` workflow.
 
@@ -10,7 +10,7 @@ Specific tests can be run adding the mocha `--grep` / `-g` flag, for example: `n
 
 Required prerequisites for building jco include:
 
-* Latest stable Rust with the `wasm32-wasi` target
+* [Latest stable Rust](https://www.rust-lang.org/tools/install) with the `wasm32-wasi` target
 * Node.js 18+ & npm (https://nodejs.org/en)
 
 ### Rust Toolchain
@@ -19,10 +19,12 @@ The latest Rust stable toolchain can be installed using [rustup](https://rustup.
 
 Specifically:
 
-```
+```shell
 rustup toolchain install stable
 rustup target add wasm32-wasi
 ```
+
+In case you do not have `rustup` installed on your system, please follow the installation instructions on the [official Rust website](https://www.rust-lang.org/tools/install) based on your operating system
 
 ## Project Structure
 

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -1,0 +1,13 @@
+# Introduction
+
+`jco` is a fully native tool for working with [WebAssembly Components](https://component-model.bytecodealliance.org/design/components.html) in JavaScript.
+
+Features include:
+
+- *Transpiling* Wasm Component binaries into [ECMAScript modules](https://nodejs.org/api/esm.html#modules-ecmascript-modules) that can run in any JavaScript environment.
+- WASI Preview2 support in Node.js (undergoing stabilization) & browsers (experimental).
+- Component builds of Wasm Tools helpers, available for use as a library or CLI commands for use in native JS environments
+- Optimization helper for Components via Binaryen.
+- `componentize` command to easily create components written in JavaScript (wrapper of ComponentizeJS).
+
+Note: This is an experimental project, no guarantees are provided for stability, security or support and breaking changes may be made without notice.

--- a/docs/src/introduction.md
+++ b/docs/src/introduction.md
@@ -2,12 +2,21 @@
 
 `jco` is a fully native tool for working with [WebAssembly Components](https://component-model.bytecodealliance.org/design/components.html) in JavaScript.
 
-Features include:
+## Features
 
-- *Transpiling* Wasm Component binaries into [ECMAScript modules](https://nodejs.org/api/esm.html#modules-ecmascript-modules) that can run in any JavaScript environment.
+- **Transpiling** Wasm Component binaries into [ECMAScript modules](https://nodejs.org/api/esm.html#modules-ecmascript-modules) that can run in any JavaScript environment.
 - WASI Preview2 support in Node.js (undergoing stabilization) & browsers (experimental).
 - Component builds of Wasm Tools helpers, available for use as a library or CLI commands for use in native JS environments
 - Optimization helper for Components via Binaryen.
-- `componentize` command to easily create components written in JavaScript (wrapper of ComponentizeJS).
+- `componentize` command to easily create components written in JavaScript (wrapper of [ComponentizeJS](https://github.com/bytecodealliance/ComponentizeJS)).
 
-Note: This is an experimental project, no guarantees are provided for stability, security or support and breaking changes may be made without notice.
+> Note: This is an experimental project. **No guarantees** are provided for stability, security or support and breaking changes may be made without notice.
+
+
+## Contributing
+
+To contribute to the codebase of the project, refer to the [Contributor guide](./contributing.md).
+
+To contribute to the documentation, refer to the [Contributor guide](./contributing-docs.md).
+
+If you find a mistake, omission, ambiguity, or other problem, please let us know via [GitHub issues](https://github.com/bytecodealliance/jco/issues).


### PR DESCRIPTION
This PR does the below:
- Creates an introduction page for the website taken from the main README.
- Creates Two separate contribution guides - one for docs and the other for the main codebase.
- Updates the codebase guide to also point to the official Rust installation website, in case users do not have `rustup` installed.
- Adds entries in SUMMARY.md for reflecting the new changes.