### PR TITLE
fix: timeout for betweenBytesTiemout and firstByteTimeout

### DIFF
--- a/packages/preview2-shim/lib/io/worker-http.js
+++ b/packages/preview2-shim/lib/io/worker-http.js
@@ -150,10 +150,10 @@ export async function createHttpRequest(
       req.once("close", () => reject);
       req.once("error", reject);
     });
-    if (firstByteTimeout) res.setTimeout(Number(firstByteTimeout));
+    if (firstByteTimeout) res.setTimeout(Number(firstByteTimeout / 1_000_000n));
     if (betweenBytesTimeout)
       res.once("readable", () => {
-        res.setTimeout(Number(betweenBytesTimeout));
+        res.setTimeout(Number(betweenBytesTimeout / 1_000_000n));
       });
     const bodyStreamId = createReadableStream(res);
     return {


### PR DESCRIPTION
Follow-on to https://github.com/bytecodealliance/jco/pull/408's timeout changes, fixing the granularity of `betweenBytesTimeout` and `firstByteTimeout` as well.