### PR TITLE
fix: TypeScript types

### DIFF
--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -119,7 +119,7 @@ async function wasm2Js (source) {
  * @param {{
  *   name: string,
  *   instantiation?: 'async' | 'sync',
- *   importBindings?: 'js' | 'optimized', 'hybrid', 'direct-optimized',
+ *   importBindings?: 'js' | 'optimized' | 'hybrid' | 'direct-optimized',
  *   map?: Record<string, string>,
  *   validLiftingOptimization?: bool,
  *   tracing?: bool,


### PR DESCRIPTION
Fixes the jsdoc type definition, resolving https://github.com/bytecodealliance/jco/issues/462.