### PR TITLE
Don't need to check for non-zero resource rep

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics.rs
+++ b/crates/js-component-bindgen/src/intrinsics.rs
@@ -280,7 +280,6 @@ pub fn render_intrinsics(
 
             Intrinsic::ResourceTableCreateBorrow => output.push_str("
                 function rscTableCreateBorrow (table, rep) {
-                    if (rep === 0) throw new TypeError('Invalid rep');
                     const free = table[0] & ~T_FLAG;
                     if (free === 0) {
                         table.push(scopeId);
@@ -296,7 +295,6 @@ pub fn render_intrinsics(
 
             Intrinsic::ResourceTableCreateOwn => output.push_str("
                 function rscTableCreateOwn (table, rep) {
-                    if (rep === 0) throw new TypeError('Invalid rep');
                     const free = table[0] & ~T_FLAG;
                     if (free === 0) {
                         table.push(0);


### PR DESCRIPTION
Handle 0 is reserved for the sentinel value, but resource rep can be 0 IIUC

> Upon initialization, table element 0 is allocated and set to None, effectively
> reserving index 0 which is both useful for catching null/uninitialized
> accesses and allowing 0 to serve as a sentinel value.
> https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#runtime-state