### PR TITLE
docs: rename preview-shim package name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ fn();
 Imports can be remapped using the `--map` flag, or to provide imports as an argument use the `--instantiation` option.
 
 Components relying on WASI bindings will contain external WASI imports, which are automatically updated
-to the `@bytecodealliance/preview-shim` package. This package can be installed from npm separately for
+to the `@bytecodealliance/preview2-shim` package. This package can be installed from npm separately for
 runtime usage. This shim layer supports both Node.js and browsers.
 
 Options include:


### PR DESCRIPTION
This commit updates the package name for the `preview-shim` package in the README.md file which I think might be a typo.