### PR TITLE
fix: browser build, with tla compat

### DIFF
--- a/packages/preview2-shim/lib/browser/http.js
+++ b/packages/preview2-shim/lib/browser/http.js
@@ -1,5 +1,3 @@
-import { UnexpectedError } from "../http/error.js";
-
 /**
  * @param {import("../../types/interfaces/wasi-http-types").Request} req
  * @returns {string}
@@ -30,7 +28,7 @@ export function send(req) {
       body,
     };
   } catch (err) {
-    throw new UnexpectedError(err.message);
+    throw new Error(err.message);
   }
 }
 

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,3 +1,11 @@
-import { $init, generate, generateTypes } from '../obj/js-component-bindgen-component.js';
-await $init;
-export { generate as transpile, generateTypes }
+import { $init, generate, generateTypes as _generateTypes } from '../obj/js-component-bindgen-component.js';
+
+export async function transpile () {
+  await $init;
+  return generate.apply(this, arguments);
+}
+
+export async function generateTypes () {
+  await $init;
+  return _generateTypes.apply(this, arguments);
+}

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -97,8 +97,6 @@ export async function transpileComponent (component, opts = {}) {
       'wasi:filesystem/*': '@bytecodealliance/preview2-shim/filesystem#*',
       'wasi:http/*': '@bytecodealliance/preview2-shim/http#*',
       'wasi:io/*': '@bytecodealliance/preview2-shim/io#*',
-      'wasi:logging/*': '@bytecodealliance/preview2-shim/logging#*',
-      'wasi:poll/*': '@bytecodealliance/preview2-shim/poll#*',
       'wasi:random/*': '@bytecodealliance/preview2-shim/random#*',
       'wasi:sockets/*': '@bytecodealliance/preview2-shim/sockets#*',
     }, opts.map || {});

--- a/test/browser.html
+++ b/test/browser.html
@@ -7,8 +7,6 @@
     "@bytecodealliance/preview2-shim/filesystem": "../packages/preview2-shim/lib/browser/filesystem.js",
     "@bytecodealliance/preview2-shim/http": "../packages/preview2-shim/lib/browser/http.js",
     "@bytecodealliance/preview2-shim/io": "../packages/preview2-shim/lib/browser/io.js",
-    "@bytecodealliance/preview2-shim/logging": "../packages/preview2-shim/lib/browser/logging.js",
-    "@bytecodealliance/preview2-shim/poll": "../packages/preview2-shim/lib/browser/poll.js",
     "@bytecodealliance/preview2-shim/random": "../packages/preview2-shim/lib/browser/random.js",
     "@bytecodealliance/preview2-shim/sockets": "../packages/preview2-shim/lib/browser/sockets.js",
     "jco": "../src/browser.js"
@@ -16,15 +14,24 @@
 }
 </script>
 <script type="module">
+  // verify preview2
+  import "@bytecodealliance/preview2-shim/cli";
+  import "@bytecodealliance/preview2-shim/clocks";
+  import "@bytecodealliance/preview2-shim/filesystem";
+  import "@bytecodealliance/preview2-shim/http";
+  import "@bytecodealliance/preview2-shim/io";
+  import "@bytecodealliance/preview2-shim/random";
+  import "@bytecodealliance/preview2-shim/sockets";
+
   import { transpile } from 'jco';
   const componentUrl = new URL('./fixtures/components/lists.component.wasm', import.meta.url);
   document.body.innerHTML = '<h1>Generating...</h1>';
   const component = await (await fetch(componentUrl)).arrayBuffer();
-  const output = transpile(component, {
+  const output = await transpile(component, {
     name: 'test',
     noTypescript: true,
     noNodejsCompat: true,
-    instantiation: 'async',
+    instantiation: { tag: 'async' },
     // force baseurls
     // todo: support a hook for inline blob url construction
     base64Cutoff: 1000000,
@@ -34,8 +41,6 @@
       ['wasi:filesystem/*', '@bytecodealliance/preview2-shim/filesystem#*'],
       ['wasi:http/*', '@bytecodealliance/preview2-shim/http#*'],
       ['wasi:io/*', '@bytecodealliance/preview2-shim/io#*'],
-      ['wasi:logging/*', '@bytecodealliance/preview2-shim/logging#*'],
-      ['wasi:poll/*', '@bytecodealliance/preview2-shim/poll#*'],
       ['wasi:random/*', '@bytecodealliance/preview2-shim/random#*'],
       ['wasi:sockets/*', '@bytecodealliance/preview2-shim/sockets#*']
     ]


### PR DESCRIPTION
Fixes the browser build and makes it async by default to support TLA compat, resolving https://github.com/bytecodealliance/jco/issues/284 and https://github.com/bytecodealliance/jco/issues/285.