### PR TITLE
Update Outdated Docs

### DIFF
--- a/docs/src/example.md
+++ b/docs/src/example.md
@@ -96,8 +96,6 @@ $ jco componentize cowsay.js --wit cowsay.wit -o cowsay.wasm
 OK Successfully written cowsay.wasm with imports ().
 ```
 
-> Note: For debugging, it is useful to pass `--enable-stdout` to ComponentizeJS to get error messages and enable `console.log`.
-
 ### Inspecting Component WIT
 
 As a first step, we might like to look instead this binary black box of a Component and see what it actually does.


### PR DESCRIPTION
This removes the reference to `--enable-stdout`, which isn't a CLI option since around `1.2.0`.

W/ this said, it looks like `--enable-stdout` was removed when `--disable-features` was added. Does that imply `stdout` is now enabled by default? I was trying to test that out and couldn't get `console.log` to work. Submitted an issue to discuss it here: https://github.com/bytecodealliance/jco/issues/457 .

