### PR TITLE
fix: --no-namespaced-exports parity

### DIFF
--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -125,7 +125,7 @@ export async function transpileComponent (component, opts = {}) {
     noTypescript: opts.noTypescript || false,
     tlaCompat: opts.tlaCompat ?? false,
     base64Cutoff: opts.js ? 0 : opts.base64Cutoff ?? 5000,
-    noNamespacedExports: !opts.namespacedExports,
+    noNamespacedExports: opts.noNamespacedExports,
   });
 
   let outDir = (opts.outDir ?? '').replace(/\\/g, '/');


### PR DESCRIPTION
Fixes a bug from the `--no-namespaced-exports` flag disabling namespaced exports by default.