### PR TITLE
fix: make getChildEntry recursively traverse the path

### DIFF
--- a/packages/preview2-shim/lib/browser/filesystem.js
+++ b/packages/preview2-shim/lib/browser/filesystem.js
@@ -37,15 +37,18 @@ function getChildEntry (parentEntry, subpath, openFlags) {
   let segmentIdx;
   do {
     if (!entry || !entry.dir) throw 'not-directory';
-    segmentIdx = subpath.indexOf('/');
+    segmentIdx = subpath.indexOf('/', segmentIdx);
     const segment = segmentIdx === -1 ? subpath : subpath.slice(0, segmentIdx);
-    if (segment === '.' || segment === '') return entry;
-    if (segment === '..') throw 'no-entry';
-    if (!entry.dir[segment] && openFlags.create)
+    if (segment === '.' || segment === '')
+      entry = entry;
+    else if (segment === '..')
+      throw 'no-entry';
+    else if (!entry.dir[segment] && openFlags.create)
       entry = entry.dir[segment] = openFlags.directory ? { dir: {} } : { source: new Uint8Array([]) };
     else
       entry = entry.dir[segment];
-  } while (segmentIdx !== -1)
+    subpath = subpath.substring(segmentIdx + 1);
+  } while (segmentIdx !== -1);
   if (!entry) throw 'no-entry';
   return entry;
 }


### PR DESCRIPTION
I'm testing JCO together with [YoWASP](https://yowasp.org). I componentized a regular build of YoWASP Yosys using `jco new --wasi-command` and `jco transpile`, and am running it with this script:

```js
import { run } from './yosys.command.js';
import { _setArgs } from '@bytecodealliance/preview2-shim/cli';
import { _setFileData } from '@bytecodealliance/preview2-shim/filesystem';

var fileData = {
    dir: {
        "inv.v": {
            source: "module inv(input i, output o); assign o = ~i; endmodule"
        }
    }
};
_setFileData(fileData)
_setArgs(["yosys", "-Q", "./inv.v", "-o", "inv.il"])
run.run()

console.log(new TextDecoder().decode(fileData.dir["inv.il"].source))
```

Without this PR, Yosys attempting to open `./inv.v` opens the directory (and then crashes because it's not a file). I'm not entirely sure what the intent for the `getChildEntry` function is, but it seems wrong as-is, and the script completes with my changes.