### PR TITLE
test: reenable ComponentizeJS test cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "terser": "^5.16.1"
   },
   "devDependencies": {
-    "@bytecodealliance/componentize-js": "^0.4.1",
+    "@bytecodealliance/componentize-js": "^0.5.0",
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",

--- a/test/cli.js
+++ b/test/cli.js
@@ -207,7 +207,7 @@ export async function cliTest (fixtures) {
       }]);
     });
 
-    test.skip('Componentize', async () => {
+    test('Componentize', async () => {
       const { stdout, stderr } = await exec(jcoPath,
           'componentize',
           'test/fixtures/componentize/source.js',

--- a/test/preview2.js
+++ b/test/preview2.js
@@ -48,7 +48,7 @@ export async function preview2Test () {
       strictEqual(stderr, 'writing to stderr: hello, world\n');
     });
 
-    test.skip('wasi-http-proxy', async () => {
+    test('wasi-http-proxy', async () => {
       const server = createServer(async (req, res) => {
         if (req.url == '/api/examples') { 
           res.writeHead(200, {


### PR DESCRIPTION
This reeanbles the ComponentizeJS tests to ComponentizeJS 0.5.0 now that it is updated to the latest WIT definitions.

Proxy and componentize tests are fully passing. There is no need to do an updated release as these will work normally anyway.