### PR TITLE
fix: support for js reserved words in resource method names

### DIFF
--- a/crates/js-component-bindgen/src/names.rs
+++ b/crates/js-component-bindgen/src/names.rs
@@ -113,7 +113,11 @@ pub fn is_js_identifier(s: &str) -> bool {
             return false;
         }
     }
-    RESERVED_KEYWORDS.binary_search(&s).is_err()
+    !is_js_reserved_word(&s)
+}
+
+pub fn is_js_reserved_word(s: &str) -> bool {
+    RESERVED_KEYWORDS.binary_search(&s).is_ok()
 }
 
 // https://tc39.es/ecma262/#prod-IdentifierStartChar

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -5,7 +5,7 @@ use crate::function_bindgen::{
     ErrHandling, FunctionBindgen, ResourceData, ResourceMap, ResourceTable,
 };
 use crate::intrinsics::{render_intrinsics, Intrinsic};
-use crate::names::{maybe_quote_id, maybe_quote_member, LocalNames};
+use crate::names::{is_js_reserved_word, maybe_quote_id, maybe_quote_member, LocalNames};
 use crate::source;
 use crate::{uwrite, uwriteln};
 use base64::{engine::general_purpose, Engine as _};
@@ -1612,7 +1612,12 @@ impl<'a> Instantiator<'a, '_> {
                 let method_name = func.item_name().to_lower_camel_case();
                 uwrite!(
                     self.src.js,
-                    "\n{local_name}.prototype.{method_name} = function {method_name}",
+                    "\n{local_name}.prototype.{method_name} = function {}",
+                    if !is_js_reserved_word(&method_name) {
+                        method_name.to_string()
+                    } else {
+                        format!("${method_name}")
+                    }
                 );
             }
             FunctionKind::Static(_) => {
@@ -1623,7 +1628,12 @@ impl<'a> Instantiator<'a, '_> {
                 let method_name = func.item_name().to_lower_camel_case();
                 uwrite!(
                     self.src.js,
-                    "\n{local_name}.{method_name} = function {method_name}",
+                    "\n{local_name}.{method_name} = function {}",
+                    if !is_js_reserved_word(&method_name) {
+                        method_name.to_string()
+                    } else {
+                        format!("${method_name}")
+                    }
                 );
             }
             FunctionKind::Constructor(ty) => {

--- a/test/fixtures/wit/wasi-http.wit
+++ b/test/fixtures/wit/wasi-http.wit
@@ -1,6 +1,7 @@
 package test:jco;
 interface commands {
   resource error {
+    new: func () -> string;
     to-string: func() -> string;
   }
 


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/jco/issues/331, supporting JS reserved words in resource method names.