### PR TITLE
perf: add release profile optimizations, separate release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,18 @@ resolver = "2"
 edition = "2021"
 version = "0.14.0"
 
+[profile.release]
+codegen-units = 1
+debug = false
+debug-assertions = false
+incremental = false
+lto = true
+opt-level = 'z'
+overflow-checks = false
+panic = 'abort'
+rpath = false
+strip = true
+
 [workspace.dependencies]
 anyhow = "1.0.75"
 base64 = "0.21.5"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "homepage": "https://github.com/bytecodealliance/jco#readme",
   "scripts": {
-    "build": "cargo xtask build workspace",
+    "build": "cargo xtask build debug",
     "build:release": "cargo xtask build release",
     "build:types:preview2-shim": "cargo xtask generate wasi-types",
     "lint": "eslint -c eslintrc.cjs lib/**/*.js packages/*/lib/**/*.js",

--- a/package.json
+++ b/package.json
@@ -52,9 +52,11 @@
   "homepage": "https://github.com/bytecodealliance/jco#readme",
   "scripts": {
     "build": "cargo xtask build workspace",
+    "build:release": "cargo xtask build release",
     "build:types:preview2-shim": "cargo xtask generate wasi-types",
     "lint": "eslint -c eslintrc.cjs lib/**/*.js packages/*/lib/**/*.js",
-    "test": "mocha -u tdd test/test.js --timeout 120000"
+    "test": "mocha -u tdd test/test.js --timeout 120000",
+    "prepublishOnly": "cargo xtask build release && npm run test"
   },
   "files": [
     "lib",

--- a/xtask/src/build/jco.rs
+++ b/xtask/src/build/jco.rs
@@ -2,13 +2,14 @@ use anyhow::{Context, Result};
 use std::{collections::HashMap, fs, io::Write, path::PathBuf};
 use wit_component::ComponentEncoder;
 
-pub(crate) fn run() -> Result<()> {
+pub(crate) fn run(release: bool) -> Result<()> {
+    let build = if release { "release" } else { "debug" };
     transpile(
-        "target/wasm32-wasi/release/js_component_bindgen_component.wasm",
+        &format!("target/wasm32-wasi/{build}/js_component_bindgen_component.wasm"),
         "js-component-bindgen-component".to_string(),
     )?;
     transpile(
-        "target/wasm32-wasi/release/wasm_tools_js.wasm",
+        &format!("target/wasm32-wasi/{build}/wasm_tools_js.wasm"),
         "wasm-tools".to_string(),
     )?;
 

--- a/xtask/src/build/workspace.rs
+++ b/xtask/src/build/workspace.rs
@@ -1,8 +1,12 @@
 use xshell::{cmd, Shell};
 
-pub(crate) fn run() -> anyhow::Result<()> {
+pub(crate) fn run(release: bool) -> anyhow::Result<()> {
     let sh = Shell::new()?;
-    cmd!(sh, "cargo build --workspace --target wasm32-wasi --release").read()?;
+    if release {
+        cmd!(sh, "cargo build --workspace --release --target wasm32-wasi").read()?;
+    } else {
+        cmd!(sh, "cargo build --workspace --target wasm32-wasi").read()?;
+    }
     cmd!(sh, "node node_modules/typescript/bin/tsc -p tsconfig.json").read()?;
     sh.copy_file(
         "lib/wasi_snapshot_preview1.command.wasm",

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -39,12 +39,12 @@ fn main() -> anyhow::Result<()> {
             build::workspace::run(false)?;
             build::jco::run()?;
             Ok(())
-        },
+        }
         Opts::Build(Build::Release) => {
             build::workspace::run(true)?;
             build::jco::run()?;
             Ok(())
-        },
+        }
         Opts::Test => test::run(),
         Opts::Generate(Generate::Tests) => generate::tests::run(),
         Opts::Generate(Generate::WasiTypes) => generate::wasi_types::run(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -16,10 +16,8 @@ enum Opts {
 
 #[derive(StructOpt)]
 enum Build {
-    /// Build and transpile the `jco` tools
-    Jco,
     /// Build the project and copy the binaries
-    Workspace,
+    Debug,
     /// Build the project for release and copy the binaries
     Release,
 }
@@ -34,15 +32,14 @@ enum Generate {
 
 fn main() -> anyhow::Result<()> {
     match Opts::from_args() {
-        Opts::Build(Build::Jco) => build::jco::run(),
-        Opts::Build(Build::Workspace) => {
+        Opts::Build(Build::Debug) => {
             build::workspace::run(false)?;
-            build::jco::run()?;
+            build::jco::run(false)?;
             Ok(())
         }
         Opts::Build(Build::Release) => {
             build::workspace::run(true)?;
-            build::jco::run()?;
+            build::jco::run(true)?;
             Ok(())
         }
         Opts::Test => test::run(),

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -20,6 +20,8 @@ enum Build {
     Jco,
     /// Build the project and copy the binaries
     Workspace,
+    /// Build the project for release and copy the binaries
+    Release,
 }
 
 #[derive(StructOpt)]
@@ -34,10 +36,15 @@ fn main() -> anyhow::Result<()> {
     match Opts::from_args() {
         Opts::Build(Build::Jco) => build::jco::run(),
         Opts::Build(Build::Workspace) => {
-            build::workspace::run()?;
+            build::workspace::run(false)?;
             build::jco::run()?;
             Ok(())
-        }
+        },
+        Opts::Build(Build::Release) => {
+            build::workspace::run(true)?;
+            build::jco::run()?;
+            Ok(())
+        },
         Opts::Test => test::run(),
         Opts::Generate(Generate::Tests) => generate::tests::run(),
         Opts::Generate(Generate::WasiTypes) => generate::wasi_types::run(),


### PR DESCRIPTION
Adds a new `npm run build:release` with release build optimizations applied.

Resolves https://github.com/bytecodealliance/jco/issues/286.