### PR TITLE
feat: add --multi-memory flag

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,8 +63,13 @@ jobs:
     - name: Build
       run: npm run build
 
-    - name: Test
+    - name: Test LTS Node.js
+      run: npm run test:lts
+      if: matrix.node == '18.x' || matrix.node == '20.x'
+
+    - name: Test Latest Node.js
       run: npm run test
+      if: matrix.node == 'latest'
 
     - name: WASI Preview 2 Conformance
       run: cargo test

--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -67,6 +67,7 @@ impl Guest for JsComponentBindgenComponent {
             valid_lifting_optimization: options.valid_lifting_optimization.unwrap_or(false),
             tracing: options.tracing.unwrap_or(false),
             no_namespaced_exports: options.no_namespaced_exports.unwrap_or(false),
+            multi_memory: options.multi_memory.unwrap_or(false),
         };
 
         let js_component_bindgen::Transpiled {
@@ -133,6 +134,7 @@ impl Guest for JsComponentBindgenComponent {
             base64_cutoff: 0,
             tracing: false,
             no_namespaced_exports: false,
+            multi_memory: false,
         };
 
         let files = generate_types(name, resolve, world, opts).map_err(|e| e.to_string())?;

--- a/crates/js-component-bindgen-component/wit/js-component-bindgen.wit
+++ b/crates/js-component-bindgen-component/wit/js-component-bindgen.wit
@@ -48,6 +48,10 @@ world js-component-bindgen {
     /// Whether to generate namespaced exports like `foo as "local:package/foo"`.
     /// These exports can break typescript builds.
     no-namespaced-exports: option<bool>,
+
+    /// Whether to output core Wasm utilizing multi-memory or to polyfill
+    /// this handling.
+    multi-memory: option<bool>,
   }
 
   variant wit {

--- a/crates/js-component-bindgen/src/core.rs
+++ b/crates/js-component-bindgen/src/core.rs
@@ -81,7 +81,10 @@ pub enum AugmentedOp {
 }
 
 impl<'a> Translation<'a> {
-    pub fn new(translation: ModuleTranslation<'a>) -> Result<Translation<'a>> {
+    pub fn new(translation: ModuleTranslation<'a>, multi_memory: bool) -> Result<Translation<'a>> {
+        if multi_memory {
+            return Ok(Translation::Normal(translation));
+        }
         let mut features = WasmFeatures {
             multi_memory: false,
             ..Default::default()

--- a/crates/js-component-bindgen/src/lib.rs
+++ b/crates/js-component-bindgen/src/lib.rs
@@ -126,7 +126,7 @@ pub fn transpile(component: &[u8], opts: TranspileOpts) -> Result<Transpiled, an
 
     let modules: PrimaryMap<StaticModuleIndex, core::Translation<'_>> = modules
         .into_iter()
-        .map(|(_i, module)| core::Translation::new(module))
+        .map(|(_i, module)| core::Translation::new(module, opts.multi_memory))
         .collect::<Result<_>>()?;
 
     let types = types.finish();

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -71,6 +71,9 @@ pub struct TranspileOpts {
     /// Whether to generate namespaced exports like `foo as "local:package/foo"`.
     /// These exports can break typescript builds.
     pub no_namespaced_exports: bool,
+    /// Whether to output core Wasm utilizing multi-memory or to polyfill
+    /// this handling.
+    pub multi_memory: bool,
 }
 
 #[derive(Default, Clone, Debug)]

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "build:release": "cargo xtask build release",
     "build:types:preview2-shim": "cargo xtask generate wasi-types",
     "lint": "eslint -c eslintrc.cjs lib/**/*.js packages/*/lib/**/*.js",
-    "test": "mocha -u tdd test/test.js --timeout 120000",
+    "test": "node --experimental-wasm-multi-memory node_modules/mocha/bin/mocha.js -u tdd test/test.js --timeout 30000",
     "prepublishOnly": "cargo xtask build release && npm run test"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "build:release": "cargo xtask build release",
     "build:types:preview2-shim": "cargo xtask generate wasi-types",
     "lint": "eslint -c eslintrc.cjs lib/**/*.js packages/*/lib/**/*.js",
+    "test:lts": "mocha -u tdd test/test.js --timeout 30000",
     "test": "node --experimental-wasm-multi-memory node_modules/mocha/bin/mocha.js -u tdd test/test.js --timeout 30000",
     "prepublishOnly": "cargo xtask build release && npm run test"
   },

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -90,6 +90,7 @@ async function wasm2Js (source) {
  *   minify?: bool,
  *   optimize?: bool,
  *   namespacedExports?: bool,
+ *   multiMemory?: bool,
  *   optArgs?: string[],
  * }} opts
  * @returns {Promise<{ files: { [filename: string]: Uint8Array }, imports: string[], exports: [string, 'function' | 'instance'][] }>}
@@ -139,6 +140,7 @@ export async function transpileComponent (component, opts = {}) {
     tlaCompat: opts.tlaCompat ?? false,
     base64Cutoff: opts.js ? 0 : opts.base64Cutoff ?? 5000,
     noNamespacedExports: opts.namespacedExports === false,
+    multiMemory: opts.multiMemory === true,
   });
 
   let outDir = (opts.outDir ?? '').replace(/\\/g, '/');

--- a/src/jco.js
+++ b/src/jco.js
@@ -49,6 +49,7 @@ program.command('transpile')
   .addOption(new Option('-I, --instantiation [mode]', 'output for custom module instantiation').choices(['async', 'sync']).preset('async'))
   .option('-q, --quiet', 'disable logging')
   .option('--no-namespaced-exports', 'disable namespaced exports for typescript compatibility')
+  .option('--multi-memory', 'optimized output for Wasm multi-memory')
   .option('--', 'for --optimize, custom wasm-opt arguments (defaults to best size optimization)')
   .action(asyncAction(transpile));
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -44,7 +44,7 @@ export async function cliTest (fixtures) {
     });
 
     test('Transcoding', async () => {
-      const { stderr } = await exec(jcoPath, 'transpile', `test/fixtures/env-allow.composed.wasm`, '-o', outDir);
+      const { stderr } = await exec(jcoPath, 'transpile', `test/fixtures/env-allow.composed.wasm`, '--multi-memory', '-o', outDir);
       strictEqual(stderr, '');
       await writeFile(`${outDir}/package.json`, JSON.stringify({ type: 'module' }));
       const source = await readFile(`${outDir}/env-allow.composed.js`);

--- a/test/cli.js
+++ b/test/cli.js
@@ -11,9 +11,11 @@ import { fileURLToPath, pathToFileURL } from "url";
 import { exec, jcoPath } from "./helpers.js";
 import { tmpdir, EOL } from "node:os";
 import { resolve, normalize, sep } from "node:path";
+import { execArgv } from "node:process";
 
-const multiMemory =
-  Number(process.versions.node.split(".")[0]) >= 21 && false ? ["--multi-memory"] : [];
+const multiMemory = execArgv.includes("--experimental-wasm-multi-memory")
+  ? ["--multi-memory"]
+  : [];
 
 export async function cliTest(fixtures) {
   suite("CLI", () => {

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,250 +1,437 @@
-import { deepStrictEqual, ok, strictEqual } from 'node:assert';
-import { mkdir, readFile, rm, symlink, writeFile, mkdtemp } from 'node:fs/promises';
-import { fileURLToPath, pathToFileURL } from 'url';
-import { exec, jcoPath } from './helpers.js';
-import { tmpdir, EOL } from 'node:os';
-import { resolve, normalize, sep } from 'node:path';
+import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import {
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+  mkdtemp,
+} from "node:fs/promises";
+import { fileURLToPath, pathToFileURL } from "url";
+import { exec, jcoPath } from "./helpers.js";
+import { tmpdir, EOL } from "node:os";
+import { resolve, normalize, sep } from "node:path";
 
-export async function cliTest (fixtures) {
-  suite('CLI', () => {
+const multiMemory =
+  Number(process.versions.node.split(".")[0]) >= 21 && false ? ["--multi-memory"] : [];
+
+export async function cliTest(fixtures) {
+  suite("CLI", () => {
     /**
      * Securely creates a temporary directory and returns its path.
      *
      * The new directory is created using `fsPromises.mkdtemp()`.
      */
-    async function getTmpDir () {
+    async function getTmpDir() {
       return await mkdtemp(normalize(tmpdir() + sep));
     }
 
     var tmpDir;
     var outDir;
     var outFile;
-    suiteSetup(async function() {
+    suiteSetup(async function () {
       tmpDir = await getTmpDir();
-      outDir = resolve(tmpDir, 'out-component-dir');
-      outFile = resolve(tmpDir, 'out-component-file');
+      outDir = resolve(tmpDir, "out-component-dir");
+      outFile = resolve(tmpDir, "out-component-file");
 
-      const modulesDir = resolve(tmpDir, 'node_modules', '@bytecodealliance');
+      const modulesDir = resolve(tmpDir, "node_modules", "@bytecodealliance");
       await mkdir(modulesDir, { recursive: true });
-      await symlink(fileURLToPath(new URL('../packages/preview2-shim', import.meta.url)), resolve(modulesDir, 'preview2-shim'), 'dir');
+      await symlink(
+        fileURLToPath(new URL("../packages/preview2-shim", import.meta.url)),
+        resolve(modulesDir, "preview2-shim"),
+        "dir"
+      );
     });
     suiteTeardown(async function () {
       try {
         await rm(tmpDir, { recursive: true });
-      }
-      catch {}
+      } catch {}
     });
 
     teardown(async function () {
       try {
         await rm(outDir, { recursive: true });
         await rm(outFile);
-      }
-      catch {}
+      } catch {}
     });
 
-    test('Transcoding', async () => {
-      const { stderr } = await exec(jcoPath, 'transpile', `test/fixtures/env-allow.composed.wasm`, '--multi-memory', '-o', outDir);
-      strictEqual(stderr, '');
-      await writeFile(`${outDir}/package.json`, JSON.stringify({ type: 'module' }));
+    test("Transcoding", async () => {
+      const { stderr } = await exec(
+        jcoPath,
+        "transpile",
+        `test/fixtures/env-allow.composed.wasm`,
+        ...multiMemory,
+        "-o",
+        outDir
+      );
+      strictEqual(stderr, "");
+      await writeFile(
+        `${outDir}/package.json`,
+        JSON.stringify({ type: "module" })
+      );
       const source = await readFile(`${outDir}/env-allow.composed.js`);
       const m = await import(`${pathToFileURL(outDir)}/env-allow.composed.js`);
-      deepStrictEqual(m.testGetEnv(), [['CUSTOM', 'VAL']]);
+      deepStrictEqual(m.testGetEnv(), [["CUSTOM", "VAL"]]);
     });
 
-    test('Transpile', async () => {
-      const name = 'flavorful';
-      const { stderr } = await exec(jcoPath, 'transpile', `test/fixtures/components/${name}.component.wasm`, '--no-wasi-shim', '--name', name, '-o', outDir);
-      strictEqual(stderr, '');
+    test("Transpile", async () => {
+      const name = "flavorful";
+      const { stderr } = await exec(
+        jcoPath,
+        "transpile",
+        `test/fixtures/components/${name}.component.wasm`,
+        "--no-wasi-shim",
+        "--name",
+        name,
+        "-o",
+        outDir
+      );
+      strictEqual(stderr, "");
       const source = await readFile(`${outDir}/${name}.js`);
-      ok(source.toString().includes('export { test'));
+      ok(source.toString().includes("export { test"));
     });
 
-    test('Transpile & Optimize & Minify', async () => {
-      const name = 'flavorful';
-      const { stderr } = await exec(jcoPath, 'transpile', `test/fixtures/components/${name}.component.wasm`, '--name', name, '--valid-lifting-optimization', '--tla-compat', '--optimize', '--minify', '--base64-cutoff=0', '-o', outDir);
-      strictEqual(stderr, '');
+    test("Transpile & Optimize & Minify", async () => {
+      const name = "flavorful";
+      const { stderr } = await exec(
+        jcoPath,
+        "transpile",
+        `test/fixtures/components/${name}.component.wasm`,
+        "--name",
+        name,
+        "--valid-lifting-optimization",
+        "--tla-compat",
+        "--optimize",
+        "--minify",
+        "--base64-cutoff=0",
+        "-o",
+        outDir
+      );
+      strictEqual(stderr, "");
       const source = await readFile(`${outDir}/${name}.js`);
-      ok(source.toString().includes('as test,'));
+      ok(source.toString().includes("as test,"));
     });
 
-    test('Transpile with tracing', async () => {
-      const name = 'flavorful';
-      const { stderr } = await exec(jcoPath, 'transpile', `test/fixtures/components/${name}.component.wasm`, '--name', name, '--map', 'testwasi=./wasi.js', '--tracing', '--base64-cutoff=0', '-o', outDir);
-      strictEqual(stderr, '');
-      const source = await readFile(`${outDir}/${name}.js`, 'utf8');
-      ok(source.includes('function toResultString('));
-      ok(source.includes('console.error(`[module="test:flavorful/test", function="f-list-in-record1"] call a'));
-      ok(source.includes('console.error(`[module="test:flavorful/test", function="list-of-variants"] return result=${toResultString(ret)}`);'));
+    test("Transpile with tracing", async () => {
+      const name = "flavorful";
+      const { stderr } = await exec(
+        jcoPath,
+        "transpile",
+        `test/fixtures/components/${name}.component.wasm`,
+        "--name",
+        name,
+        "--map",
+        "testwasi=./wasi.js",
+        "--tracing",
+        "--base64-cutoff=0",
+        "-o",
+        outDir
+      );
+      strictEqual(stderr, "");
+      const source = await readFile(`${outDir}/${name}.js`, "utf8");
+      ok(source.includes("function toResultString("));
+      ok(
+        source.includes(
+          'console.error(`[module="test:flavorful/test", function="f-list-in-record1"] call a'
+        )
+      );
+      ok(
+        source.includes(
+          'console.error(`[module="test:flavorful/test", function="list-of-variants"] return result=${toResultString(ret)}`);'
+        )
+      );
     });
 
-    test('TypeScript naming checks', async () => {
-      const { stderr } = await exec(jcoPath, 'transpile', `test/fixtures/wit/deps/ts-check/ts-check.wit`, '--stub', '-o', outDir);
-      strictEqual(stderr, '');
+    test("TypeScript naming checks", async () => {
+      const { stderr } = await exec(
+        jcoPath,
+        "transpile",
+        `test/fixtures/wit/deps/ts-check/ts-check.wit`,
+        "--stub",
+        "-o",
+        outDir
+      );
+      strictEqual(stderr, "");
       {
         const source = await readFile(`${outDir}/ts-check.d.ts`);
-        ok(source.toString().includes('declare function _class(): void'));
-        ok(source.toString().includes('export { _class as class }'));
+        ok(source.toString().includes("declare function _class(): void"));
+        ok(source.toString().includes("export { _class as class }"));
       }
       {
-        const source = await readFile(`${outDir}/interfaces/ts-naming-blah.d.ts`);
-        ok(source.toString().includes('declare function _class(): void'));
-        ok(source.toString().includes('export { _class as class }'));
+        const source = await readFile(
+          `${outDir}/interfaces/ts-naming-blah.d.ts`
+        );
+        ok(source.toString().includes("declare function _class(): void"));
+        ok(source.toString().includes("export { _class as class }"));
       }
     });
 
-    test('Transpile to JS', async () => {
-      const name = 'flavorful';
-      const { stderr } = await exec(jcoPath, 'transpile', `test/fixtures/components/${name}.component.wasm`, '--name', name, '--map', 'testwasi=./wasi.js', '--valid-lifting-optimization', '--tla-compat', '--js', '--base64-cutoff=0', '-o', outDir);
-      strictEqual(stderr, '');
-      const source = await readFile(`${outDir}/${name}.js`, 'utf8');
-      ok(source.includes('./wasi.js'));
-      ok(source.includes('testwasi'));
-      ok(source.includes('FUNCTION_TABLE'));
-      ok(source.includes('export {\n  $init'));
+    test("Transpile to JS", async () => {
+      const name = "flavorful";
+      const { stderr } = await exec(
+        jcoPath,
+        "transpile",
+        `test/fixtures/components/${name}.component.wasm`,
+        "--name",
+        name,
+        "--map",
+        "testwasi=./wasi.js",
+        "--valid-lifting-optimization",
+        "--tla-compat",
+        "--js",
+        "--base64-cutoff=0",
+        "-o",
+        outDir
+      );
+      strictEqual(stderr, "");
+      const source = await readFile(`${outDir}/${name}.js`, "utf8");
+      ok(source.includes("./wasi.js"));
+      ok(source.includes("testwasi"));
+      ok(source.includes("FUNCTION_TABLE"));
+      ok(source.includes("export {\n  $init"));
     });
 
-    test('Transpile without namespaced exports', async () => {
-      const name = 'flavorful';
-      const { stderr } = await exec(jcoPath, 'transpile', `test/fixtures/components/${name}.component.wasm`, '--no-namespaced-exports', '--no-wasi-shim', '--name', name, '-o', outDir);
-      strictEqual(stderr, '');
+    test("Transpile without namespaced exports", async () => {
+      const name = "flavorful";
+      const { stderr } = await exec(
+        jcoPath,
+        "transpile",
+        `test/fixtures/components/${name}.component.wasm`,
+        "--no-namespaced-exports",
+        "--no-wasi-shim",
+        "--name",
+        name,
+        "-o",
+        outDir
+      );
+      strictEqual(stderr, "");
       const source = await readFile(`${outDir}/${name}.js`);
-      const finalLine = source.toString().split("\n").at(-1)
+      const finalLine = source.toString().split("\n").at(-1);
       //Check final line is the export statement
       ok(finalLine.toString().includes("export {"));
       //Check that it does not contain the namespaced export
       ok(!finalLine.toString().includes("test:flavorful/test"));
     });
 
-    test('Transpile with namespaced exports', async () => {
-      const name = 'flavorful';
-      const { stderr } = await exec(jcoPath, 'transpile', `test/fixtures/components/${name}.component.wasm`, '--no-wasi-shim', '--name', name, '-o', outDir);
-      strictEqual(stderr, '');
+    test("Transpile with namespaced exports", async () => {
+      const name = "flavorful";
+      const { stderr } = await exec(
+        jcoPath,
+        "transpile",
+        `test/fixtures/components/${name}.component.wasm`,
+        "--no-wasi-shim",
+        "--name",
+        name,
+        "-o",
+        outDir
+      );
+      strictEqual(stderr, "");
       const source = await readFile(`${outDir}/${name}.js`);
-      const finalLine = source.toString().split("\n").at(-1)
+      const finalLine = source.toString().split("\n").at(-1);
       //Check final line is the export statement
       ok(finalLine.toString().includes("export {"));
       //Check that it does contain the namespaced export
       ok(finalLine.toString().includes("test as 'test:flavorful/test'"));
     });
 
-    test('Optimize', async () => {
-      const component = await readFile(`test/fixtures/components/flavorful.component.wasm`);
-      const { stderr, stdout } = await exec(jcoPath, 'opt', `test/fixtures/components/flavorful.component.wasm`, '-o', outFile);
-      strictEqual(stderr, '');
-      ok(stdout.includes('Core Module 1:'));
+    test("Optimize", async () => {
+      const component = await readFile(
+        `test/fixtures/components/flavorful.component.wasm`
+      );
+      const { stderr, stdout } = await exec(
+        jcoPath,
+        "opt",
+        `test/fixtures/components/flavorful.component.wasm`,
+        "-o",
+        outFile
+      );
+      strictEqual(stderr, "");
+      ok(stdout.includes("Core Module 1:"));
       const optimizedComponent = await readFile(outFile);
       ok(optimizedComponent.byteLength < component.byteLength);
     });
 
-    test('Print & Parse', async () => {
-      const { stderr, stdout } = await exec(jcoPath, 'print', `test/fixtures/components/flavorful.component.wasm`);
-      strictEqual(stderr, '');
-      strictEqual(stdout.slice(0, 10), '(component');
+    test("Print & Parse", async () => {
+      const { stderr, stdout } = await exec(
+        jcoPath,
+        "print",
+        `test/fixtures/components/flavorful.component.wasm`
+      );
+      strictEqual(stderr, "");
+      strictEqual(stdout.slice(0, 10), "(component");
       {
-        const { stderr, stdout } = await exec(jcoPath, 'print', `test/fixtures/components/flavorful.component.wasm`, '-o', outFile);
-        strictEqual(stderr, '');
-        strictEqual(stdout, '');
+        const { stderr, stdout } = await exec(
+          jcoPath,
+          "print",
+          `test/fixtures/components/flavorful.component.wasm`,
+          "-o",
+          outFile
+        );
+        strictEqual(stderr, "");
+        strictEqual(stdout, "");
       }
       {
-        const { stderr, stdout } = await exec(jcoPath, 'parse', outFile, '-o', outFile);
-        strictEqual(stderr, '');
-        strictEqual(stdout, '');
+        const { stderr, stdout } = await exec(
+          jcoPath,
+          "parse",
+          outFile,
+          "-o",
+          outFile
+        );
+        strictEqual(stderr, "");
+        strictEqual(stdout, "");
         ok(await readFile(outFile));
       }
     });
 
-    test('Wit shadowing stub test', async () => {
-      const { stderr, stdout } = await exec(jcoPath, 'transpile', `test/fixtures/wit/deps/app/app.wit`, '-o', outDir, '--stub');
-      strictEqual(stderr, '');
+    test("Wit shadowing stub test", async () => {
+      const { stderr, stdout } = await exec(
+        jcoPath,
+        "transpile",
+        `test/fixtures/wit/deps/app/app.wit`,
+        "-o",
+        outDir,
+        "--stub"
+      );
+      strictEqual(stderr, "");
       const source = await readFile(`${outDir}/app.js`);
-      ok(source.includes('class PString$1{'));
+      ok(source.includes("class PString$1{"));
     });
 
-    test('Wit & New', async () => {
-      const { stderr, stdout } = await exec(jcoPath, 'wit', `test/fixtures/components/flavorful.component.wasm`);
-      strictEqual(stderr, '');
-      ok(stdout.includes('world root {'));
+    test("Wit & New", async () => {
+      const { stderr, stdout } = await exec(
+        jcoPath,
+        "wit",
+        `test/fixtures/components/flavorful.component.wasm`
+      );
+      strictEqual(stderr, "");
+      ok(stdout.includes("world root {"));
 
       {
-        const { stderr, stdout } = await exec(jcoPath, 'embed', '--dummy', '--wit', 'test/fixtures/wit/deps/flavorful/flavorful.wit', '-m', 'language=javascript', '-m', 'processed-by=dummy-gen@test', '-o', outFile);
-        strictEqual(stderr, '');
-        strictEqual(stdout, '');
+        const { stderr, stdout } = await exec(
+          jcoPath,
+          "embed",
+          "--dummy",
+          "--wit",
+          "test/fixtures/wit/deps/flavorful/flavorful.wit",
+          "-m",
+          "language=javascript",
+          "-m",
+          "processed-by=dummy-gen@test",
+          "-o",
+          outFile
+        );
+        strictEqual(stderr, "");
+        strictEqual(stdout, "");
       }
 
       {
-        const { stderr, stdout } = await exec(jcoPath, 'print', outFile);
-        strictEqual(stderr, '');
-        strictEqual(stdout.slice(0, 7), '(module');
+        const { stderr, stdout } = await exec(jcoPath, "print", outFile);
+        strictEqual(stderr, "");
+        strictEqual(stdout.slice(0, 7), "(module");
       }
       {
-        const { stderr, stdout } = await exec(jcoPath, 'new', outFile, '-o', outFile);
-        strictEqual(stderr, '');
-        strictEqual(stdout, '');
+        const { stderr, stdout } = await exec(
+          jcoPath,
+          "new",
+          outFile,
+          "-o",
+          outFile
+        );
+        strictEqual(stderr, "");
+        strictEqual(stdout, "");
       }
       {
-        const { stderr, stdout } = await exec(jcoPath, 'print', outFile);
-        strictEqual(stderr, '');
-        strictEqual(stdout.slice(0, 10), '(component');
+        const { stderr, stdout } = await exec(jcoPath, "print", outFile);
+        strictEqual(stderr, "");
+        strictEqual(stdout.slice(0, 10), "(component");
       }
       {
-        const { stdout, stderr } = await exec(jcoPath, 'metadata-show', outFile, '--json');
-        strictEqual(stderr, '');
+        const { stdout, stderr } = await exec(
+          jcoPath,
+          "metadata-show",
+          outFile,
+          "--json"
+        );
+        strictEqual(stderr, "");
         const meta = JSON.parse(stdout);
-        deepStrictEqual(meta[0].metaType, { tag: 'component', val: 4 });
+        deepStrictEqual(meta[0].metaType, { tag: "component", val: 4 });
         deepStrictEqual(meta[1].producers, [
-          ['processed-by', [['wit-component', '0.20.0'], ['dummy-gen', 'test']]],
-          ['language', [['javascript', '']]],
+          [
+            "processed-by",
+            [
+              ["wit-component", "0.20.0"],
+              ["dummy-gen", "test"],
+            ],
+          ],
+          ["language", [["javascript", ""]]],
         ]);
       }
     });
 
-    test('Component new adapt', async () => {
-      const { stderr } = await exec(jcoPath,
-          'new',
-          'test/fixtures/modules/exitcode.wasm',
-          '--wasi-reactor',
-          '-o', outFile);
-      strictEqual(stderr, '');
+    test("Component new adapt", async () => {
+      const { stderr } = await exec(
+        jcoPath,
+        "new",
+        "test/fixtures/modules/exitcode.wasm",
+        "--wasi-reactor",
+        "-o",
+        outFile
+      );
+      strictEqual(stderr, "");
       {
-        const { stderr, stdout } = await exec(jcoPath, 'print', outFile);
-        strictEqual(stderr, '');
-        strictEqual(stdout.slice(0, 10), '(component');
+        const { stderr, stdout } = await exec(jcoPath, "print", outFile);
+        strictEqual(stderr, "");
+        strictEqual(stdout.slice(0, 10), "(component");
       }
     });
 
-    test('Extract metadata', async () => {
-      const { stdout, stderr } = await exec(jcoPath,
-          'metadata-show',
-          'test/fixtures/modules/exitcode.wasm',
-          '--json');
-      strictEqual(stderr, '');
-      deepStrictEqual(JSON.parse(stdout), [{
-        metaType: { tag: 'module' },
-        producers: [],
-        range: [
-          0,
-          262
-        ]
-      }]);
+    test("Extract metadata", async () => {
+      const { stdout, stderr } = await exec(
+        jcoPath,
+        "metadata-show",
+        "test/fixtures/modules/exitcode.wasm",
+        "--json"
+      );
+      strictEqual(stderr, "");
+      deepStrictEqual(JSON.parse(stdout), [
+        {
+          metaType: { tag: "module" },
+          producers: [],
+          range: [0, 262],
+        },
+      ]);
     });
 
-    test('Componentize', async () => {
-      const { stdout, stderr } = await exec(jcoPath,
-          'componentize',
-          'test/fixtures/componentize/source.js',
-          '-w',
-          'test/fixtures/componentize/source.wit',
-          '-o',
-          outFile);
-      strictEqual(stderr, '');
+    test("Componentize", async () => {
+      const { stdout, stderr } = await exec(
+        jcoPath,
+        "componentize",
+        "test/fixtures/componentize/source.js",
+        "-w",
+        "test/fixtures/componentize/source.wit",
+        "-o",
+        outFile
+      );
+      strictEqual(stderr, "");
       {
-        const { stderr } = await exec(jcoPath, 'transpile', outFile, '--name', 'componentize', '-o', outDir);
-        strictEqual(stderr, '');
+        const { stderr } = await exec(
+          jcoPath,
+          "transpile",
+          outFile,
+          "--name",
+          "componentize",
+          "-o",
+          outDir
+        );
+        strictEqual(stderr, "");
       }
-      await writeFile(`${outDir}/package.json`, JSON.stringify({ type: 'module' }));
+      await writeFile(
+        `${outDir}/package.json`,
+        JSON.stringify({ type: "module" })
+      );
       const m = await import(`${pathToFileURL(outDir)}/componentize.js`);
-      strictEqual(m.hello(), 'world');
+      strictEqual(m.hello(), "world");
       // strictEqual(m.consumeBar(m.createBar()), 'bar1');
     });
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -6,7 +6,7 @@ export const jcoPath = 'src/jco.js';
 export async function exec (cmd, ...args) {
   let stdout = '', stderr = '';
   await new Promise((resolve, reject) => {
-    const cp = spawn(argv[0], ['--no-warnings', cmd, ...args], { stdio: 'pipe' });
+    const cp = spawn(argv[0], ['--no-warnings', '--experimental-wasm-multi-memory', cmd, ...args], { stdio: 'pipe' });
     cp.stdout.on('data', chunk => {
       stdout += chunk;
     });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { argv } from "node:process";
+import { argv, execArgv } from "node:process";
 
 export const jcoPath = "src/jco.js";
 const multiMemory =
@@ -13,7 +13,7 @@ export async function exec(cmd, ...args) {
   await new Promise((resolve, reject) => {
     const cp = spawn(
       argv[0],
-      ["--no-warnings", "--experimental-wasm-multi-memory", cmd, ...args],
+      ["--no-warnings", ...execArgv, cmd, ...args],
       { stdio: "pipe" }
     );
     cp.stdout.on("data", (chunk) => {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,20 +1,31 @@
-import { spawn } from 'node:child_process';
-import { argv } from 'node:process';
+import { spawn } from "node:child_process";
+import { argv } from "node:process";
 
-export const jcoPath = 'src/jco.js';
+export const jcoPath = "src/jco.js";
+const multiMemory =
+  Number(process.versions.node.split(".")[0]) >= 21
+    ? ["--experimental-wasm-multi-memory"]
+    : [];
 
-export async function exec (cmd, ...args) {
-  let stdout = '', stderr = '';
+export async function exec(cmd, ...args) {
+  let stdout = "",
+    stderr = "";
   await new Promise((resolve, reject) => {
-    const cp = spawn(argv[0], ['--no-warnings', '--experimental-wasm-multi-memory', cmd, ...args], { stdio: 'pipe' });
-    cp.stdout.on('data', chunk => {
+    const cp = spawn(
+      argv[0],
+      ["--no-warnings", "--experimental-wasm-multi-memory", cmd, ...args],
+      { stdio: "pipe" }
+    );
+    cp.stdout.on("data", (chunk) => {
       stdout += chunk;
     });
-    cp.stderr.on('data', chunk => {
+    cp.stderr.on("data", (chunk) => {
       stderr += chunk;
     });
-    cp.on('error', reject);
-    cp.on('exit', code => code === 0 ? resolve() : reject(new Error((stderr || stdout).toString())));
+    cp.on("error", reject);
+    cp.on("exit", (code) =>
+      code === 0 ? resolve() : reject(new Error((stderr || stdout).toString()))
+    );
   });
   return { stdout, stderr };
 }

--- a/xtask/src/build/jco.rs
+++ b/xtask/src/build/jco.rs
@@ -67,6 +67,7 @@ fn transpile(component_path: &str, name: String) -> Result<()> {
         valid_lifting_optimization: false,
         tracing: false,
         no_namespaced_exports: true,
+        multi_memory: true,
     };
 
     let transpiled = js_component_bindgen::transpile(&adapted_component, opts)?;

--- a/xtask/src/generate/wasi_types.rs
+++ b/xtask/src/generate/wasi_types.rs
@@ -36,6 +36,7 @@ pub(crate) fn run() -> Result<()> {
             base64_cutoff: 0,
             tracing: false,
             no_namespaced_exports: true,
+            multi_memory: false,
         };
 
         let files = generate_types(name, resolve, world, opts)?;


### PR DESCRIPTION
Adds a `--multi-memory` flag to JCO transpile to disable the multi memory polyfill.

Resolves https://github.com/bytecodealliance/jco/issues/356.