### PR TITLE
feat: slab implementation for resource tables

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -45,8 +45,8 @@ pub enum ResourceData {
 ///
 /// For a given resource id {x}, the local variables are assumed:
 /// - handleTable{x}
-/// - captureTable{x}
-/// - captureCnt{x}
+/// - captureTable{x} (only for imported tables)
+/// - captureCnt{x} (only for imported tables)
 ///
 /// For component-defined resources:
 /// - finalizationRegistry{x}

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1216,12 +1216,12 @@ impl Bindgen for FunctionBindgen<'_> {
                                     self.src,
                                     "finalizationRegistry{id}.register({rsc}, {handle}, {rsc});
                                     Object.defineProperty({rsc}, {symbol_dispose}, {{ writable: true, value: function () {{{}}} }});
-                                    handleTable{id}.take({handle});
+                                    handleTable{id}.remove({handle});
                                     ",
                                     match dtor_name {
                                         Some(dtor) => format!("
                                             finalizationRegistry{id}.unregister({rsc});
-                                            handleTable{id}.take({handle});
+                                            handleTable{id}.remove({handle});
                                             {rsc}[{symbol_dispose}] = {empty_func};
                                             {rsc}[{symbol_resource_handle}] = null;
                                             {dtor}({rep});
@@ -1243,7 +1243,7 @@ impl Bindgen for FunctionBindgen<'_> {
                             if is_own {
                                 uwriteln!(
                                     self.src,
-                                    "captureTable{id}.delete(handleTable{id}.take({handle}).rep);"
+                                    "captureTable{id}.delete(handleTable{id}.remove({handle}).rep);"
                                 );
                             }
                         }

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1351,15 +1351,13 @@ impl Bindgen for FunctionBindgen<'_> {
                             }
                         } else {
                             // imported resources are always given a unique handle
-                            let rep = format!("rep{}", self.tmp());
                             uwriteln!(
                                 self.src,
                                 "if (!({op} instanceof {local_name})) {{
                                      throw new Error('Resource error: Not a valid \"{class_name}\" resource.');
                                  }}
-                                 var {rep} = ++captureCnt{id};
-                                 captureTable{id}.set({rep}, {op});
-                                 var {handle} = handleTable{id}.create{}({rep});
+                                 captureTable{id}.set(++captureCnt{id}, {op});
+                                 var {handle} = handleTable{id}.create{}(captureCnt{id});
                                  ",
                                  if is_own { "Own" } else { "Borrow" }
                             );

