### PR TITLE
fix: http conformance tests

### DIFF
--- a/packages/preview2-shim/lib/io/worker-thread.js
+++ b/packages/preview2-shim/lib/io/worker-thread.js
@@ -853,12 +853,10 @@ export function pollStateWait(pollState) {
  * @param {bool} finished
  */
 export function pollStateReady(pollState, finished) {
-  if (pollState.state !== POLL_STATE_WAIT) {
-    if (pollState.listener)
-      throw new Error(
-        "wasi-io trap: poll already ready with listener attached"
-      );
-    return;
+  if (pollState.state !== POLL_STATE_WAIT && pollState.listener) {
+    throw new Error(
+      "wasi-io trap: poll already ready with listener attached"
+    );
   }
   pollState.state = finished ? POLL_STATE_FINISHED : POLL_STATE_READY;
   if (pollState.listener) {

--- a/tests/generated/mod.rs
+++ b/tests/generated/mod.rs
@@ -100,3 +100,6 @@ mod preview2_udp_connect;
 mod preview2_udp_sample_application;
 mod preview2_udp_sockopts;
 mod preview2_udp_states;
+mod proxy_echo;
+mod proxy_handler;
+mod proxy_hash;

--- a/tests/generated/proxy_echo.rs
+++ b/tests/generated/proxy_echo.rs
@@ -1,0 +1,26 @@
+//! This file has been auto-generated, please do not modify manually
+//! To regenerate this file re-run `cargo xtask generate tests` from the project root
+
+use std::fs;
+use std::process::{Command, Stdio};
+
+#[test]
+fn proxy_echo() -> anyhow::Result<()> {
+    let wasi_file = "./tests/rundir/proxy_echo.component.wasm";
+    let _ = fs::remove_dir_all("./tests/rundir/proxy_echo");
+    let mut cmd1 = Command::new("node");
+    cmd1.arg("./src/jco.js");
+    cmd1.arg("run");
+
+    cmd1.arg("--jco-dir");
+    cmd1.arg("./tests/rundir/proxy_echo");
+    cmd1.arg("--jco-import");
+    cmd1.arg("./tests/virtualenvs/server-api-proxy-streaming.js");
+    cmd1.arg(wasi_file);
+    cmd1.args(&["hello", "this", "", "is an argument", "with 🚩 emoji"]);
+    cmd1.stdin(Stdio::null());
+    let mut cmd1_child = cmd1.spawn().expect("failed to spawn test program");
+    let status = cmd1_child.wait().expect("failed to wait on child");
+    assert!(status.success(), "test execution failed");
+    Ok(())
+}

--- a/tests/generated/proxy_handler.rs
+++ b/tests/generated/proxy_handler.rs
@@ -1,0 +1,26 @@
+//! This file has been auto-generated, please do not modify manually
+//! To regenerate this file re-run `cargo xtask generate tests` from the project root
+
+use std::fs;
+use std::process::{Command, Stdio};
+
+#[test]
+fn proxy_handler() -> anyhow::Result<()> {
+    let wasi_file = "./tests/rundir/proxy_handler.component.wasm";
+    let _ = fs::remove_dir_all("./tests/rundir/proxy_handler");
+    let mut cmd1 = Command::new("node");
+    cmd1.arg("./src/jco.js");
+    cmd1.arg("run");
+
+    cmd1.arg("--jco-dir");
+    cmd1.arg("./tests/rundir/proxy_handler");
+    cmd1.arg("--jco-import");
+    cmd1.arg("./tests/virtualenvs/server-api-proxy.js");
+    cmd1.arg(wasi_file);
+    cmd1.args(&["hello", "this", "", "is an argument", "with 🚩 emoji"]);
+    cmd1.stdin(Stdio::null());
+    let mut cmd1_child = cmd1.spawn().expect("failed to spawn test program");
+    let status = cmd1_child.wait().expect("failed to wait on child");
+    assert!(status.success(), "test execution failed");
+    Ok(())
+}

--- a/tests/generated/proxy_hash.rs
+++ b/tests/generated/proxy_hash.rs
@@ -1,0 +1,26 @@
+//! This file has been auto-generated, please do not modify manually
+//! To regenerate this file re-run `cargo xtask generate tests` from the project root
+
+use std::fs;
+use std::process::{Command, Stdio};
+
+#[test]
+fn proxy_hash() -> anyhow::Result<()> {
+    let wasi_file = "./tests/rundir/proxy_hash.component.wasm";
+    let _ = fs::remove_dir_all("./tests/rundir/proxy_hash");
+    let mut cmd1 = Command::new("node");
+    cmd1.arg("./src/jco.js");
+    cmd1.arg("run");
+
+    cmd1.arg("--jco-dir");
+    cmd1.arg("./tests/rundir/proxy_hash");
+    cmd1.arg("--jco-import");
+    cmd1.arg("./tests/virtualenvs/server-api-proxy-streaming.js");
+    cmd1.arg(wasi_file);
+    cmd1.args(&["hello", "this", "", "is an argument", "with 🚩 emoji"]);
+    cmd1.stdin(Stdio::null());
+    let mut cmd1_child = cmd1.spawn().expect("failed to spawn test program");
+    let status = cmd1_child.wait().expect("failed to wait on child");
+    assert!(status.success(), "test execution failed");
+    Ok(())
+}

--- a/xtask/src/generate/tests.rs
+++ b/xtask/src/generate/tests.rs
@@ -5,13 +5,7 @@ use xshell::{cmd, Shell};
 const TRACE: bool = false;
 const TEST_FILTER: &[&str] = &[];
 
-const TEST_IGNORE: &[&str] = &[
-    "nn_image_classification",
-    "nn_image_classification_named",
-    "proxy_handler",
-    "proxy_hash",
-    "proxy_echo",
-];
+const TEST_IGNORE: &[&str] = &["nn_image_classification", "nn_image_classification_named"];
 
 pub fn run() -> anyhow::Result<()> {
     let sh = Shell::new()?;


### PR DESCRIPTION
This fixes the the remaining failures on the HTTP conformance tests from the latest refactoring in https://github.com/bytecodealliance/jco/pull/334.