### PR TITLE
fix: isolate runtime states per component instance

### DIFF
--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -261,9 +261,9 @@ impl<'a> JsBindgen<'a> {
                 uwrite!(
                     output,
                     "\
-                        {}
-                        {}
                         export async function instantiate(getCoreModule, imports, instantiateCore = WebAssembly.instantiate) {{
+                            {}
+                            {}
                             {}
                     ",
                     &js_intrinsics as &str,
@@ -276,9 +276,9 @@ impl<'a> JsBindgen<'a> {
                 uwrite!(
                     output,
                     "\
-                        {}
-                        {}
                         export function instantiate(getCoreModule, imports, instantiateCore = (module, importObject) => new WebAssembly.Instance(module, importObject)) {{
+                            {}
+                            {}
                             {}
                     ",
                     &js_intrinsics as &str,


### PR DESCRIPTION
Thanks to no-reentrancy of CM, we can safely share the runtime state within a component instantiation closure. However, we cannot share the state across different component instances created by different `instantiate` calls.

This commit fixes the issue by moving all the runtime states under the `instantiate` scope.