### PR TITLE
fixes for `deno` compatibility

### DIFF
--- a/packages/preview2-shim/lib/io/worker-io.js
+++ b/packages/preview2-shim/lib/io/worker-io.js
@@ -33,7 +33,10 @@ import {
   STDOUT,
   reverseMap,
 } from "./calls.js";
-import { _rawDebug, exit, stderr, stdout, env } from "node:process";
+import { exit, stderr, stdout, env } from "node:process";
+
+import * as nodeProcess from "node:process";
+const _rawDebug = nodeProcess._rawDebug || console.error.bind(console);
 
 const workerPath = fileURLToPath(
   new URL("./worker-thread.js", import.meta.url)

--- a/packages/preview2-shim/lib/io/worker-socket-tcp.js
+++ b/packages/preview2-shim/lib/io/worker-socket-tcp.js
@@ -8,6 +8,7 @@ import {
   pollStateReady,
   verifyPollsDroppedForDrop,
 } from "./worker-thread.js";
+import process from "node:process";
 const { TCP, constants: TCPConstants } = process.binding("tcp_wrap");
 import {
   convertSocketError,

--- a/packages/preview2-shim/lib/io/worker-thread.js
+++ b/packages/preview2-shim/lib/io/worker-thread.js
@@ -147,6 +147,7 @@ import {
   socketUdpStream,
   udpSockets,
 } from "./worker-socket-udp.js";
+import process from "node:process";
 
 function log(msg) {
   if (debug) process._rawDebug(msg);

--- a/packages/preview2-shim/lib/nodejs/filesystem.js
+++ b/packages/preview2-shim/lib/nodejs/filesystem.js
@@ -17,7 +17,6 @@ import {
   futimesSync,
   linkSync,
   lstatSync,
-  lutimesSync,
   mkdirSync,
   opendirSync,
   openSync,
@@ -32,6 +31,9 @@ import {
   writeSync,
 } from "node:fs";
 import { platform } from "node:process";
+
+import * as nodeFs from 'node:fs';
+const lutimesSync = nodeFs.lutimesSync;
 
 const symbolDispose = Symbol.dispose || Symbol.for("dispose");
 
@@ -297,6 +299,9 @@ class Descriptor {
       dataModificationTimestamp.tag === "no-change" &&
         stats.dataModificationTimestamp
     );
+    if (!pathFlags.symlinkFollow && !lutimesSync){
+      throw new Error("Changing the timestamps of symlinks isn't supported");
+    }
     try {
       (pathFlags.symlinkFollow ? utimesSync : lutimesSync)(
         fullPath,

--- a/packages/preview2-shim/lib/nodejs/http.js
+++ b/packages/preview2-shim/lib/nodejs/http.js
@@ -21,8 +21,11 @@ import {
   registerDispose,
   registerIncomingHttpHandler,
 } from "../io/worker-io.js";
-import { validateHeaderName, validateHeaderValue } from "node:http";
+// import { validateHeaderName, validateHeaderValue } from "node:http";
 import { HTTP } from "../io/calls.js";
+
+function validateHeaderName(_name){}
+function validateHeaderValue(_name, _value){}
 
 const symbolDispose = Symbol.dispose || Symbol.for("dispose");
 export const _forbiddenHeaders = new Set(["connection", "keep-alive"]);

--- a/packages/preview2-shim/lib/nodejs/http.js
+++ b/packages/preview2-shim/lib/nodejs/http.js
@@ -21,11 +21,10 @@ import {
   registerDispose,
   registerIncomingHttpHandler,
 } from "../io/worker-io.js";
-// import { validateHeaderName, validateHeaderValue } from "node:http";
 import { HTTP } from "../io/calls.js";
 
-function validateHeaderName(_name){}
-function validateHeaderValue(_name, _value){}
+import * as http from "node:http";
+const { validateHeaderName = () => {}, validateHeaderValue = () => {} } = http;
 
 const symbolDispose = Symbol.dispose || Symbol.for("dispose");
 export const _forbiddenHeaders = new Set(["connection", "keep-alive"]);

--- a/packages/preview2-shim/lib/synckit/index.js
+++ b/packages/preview2-shim/lib/synckit/index.js
@@ -87,7 +87,7 @@ export function createSyncFn(workerPath, debug, callbackHandler) {
     }
     return result;
   };
-  // worker.unref();
+  if (worker.unref) worker.unref();
   return syncFn;
 }
 

--- a/packages/preview2-shim/lib/synckit/index.js
+++ b/packages/preview2-shim/lib/synckit/index.js
@@ -87,7 +87,7 @@ export function createSyncFn(workerPath, debug, callbackHandler) {
     }
     return result;
   };
-  worker.unref();
+  // worker.unref();
   return syncFn;
 }
 


### PR DESCRIPTION
Just a first draft PR to feed the CI pipeline, because local testing doesn't work on my machine.

Fixes: #385

Warning! -- there are important parts missing/untested!

* `validateHeaderName` and `validateHeaderValue` are temporary replaced by dummy entries.

  This should be better fixed on the `deno` side (see: https://github.com/denoland/deno/issues/22614).

 * The `worker_thread.unref()` case is still uttery unsolved and just temporary removed.