### PR TITLE
Fix syntax error with defined intrinsics

### DIFF
--- a/test/commands.js
+++ b/test/commands.js
@@ -3,6 +3,8 @@ import { readdirSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { exec, jcoPath } from "./helpers.js";
 
+const DEBUG = false;
+
 const tests = JSON.parse(readFileSync('test/fixtures/commands/tests.json', 'utf8'));
 
 export async function commandsTest() {
@@ -14,6 +16,7 @@ export async function commandsTest() {
         const { stdout, stderr } = await exec(
           jcoPath,
           "run",
+          ...DEBUG ? ["--jco-dir", `test/output/commands/${fixture}`] : [],
           resolve("test/fixtures/commands", fixture),
           ...(tests[runName]?.args || [])
         );


### PR DESCRIPTION
Fixes a syntax error in not closing the statement correctly when outputting `definedResourceTables`.

We need a new output source to define the concept of defined intrinsics, which is now carried through properly to ensure scoping in all instantiation outputs.

Resolves https://github.com/bytecodealliance/jco/issues/436.