--- a/crates/js-component-bindgen/src/intrinsics.rs
+++ b/crates/js-component-bindgen/src/intrinsics.rs
@@ -195,9 +195,9 @@ pub fn render_intrinsics(
             // 
             // # Resource table slab implementation
             // 
-            // To correspond to a fixed "SMI" array in JS engines, a fixed contiguous array of u32s
-            // in the browser engine for performance. We don't use a typed array because we need
-            // resizability without reserving a large buffer.
+            // Resource table slab implementation on top of a fixed "SMI" array in JS engines,
+            // a fixed contiguous array of u32s, for performance. We don't use a typed array because
+            // we need resizability without reserving a large buffer.
             //
             // The flag bit for all data values is 1 << 30. We avoid the use of the highest bit
             // entirely to not trigger SMI deoptimization.
@@ -273,6 +273,15 @@ pub fn render_intrinsics(
                         const own = (val & T_FLAG) !== 0;
                         const rep = val & ~T_FLAG;
                         if (rep === 0 || (scope & T_FLAG) !== 0) throw new Error('Invalid handle');
+                        return {{ rep, scope, own }};
+                    }}
+                    tryGet(handle) {{
+                        const scope = this.table[handle << 1];
+                        const val = this.table[(handle << 1) + 1];
+                        const own = (val & T_FLAG) !== 0;
+                        const rep = val & ~T_FLAG;
+                        if (rep === 0 || (scope & T_FLAG) !== 0)
+                            return;
                         return {{ rep, scope, own }};
                     }}
                     remove(handle) {{

--- a/crates/js-component-bindgen/src/intrinsics.rs
+++ b/crates/js-component-bindgen/src/intrinsics.rs
@@ -305,7 +305,7 @@ pub fn render_intrinsics(
 
             Intrinsic::ThrowUninitialized => output.push_str("
                 function throwUninitialized() {
-                    throw new TypeError('Wasm uninitialized use `await $init` first');
+                    throw new Error('Wasm uninitialized use `await $init` first');
                 }
             "),
 

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -585,14 +585,15 @@ impl<'a> Instantiator<'a, '_> {
                 };
 
             let handle_tables = self.gen.intrinsic(Intrinsic::HandleTables);
-            let resource_table = self.gen.intrinsic(Intrinsic::ResourceTable);
+            let rsc_table_flag = self.gen.intrinsic(Intrinsic::ResourceTableFlag);
+            let rsc_table_remove = self.gen.intrinsic(Intrinsic::ResourceTableRemove);
 
             if is_imported {
                 // imported resouces have both a rep table and a rep assignment
                 // for captured resource classes to assign them a rep numbering
                 uwriteln!(
                     self.src.js,
-                    "const handleTable{rid} = new {resource_table}();
+                    "const handleTable{rid} = [{rsc_table_flag}, 0];
                     const captureTable{rid} = new Map();
                     let captureCnt{rid} = 0;
                     {handle_tables}.set({rid}, {{ t: handleTable{rid}, i: captureTable{rid}.get.bind(captureTable{rid}) }});",
@@ -600,9 +601,9 @@ impl<'a> Instantiator<'a, '_> {
             } else {
                 uwriteln!(
                     self.src.js,
-                    "const handleTable{rid} = new {resource_table}();
+                    "const handleTable{rid} = [{rsc_table_flag}, 0];
                     const finalizationRegistry{rid} = new FinalizationRegistry((handle) => {{
-                        const {{ rep }} = handleTable{rid}.remove(handle);{maybe_dtor}
+                        const {{ rep }} = {rsc_table_remove}(handleTable{rid}, handle);{maybe_dtor}
                     }});
                     {handle_tables}.set({rid}, {{ t: handleTable{rid}, i: null }});
                     ",
@@ -701,17 +702,19 @@ impl<'a> Instantiator<'a, '_> {
             Trampoline::ResourceNew(resource) => {
                 self.ensure_resource_table(*resource);
                 let rid = resource.as_u32();
+                let rsc_table_create_own = self.gen.intrinsic(Intrinsic::ResourceTableCreateOwn);
                 uwriteln!(
                     self.src.js,
-                    "const trampoline{i} = handleTable{rid}.createOwn.bind(handleTable{rid});"
+                    "const trampoline{i} = {rsc_table_create_own}.bind(null, handleTable{rid});"
                 );
             }
             Trampoline::ResourceRep(resource) => {
                 self.ensure_resource_table(*resource);
                 let rid = resource.as_u32();
+                let rsc_table_get = self.gen.intrinsic(Intrinsic::ResourceTableGet);
                 uwriteln!(
                     self.src.js,
-                    "const trampoline{i} = handleTable{rid}.get.bind(handleTable{rid});"
+                    "const trampoline{i} = {rsc_table_get}.bind(null, handleTable{rid});"
                 );
             }
             Trampoline::ResourceDrop(resource) => {
@@ -747,10 +750,11 @@ impl<'a> Instantiator<'a, '_> {
                     )
                 };
 
+                let rsc_table_remove = self.gen.intrinsic(Intrinsic::ResourceTableRemove);
                 uwrite!(
                     self.src.js,
                     "function trampoline{i}(handle) {{
-                        const handleEntry = handleTable{rid}.remove(handle);
+                        const handleEntry = {rsc_table_remove}(handleTable{rid}, handle);
                         if (!handleEntry.own) throw new Error('Unexpected borrow handle');
                         {dtor}
                     }}
@@ -772,38 +776,30 @@ impl<'a> Instantiator<'a, '_> {
                 uwriteln!(self.src.js, "const trampoline{i} = {resource_transfer};");
             }
             Trampoline::ResourceEnterCall => {
-                // Resource enter call does not do anything in Jco as all the logic is handled
-                // by exit call based on the invariant that resourceCallBorrows should always
-                // be an empty array here.
-                let empty_func = self.gen.intrinsic(Intrinsic::EmptyFunc);
+                let scope_id = self.gen.intrinsic(Intrinsic::ScopeId);
                 uwrite!(
                     self.src.js,
-                    "const trampoline{i} = {empty_func};
+                    "function trampoline{i}() {{
+                        {scope_id}++;
+                    }}
                     ",
                 );
             }
             Trampoline::ResourceExitCall => {
-                // Resource exit call is responsible for handling dynamic borrow drop checks
-                // for transferred resources (disabled for valid_lifting_optimization).
-                if self.gen.opts.valid_lifting_optimization {
-                    let empty_func = self.gen.intrinsic(Intrinsic::EmptyFunc);
-                    uwrite!(
-                        self.src.js,
-                        "const trampoline{i} = {empty_func};
-                        ",
-                    );
-                    return;
-                }
+                let scope_id = self.gen.intrinsic(Intrinsic::ScopeId);
                 let resource_borrows = self.gen.intrinsic(Intrinsic::ResourceCallBorrows);
                 let handle_tables = self.gen.intrinsic(Intrinsic::HandleTables);
+                let rsc_table_try_get = self.gen.intrinsic(Intrinsic::ResourceTableCreateOwn);
                 uwrite!(
                     self.src.js,
                     "function trampoline{i}() {{
-                        for (const {{ rid, handle, rep }} of {resource_borrows}) {{
-                            if ({handle_tables}.get(rid).tryGet(handle)?.rep === rep)
+                        for (const {{ rid, handle, rep, scope }} of {resource_borrows}) {{
+                            const entry = {rsc_table_try_get}({handle_tables}.get(rid), handle);
+                            if (entry && entry.rep === rep && entry.scope === scope)
                                 throw new Error('borrow was not dropped for resource transfer call');
                         }}
                         {resource_borrows} = [];
+                        {scope_id}--;
                     }}
                     ",
                 );

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -747,8 +747,10 @@ impl<'a> Instantiator<'a, '_> {
                     // resources when the resource is dropped
                     let symbol_dispose = self.gen.intrinsic(Intrinsic::SymbolDispose);
                     format!(
-                        "if (handleEntry.own && handleEntry.rep[{symbol_dispose}]) {{
-                            handleEntry.rep[{symbol_dispose}]();
+                        "if (handleEntry.own) {{
+                            const rsc = captureTable{rid}.get(handleEntry.rep);
+                            if (rsc[{symbol_dispose}]) rsc[{symbol_dispose}]();
+                            captureTable{rid}.delete(handleEntry.rep);
                         }}"
                     )
                 };
