### PR TITLE
Add support for generating types from a `wit` directory

### DIFF
--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -117,17 +117,25 @@ impl Guest for JsComponentBindgenComponent {
         opts: TypeGenerationOptions,
     ) -> Result<Vec<(String, Vec<u8>)>, String> {
         let mut resolve = Resolve::default();
-        let pkg = match opts.wit {
+        let id = match opts.wit {
             Wit::Source(source) => {
-                UnresolvedPackage::parse(&PathBuf::from(format!("{name}.wit")), &source)
-                    .map_err(|e| e.to_string())?
+                let pkg = UnresolvedPackage::parse(&PathBuf::from(format!("{name}.wit")), &source)
+                    .map_err(|e| e.to_string())?;
+                resolve.push(pkg).map_err(|e| e.to_string())?
             }
             Wit::Path(path) => {
-                UnresolvedPackage::parse_file(&PathBuf::from(path)).map_err(|e| e.to_string())?
+                let pkg = UnresolvedPackage::parse_file(&PathBuf::from(path))
+                    .map_err(|e| e.to_string())?;
+                resolve.push(pkg).map_err(|e| e.to_string())?
+            }
+            Wit::Dir(path) => {
+                resolve
+                    .push_dir(&PathBuf::from(path))
+                    .map_err(|e| e.to_string())?
+                    .0
             }
             Wit::Binary(_) => todo!(),
         };
-        let id = resolve.push(pkg).map_err(|e| e.to_string())?;
 
         let world_string = opts.world.map(|world| world.to_string());
         let world = resolve

--- a/crates/js-component-bindgen-component/wit/js-component-bindgen.wit
+++ b/crates/js-component-bindgen-component/wit/js-component-bindgen.wit
@@ -71,6 +71,8 @@ world js-component-bindgen {
     binary(list<u8>),
     /// wit is provided from a filesystem path
     path(string),
+    /// wit is provided from a directory path
+    dir(string),
   }
 
   record type-generation-options {


### PR DESCRIPTION
We use jco to generate TypeScript interface from WIT definitions by using `obj/js-component-bindgen-component.js`. Exposing the ability to generate types from directory would allow us to manage our WIT in multiple files.