### PR TITLE
preview2-shim: update to 0.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "type": "module",
   "dependencies": {
-    "@bytecodealliance/preview2-shim": "0.16.0",
+    "@bytecodealliance/preview2-shim": "^0.16.1",
     "binaryen": "^116.0.0",
     "chalk-template": "^1",
     "commander": "^12",


### PR DESCRIPTION
Bumps the preview2-shim version in Jco to 0.16.1, and goes back to semver now that this is stable.