### PR TITLE
chore: preview2_tcp_sockopts passing

### DIFF
--- a/packages/preview2-shim/lib/io/worker-thread.js
+++ b/packages/preview2-shim/lib/io/worker-thread.js
@@ -311,11 +311,7 @@ function handle(call, id, payload) {
       return socketTcpDispose(id);
 
     case SOCKET_TCP_CREATE_INPUT_STREAM:
-      // TODO: implement a proper input stream
-      return createStream(new PassThrough());
-
-    case SOCKET_TCP_CREATE_OUTPUT_STREAM: 
-      // TODO: implement a proper output stream
+    case SOCKET_TCP_CREATE_OUTPUT_STREAM:
       return createStream(new PassThrough());
   
     // Sockets UDP


### PR DESCRIPTION
Both `preview2_tcp_states `and `preview2_tcp_sockopts` are passing.

Related https://github.com/bytecodealliance/jco/issues/315