### PR TITLE
translate errno=-4094 errors to "no-such-device" on Windows

### DIFF
--- a/packages/preview2-shim/lib/nodejs/filesystem.js
+++ b/packages/preview2-shim/lib/nodejs/filesystem.js
@@ -700,6 +700,13 @@ function convertFsError(e) {
       return "text-file-busy";
     case "EXDEV":
       return "cross-device";
+    case "UNKNOWN":
+      switch (e.errno) {
+        case -4094:
+          return "no-such-device";
+        default:
+          throw e;
+      }
     default:
       throw e;
   }


### PR DESCRIPTION
When an application attempts to open a non-existent path such as `//foo/bar/baz` on Windows, Node generates an error of the form:

```
{
  errno: -4094,
  syscall: 'open',
  code: 'UNKNOWN',
  path: '//foo/bar/baz'
}
```

Prior to this commit, that error would be re-thrown, causing Wasm execution to trap.  Now we convert it to a "no-such-device" error instead.