### PR TITLE
Fix definedResourceTables ReferenceError with instantiation mode

### DIFF
--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -260,17 +260,17 @@ impl<'a> JsBindgen<'a> {
             uwrite!(
                 output,
                 "\
-                    {}
                     export function instantiate(getCoreModule, imports, instantiateCore = {}) {{
                         {}
                         {}
+                        {}
                 ",
-                &js_intrinsics as &str,
                 match instantiation {
                     InstantiationMode::Async => "WebAssembly.instantiate",
                     InstantiationMode::Sync =>
                         "(module, importObject) => new WebAssembly.Instance(module, importObject)",
                 },
+                &js_intrinsics as &str,
                 &intrinsic_definitions as &str,
                 &compilation_promises as &str,
             );


### PR DESCRIPTION
The `js_instrinsics` should be defined under the `instantiate` function. Otherwise we get the following error:

```
dist/component/ruby.component.js:73
  if (definedResourceTables[toTid]) return rep;
  ^

ReferenceError: definedResourceTables is not defined
```

https://github.com/ruby/ruby.wasm/actions/runs/9708747430/job/26796119275?pr=479#step:14:302