### PR TITLE
feat: conditionally support FinalizationRegistry

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics.rs
+++ b/crates/js-component-bindgen/src/intrinsics.rs
@@ -13,6 +13,7 @@ pub enum Intrinsic {
     F32ToI32,
     F64ToI64,
     FetchCompile,
+    FinalizationRegistryCreate,
     GetErrorPayload,
     GetErrorPayloadString,
     HandleTables,
@@ -141,6 +142,15 @@ pub fn render_intrinsics(
 
             Intrinsic::EmptyFunc => output.push_str("
                 const emptyFunc = () => {};
+            "),
+
+            Intrinsic::FinalizationRegistryCreate => output.push_str("
+                function finalizationRegistryCreate (unregister) {{
+                    if (typeof FinalizationRegistry === 'undefined') {{
+                        return {{ unregister () {{}} }};
+                    }}
+                    return new FinalizationRegistry(unregister);
+                }}
             "),
 
             Intrinsic::F64ToI64 => output.push_str("
@@ -585,6 +595,7 @@ impl Intrinsic {
             "f32ToI32",
             "f64ToI64",
             "fetchCompile",
+            "finalizationRegistryCreate",
             "getErrorPayload",
             "handleTables",
             "hasOwnProperty",
@@ -661,6 +672,7 @@ impl Intrinsic {
             Intrinsic::F32ToI32 => "f32ToI32",
             Intrinsic::F64ToI64 => "f64ToI64",
             Intrinsic::FetchCompile => "fetchCompile",
+            Intrinsic::FinalizationRegistryCreate => "finalizationRegistryCreate",
             Intrinsic::GetErrorPayload => "getErrorPayload",
             Intrinsic::GetErrorPayloadString => "getErrorPayloadString",
             Intrinsic::HandleTables => "handleTables",

--- a/crates/js-component-bindgen/src/intrinsics.rs
+++ b/crates/js-component-bindgen/src/intrinsics.rs
@@ -145,12 +145,12 @@ pub fn render_intrinsics(
             "),
 
             Intrinsic::FinalizationRegistryCreate => output.push_str("
-                function finalizationRegistryCreate (unregister) {{
-                    if (typeof FinalizationRegistry === 'undefined') {{
-                        return {{ unregister () {{}} }};
-                    }}
+                function finalizationRegistryCreate (unregister) {
+                    if (typeof FinalizationRegistry === 'undefined') {
+                        return { unregister () {} };
+                    }
                     return new FinalizationRegistry(unregister);
-                }}
+                }
             "),
 
             Intrinsic::F64ToI64 => output.push_str("

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -641,10 +641,12 @@ impl<'a> Instantiator<'a, '_> {
                 self.resources_initialized[resource] = true;
             }
         } else {
+            let finalization_registry_create =
+                self.gen.intrinsic(Intrinsic::FinalizationRegistryCreate);
             uwriteln!(
                 self.src.js,
                 "const handleTable{rtid} = [{rsc_table_flag}, 0];
-                const finalizationRegistry{rtid} = new FinalizationRegistry((handle) => {{
+                const finalizationRegistry{rtid} = {finalization_registry_create}((handle) => {{
                     const {{ rep }} = {rsc_table_remove}(handleTable{rtid}, handle);{maybe_dtor}
                 }});
                 ",


### PR DESCRIPTION
In JS environments that do not support the `FinalizationRegistry`, this conditionally checks that it exists without assuming it when integrating into resource GC disposal.