### PR TITLE
fix: generated default arg WebAssembly.Instance needs to be called as constructor

### DIFF
--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -245,7 +245,7 @@ impl<'a> JsBindgen<'a> {
                     output,
                     "\
                         {}
-                        export function instantiate(getCoreModule, imports, instantiateCore = WebAssembly.Instance) {{
+                        export function instantiate(getCoreModule, imports, instantiateCore = (module, importObject) => new WebAssembly.Instance(module, importObject)) {{
                             {}
                     ",
                     &js_intrinsics as &str,


### PR DESCRIPTION
The current default parameter does not work. When running the generated code one gets:
```
    new WebAssembly.Instance,
    ^

TypeError: WebAssembly.Instance(): Argument 0 must be a WebAssembly.Module
```