### PR TITLE
fix: own resource handle rep

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -30,15 +30,15 @@ export async function cliTest (fixtures) {
     });
     suiteTeardown(async function () {
       try {
-        // await rm(tmpDir, { recursive: true });
+        await rm(tmpDir, { recursive: true });
       }
       catch {}
     });
 
     teardown(async function () {
       try {
-        // await rm(outDir, { recursive: true });
-        // await rm(outFile);
+        await rm(outDir, { recursive: true });
+        await rm(outFile);
       }
       catch {}
     });

--- a/test/cli.js
+++ b/test/cli.js
@@ -30,15 +30,15 @@ export async function cliTest (fixtures) {
     });
     suiteTeardown(async function () {
       try {
-        await rm(tmpDir, { recursive: true });
+        // await rm(tmpDir, { recursive: true });
       }
       catch {}
     });
 
     teardown(async function () {
       try {
-        await rm(outDir, { recursive: true });
-        await rm(outFile);
+        // await rm(outDir, { recursive: true });
+        // await rm(outFile);
       }
       catch {}
     });
@@ -245,6 +245,7 @@ export async function cliTest (fixtures) {
       await writeFile(`${outDir}/package.json`, JSON.stringify({ type: 'module' }));
       const m = await import(`${pathToFileURL(outDir)}/componentize.js`);
       strictEqual(m.hello(), 'world');
+      // strictEqual(m.consumeBar(m.createBar()), 'bar1');
     });
   });
 }

--- a/test/fixtures/componentize/source.js
+++ b/test/fixtures/componentize/source.js
@@ -1,3 +1,23 @@
+class Bar {
+  constructor (name) {
+    this.name = name;
+  }
+}
+
+export const foo = {
+  Bar
+};
+
+let idx = 1;
+
+export function createBar () {
+  return new Bar('bar' + idx++);
+}
+
+export function consumeBar (bar) {
+  return bar.name;
+}
+
 export function hello () {
   return 'world';
 }

--- a/test/fixtures/componentize/source.wit
+++ b/test/fixtures/componentize/source.wit
@@ -1,5 +1,13 @@
 package local:test;
 
+interface foo {
+  resource bar {}
+}
+
 world test {
+  use foo.{bar};
+  export create-bar: func() -> bar;
+  export consume-bar: func(bar: bar) -> string;
+
   export hello: func() -> string;
 }


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/jco/issues/337 as described in https://github.com/bytecodealliance/jco/issues/337#issuecomment-1894471068 where own resources passed back into components defining those resources are still fully maintained in the handle table.