### PR TITLE
feat: GC finalization for preview2-shims

### DIFF
--- a/packages/preview2-shim/lib/io/calls.js
+++ b/packages/preview2-shim/lib/io/calls.js
@@ -62,6 +62,7 @@ export const HTTP_SERVER_STOP = ++call_id << CALL_SHIFT;
 export const HTTP_SERVER_INCOMING_HANDLER = ++call_id << CALL_SHIFT;
 export const HTTP_SERVER_SET_OUTGOING_RESPONSE = ++call_id << CALL_SHIFT;
 export const HTTP_SERVER_CLEAR_OUTGOING_RESPONSE = ++call_id << CALL_SHIFT;
+export const HTTP_OUTGOING_BODY_DISPOSE = ++call_id << CALL_SHIFT;
 
 // Clocks
 export const CLOCKS_NOW = ++call_id << CALL_SHIFT;
@@ -102,7 +103,8 @@ export const SOCKET_UDP_SET_RECEIVE_BUFFER_SIZE = ++call_id << CALL_SHIFT;
 export const SOCKET_UDP_SET_SEND_BUFFER_SIZE = ++call_id << CALL_SHIFT;
 export const SOCKET_UDP_SET_UNICAST_HOP_LIMIT = ++call_id << CALL_SHIFT;
 export const SOCKET_INCOMING_DATAGRAM_STREAM_RECEIVE = ++call_id << CALL_SHIFT;
-export const SOCKET_OUTGOING_DATAGRAM_STREAM_CHECK_SEND = ++call_id << CALL_SHIFT;
+export const SOCKET_OUTGOING_DATAGRAM_STREAM_CHECK_SEND =
+  ++call_id << CALL_SHIFT;
 export const SOCKET_OUTGOING_DATAGRAM_STREAM_SEND = ++call_id << CALL_SHIFT;
 export const SOCKET_DATAGRAM_STREAM_SUBSCRIBE = ++call_id << CALL_SHIFT;
 export const SOCKET_DATAGRAM_STREAM_DISPOSE = ++call_id << CALL_SHIFT;
@@ -118,9 +120,9 @@ export const SOCKET_RESOLVE_ADDRESS_DISPOSE_REQUEST = ++call_id << CALL_SHIFT;
 
 export const reverseMap = {};
 
-import * as calls from './calls.js';
+import * as calls from "./calls.js";
 
 for (const name of Object.getOwnPropertyNames(calls)) {
-  if (name === 'reverseMap') continue;
+  if (name === "reverseMap") continue;
   reverseMap[calls[name]] = name;
 }

