### PR TITLE
deps: update ComponentizeJS in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "terser": "^5"
   },
   "devDependencies": {
-    "@bytecodealliance/componentize-js": "^0.8.2",
+    "@bytecodealliance/componentize-js": "^0.8.3",
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "terser": "^5"
   },
   "devDependencies": {
-    "@bytecodealliance/componentize-js": "^0.8.0",
+    "@bytecodealliance/componentize-js": "^0.8.2",
     "@types/node": "^18.11.17",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",

--- a/test/cli.js
+++ b/test/cli.js
@@ -441,7 +441,7 @@ export async function cliTest(fixtures) {
       ]);
     });
 
-    (process.platform === 'win32' ? test.skip : test)("Componentize", async () => {
+    test("Componentize", async () => {
       const { stdout, stderr } = await exec(
         jcoPath,
         "componentize",

--- a/test/preview2.js
+++ b/test/preview2.js
@@ -61,7 +61,7 @@ export async function preview2Test() {
       strictEqual(stderr, "writing to stderr: hello, world\n");
     });
 
-    (process.platform === 'win32' ? test.skip : test)("wasi-http-proxy", async () => {
+    test("wasi-http-proxy", async () => {
       const server = createServer(async (req, res) => {
         if (req.url == "/api/examples") {
           res.writeHead(200, {


### PR DESCRIPTION
Updates the ComponentizeJS tests to the latest version, fixing the Windows support.