@@ -757,9 +759,6 @@ impl<'a> Instantiator<'a, '_> {
                     self.src.js,
                     "function trampoline{i}(handle) {{
                         const handleEntry = handleTable{rid}.take(handle);
-                        if (handleEntry.own) {{
-                            captureTable{rid}.delete(handleEntry.rep);
-                        }}
                         {dtor}
                     }}
                     ",

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -799,8 +799,8 @@ impl<'a> Instantiator<'a, '_> {
                 uwrite!(
                     self.src.js,
                     "function trampoline{i}() {{
-                        for (const {{ rid, handle }} of {resource_borrows}) {{
-                            if ({handle_tables}.get(rid).has(handle))
+                        for (const {{ rid, handle, rep }} of {resource_borrows}) {{
+                            if ({handle_tables}.get(rid).tryGet(handle)?.rep === rep)
                                 throw new Error('borrow was not dropped for resource transfer call');
                         }}
                         {resource_borrows} = [];

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -602,7 +602,7 @@ impl<'a> Instantiator<'a, '_> {
                     self.src.js,
                     "const handleTable{rid} = new {resource_table}();
                     const finalizationRegistry{rid} = new FinalizationRegistry((handle) => {{
-                        const {{ rep }} = handleTable{rid}.take(handle);{maybe_dtor}
+                        const {{ rep }} = handleTable{rid}.remove(handle);{maybe_dtor}
                     }});
                     {handle_tables}.set({rid}, {{ t: handleTable{rid}, i: null }});
                     ",
@@ -750,7 +750,7 @@ impl<'a> Instantiator<'a, '_> {
                 uwrite!(
                     self.src.js,
                     "function trampoline{i}(handle) {{
-                        const handleEntry = handleTable{rid}.take(handle);
+                        const handleEntry = handleTable{rid}.remove(handle);
                         if (!handleEntry.own) throw new Error('Unexpected borrow handle');
                         {dtor}
                     }}


### PR DESCRIPTION
This updates the resource tables to use a fixed sized array of numbers with a free list as a slab implementation for more optimal resource operations.

The table data structure is also designed to be used in the new low-level bindgen for optimized table operations..

Previously, we were using a non-numeric `rep` for imported resources, where instead of using a number we would just reference the JS class instance directly in this position. Now that `rep` is only numeric, this also implements a separate `captureTable` to do rep assignment for captured imported resources, while retaining the same semantics.