--- a/packages/preview2-shim/lib/io/worker-http.js
+++ b/packages/preview2-shim/lib/io/worker-http.js
@@ -156,7 +156,7 @@ export async function createHttpRequest(
     return {
       status: res.statusCode,
       headers: Array.from(Object.entries(res.headers)),
-      bodyStreamId: bodyStreamId,
+      bodyStreamId
     };
   } catch (e) {
     if (e?.tag) throw e;

--- a/packages/preview2-shim/lib/io/worker-io.js
+++ b/packages/preview2-shim/lib/io/worker-io.js
@@ -45,7 +45,7 @@ export function registerIncomingHttpHandler(id, handler) {
 }
 
 const instanceId = Math.round(Math.random() * 1000).toString();
-const DEBUG_DEFAULT = false;
+const DEBUG_DEFAULT = true;
 const DEBUG =
   env.PREVIEW2_SHIM_DEBUG === "0"
     ? false
@@ -124,6 +124,7 @@ export function registerDispose(resource, parentResource, id, disposeFn) {
     // This makes the generational JS GC become piecewise over child resource
     // graphs (generational at each resource hierarchy level at least).
     if (parentResource?.[dummySymbol]) return;
+    process._rawDebug('FINALIZE', id);
     disposeFn(id);
   }
   finalizationRegistry.register(resource, finalizer, finalizer);
@@ -132,6 +133,7 @@ export function registerDispose(resource, parentResource, id, disposeFn) {
   Object.defineProperty(resource, symbolDispose, {
     value: () => {
       finalizationRegistry.unregister(finalizer);
+      process._rawDebug('DISPOSE', id);
       disposeFn(id);
     },
   });

--- a/packages/preview2-shim/lib/io/worker-io.js
+++ b/packages/preview2-shim/lib/io/worker-io.js
@@ -124,7 +124,6 @@ export function registerDispose(resource, parentResource, id, disposeFn) {
     // This makes the generational JS GC become piecewise over child resource
     // graphs (generational at each resource hierarchy level at least).
     if (parentResource?.[dummySymbol]) return;
-    process._rawDebug('FINALIZE', id);
     disposeFn(id);
   }
   finalizationRegistry.register(resource, finalizer, finalizer);
@@ -133,7 +132,6 @@ export function registerDispose(resource, parentResource, id, disposeFn) {
   Object.defineProperty(resource, symbolDispose, {
     value: () => {
       finalizationRegistry.unregister(finalizer);
-      process._rawDebug('DISPOSE', id);
       disposeFn(id);
     },
   });

--- a/packages/preview2-shim/lib/nodejs/clocks.js
+++ b/packages/preview2-shim/lib/nodejs/clocks.js
@@ -1,4 +1,4 @@
-import { ioCall, createPoll, resolvedPoll } from "../io/worker-io.js";
+import { ioCall, createPoll } from "../io/worker-io.js";
 import {
   CLOCKS_NOW,
   CLOCKS_INSTANT_SUBSCRIBE,
@@ -17,7 +17,6 @@ export const monotonicClock = {
   },
   subscribeDuration(duration) {
     duration = BigInt(duration);
-    if (duration === 0n) return resolvedPoll;
     return createPoll(CLOCKS_DURATION_SUBSCRIBE, null, duration);
   },
 };

--- a/packages/preview2-shim/lib/nodejs/http.js
+++ b/packages/preview2-shim/lib/nodejs/http.js
@@ -1,23 +1,23 @@
 import {
-  INPUT_STREAM_DISPOSE,
+  FUTURE_DISPOSE,
+  FUTURE_SUBSCRIBE,
+  FUTURE_TAKE_VALUE,
   HTTP_CREATE_REQUEST,
+  HTTP_OUTGOING_BODY_DISPOSE,
   HTTP_OUTPUT_STREAM_FINISH,
+  HTTP_SERVER_CLEAR_OUTGOING_RESPONSE,
+  HTTP_SERVER_SET_OUTGOING_RESPONSE,
   HTTP_SERVER_START,
   HTTP_SERVER_STOP,
   OUTPUT_STREAM_CREATE,
-  FUTURE_DISPOSE,
-  FUTURE_TAKE_VALUE,
-  FUTURE_SUBSCRIBE,
-  HTTP_SERVER_SET_OUTGOING_RESPONSE,
-  HTTP_SERVER_CLEAR_OUTGOING_RESPONSE,
 } from "../io/calls.js";
 import {
   inputStreamCreate,
   ioCall,
   outputStreamCreate,
   pollableCreate,
+  registerDispose,
   registerIncomingHttpHandler,
-  resolvedPoll,
 } from "../io/worker-io.js";
 import { validateHeaderName, validateHeaderValue } from "node:http";
 import { HTTP } from "../io/calls.js";
@@ -27,12 +27,12 @@ export const _forbiddenHeaders = new Set(["connection", "keep-alive"]);
 
 class IncomingBody {
   #finished = false;
-  #calledStream = false;
-  #streamId = undefined;
+  #stream = undefined;
   stream() {
-    if (this.#calledStream) throw undefined;
-    this.#calledStream = true;
-    return inputStreamCreate(HTTP, this.#streamId);
+    if (!this.#stream) throw undefined;
+    const stream = this.#stream;
+    this.#stream = null;
+    return stream;
   }
   static finish(incomingBody) {
     if (incomingBody.#finished)
@@ -40,15 +40,10 @@ class IncomingBody {
     incomingBody.#finished = true;
     return futureTrailersCreate();
   }
-  [symbolDispose]() {
-    if (!this.#finished) {
-      ioCall(INPUT_STREAM_DISPOSE | HTTP, this.#streamId);
-      this.#streamId = undefined;
-    }
-  }
+  [symbolDispose]() {}
   static _create(streamId) {
     const incomingBody = new IncomingBody();
-    incomingBody.#streamId = streamId;
+    incomingBody.#stream = inputStreamCreate(HTTP, streamId);
     return incomingBody;
   }
 }
@@ -80,6 +75,7 @@ class IncomingRequest {
   consume() {
     return incomingBodyCreate(this.#streamId);
   }
+  [symbolDispose]() {}
   static _create(method, pathWithQuery, scheme, authority, headers, streamId) {
     const incomingRequest = new IncomingRequest();
     incomingRequest.#method = method;
@@ -97,7 +93,7 @@ delete IncomingRequest._create;
 class FutureTrailers {
   #requested = false;
   subscribe() {
-    return resolvedPoll;
+    return pollableCreate(0, this);
   }
   get() {
     if (this.#requested) return { tag: "err" };
@@ -149,7 +145,7 @@ class OutgoingResponse {
     let contentLength;
     if (contentLengthValues.length > 0)
       contentLength = Number(new TextDecoder().decode(contentLengthValues[0]));
-    this.#body = outgoingBodyCreate(contentLength, true);
+    this.#body = outgoingBodyCreate(contentLength);
     return this.#body;
   }
 
@@ -216,7 +212,7 @@ class OutgoingRequest {
     let contentLength;
     if (contentLengthValues.length > 0)
       contentLength = Number(new TextDecoder().decode(contentLengthValues[0]));
-    this.#body = outgoingBodyCreate(contentLength, false);
+    this.#body = outgoingBodyCreate(contentLength);
   }
   body() {
     if (this.#bodyRequested) throw new Error("Body already requested");
@@ -304,23 +300,11 @@ class OutgoingBody {
   #outputStreamId = null;
   #contentLength = undefined;
   write() {
-    if (!this.#outputStreamId) this.#createOutputStream();
     // can only call write once
     const outputStream = this.#outputStream;
     if (outputStream === null) throw undefined;
     this.#outputStream = null;
     return outputStream;
-  }
-  #createOutputStream() {
-    this.#outputStream = outputStreamCreate(
-      HTTP,
-      (this.#outputStreamId = ioCall(
-        OUTPUT_STREAM_CREATE | HTTP,
-        null,
-        this.#contentLength
-      ))
-    );
-    this.#outputStream[symbolDispose] = () => {};
   }
   /**
    * @param {OutgoingBody} body
@@ -330,19 +314,37 @@ class OutgoingBody {
     if (trailers) throw { tag: "internal-error", val: "trailers unsupported" };
     // this will verify content length, and also verify not already finished
     // throwing errors as appropriate
-    if (body.#outputStreamId)
-      ioCall(HTTP_OUTPUT_STREAM_FINISH, body.#outputStreamId, null);
+    ioCall(HTTP_OUTPUT_STREAM_FINISH, body.#outputStreamId, null);
   }
   static _outputStreamId(outgoingBody) {
     return outgoingBody.#outputStreamId;
   }
-  static _create(contentLength, createBodyStream) {
+  static _create(contentLength) {
     const outgoingBody = new OutgoingBody();
     outgoingBody.#contentLength = contentLength;
-    if (createBodyStream) outgoingBody.#createOutputStream();
+    outgoingBody.#outputStreamId = ioCall(
+      OUTPUT_STREAM_CREATE | HTTP,
+      null,
+      outgoingBody.#contentLength
+    );
+    outgoingBody.#outputStream = outputStreamCreate(
+      HTTP,
+      outgoingBody.#outputStreamId
+    );
+    registerDispose(
+      outgoingBody,
+      null,
+      outgoingBody.#outputStreamId,
+      outgoingBodyDispose
+    );
     return outgoingBody;
   }
 }
+
+function outgoingBodyDispose(id) {
+  ioCall(HTTP_OUTGOING_BODY_DISPOSE, id, null);
+}
+
 const outgoingBodyOutputStreamId = OutgoingBody._outputStreamId;
 delete OutgoingBody._outputStreamId;
 
@@ -352,7 +354,7 @@ delete OutgoingBody._create;
 class IncomingResponse {
   /** @type {Fields} */ #headers = undefined;
   #status = 0;
-  /** @type {number} */ #bodyStreamId;
+  /** @type {number} */ #bodyStream;
   status() {
     return this.#status;
   }
@@ -360,22 +362,19 @@ class IncomingResponse {
     return this.#headers;
   }
   consume() {
-    if (this.#bodyStreamId === undefined) throw undefined;
-    const bodyStreamId = this.#bodyStreamId;
-    this.#bodyStreamId = undefined;
-    return incomingBodyCreate(bodyStreamId);
+    if (this.#bodyStream === undefined) throw undefined;
+    const bodyStream = this.#bodyStream;
+    this.#bodyStream = undefined;
+    return bodyStream;
   }
   [symbolDispose]() {
-    if (this.#bodyStreamId) {
-      ioCall(INPUT_STREAM_DISPOSE | HTTP, this.#bodyStreamId, null);
-      this.#bodyStreamId = undefined;
-    }
+    if (this.#bodyStream) this.#bodyStream[symbolDispose]();
   }
   static _create(status, headers, bodyStreamId) {
     const res = new IncomingResponse();
     res.#status = status;
     res.#headers = headers;
-    res.#bodyStreamId = bodyStreamId;
+    res.#bodyStream = incomingBodyCreate(bodyStreamId);
     return res;
   }
 }
@@ -386,7 +385,10 @@ delete IncomingResponse._create;
 class FutureIncomingResponse {
   #id;
   subscribe() {
-    return pollableCreate(ioCall(FUTURE_SUBSCRIBE | HTTP, this.#id, null));
+    return pollableCreate(
+      ioCall(FUTURE_SUBSCRIBE | HTTP, this.#id, null),
+      this
+    );
   }
   get() {
     const ret = ioCall(FUTURE_TAKE_VALUE | HTTP, this.#id, null);
@@ -403,9 +405,6 @@ class FutureIncomingResponse {
       );
     }
     return ret;
-  }
-  [symbolDispose]() {
-    ioCall(FUTURE_DISPOSE | HTTP, this.#id, null);
   }
   static _create(
     method,
@@ -430,8 +429,13 @@ class FutureIncomingResponse {
       betweenBytesTimeout,
       firstByteTimeout,
     });
+    registerDispose(res, null, res.#id, futureIncomingResponseDispose);
     return res;
   }
+}
+
+function futureIncomingResponseDispose(id) {
+  ioCall(FUTURE_DISPOSE | HTTP, id, null);
 }
 
 const futureIncomingResponseCreate = FutureIncomingResponse._create;
@@ -676,5 +680,6 @@ export class HTTPServer {
   stop() {
     clearInterval(this.#liveEventLoopInterval);
     ioCall(HTTP_SERVER_STOP, this.#id, null);
+    httpServers.delete(this.#id);
   }
 }

--- a/packages/preview2-shim/package.json
+++ b/packages/preview2-shim/package.json
@@ -18,7 +18,7 @@
     }
   },
   "scripts": {
-    "test": "mocha -u tdd test/test.js --timeout 10000"
+    "test": "node --expose-gc ../../node_modules/mocha/bin/mocha.js -u tdd test/test.js --timeout 30000"
   },
   "files": [
     "types",


### PR DESCRIPTION
This resolves the GC integration for the JS preview2-shims bindings, where if a `Symbol.dispose` call is not done for any resource, the GC will always kick in and handle the resource finalization in this case.

This is typically only for invalid components, but also affects direct usage of the preview2 APIs from JS where manual `Symbol.dispose` calls are forgotten to be called by a consumer.

One complexity here is that when the GC runs, it can dispose parent resources before their children. To avoid this, we create a strong reference in the finalizer for any child resource to its parent resource, so that this is not possible by the semantics of the GC itself. Thanks to @alexcrichton for suggesting the approach to this problem here. GC tests are included in the preview2 unit tests using the `--expose-gc` option in Node.js, verifying the GC integration, and that these ordering bugs are avoided.

Resolves https://github.com/bytecodealliance/jco/issues/335.