### PR TITLE
Update package-lock.json by `npm install`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@bytecodealliance/jco",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bytecodealliance/jco",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "(Apache-2.0 WITH LLVM-exception)",
       "workspaces": [
         "packages/preview2-shim"
       ],
       "dependencies": {
-        "@bytecodealliance/preview2-shim": "^0.16.3",
+        "@bytecodealliance/preview2-shim": "^0.16.4",
         "binaryen": "^116.0.0",
         "chalk-template": "^1",
         "commander": "^12",
@@ -2785,7 +2785,8 @@
       }
     },
     "packages/preview2-shim": {
-      "version": "0.16.3",
+      "name": "@bytecodealliance/preview2-shim",
+      "version": "0.16.4",
       "license": "(Apache-2.0 WITH LLVM-exception)",
       "devDependencies": {
         "mocha": "^10.2.0"


### PR DESCRIPTION
The inconsistent lock file lead `npm ci` fails when vendoring jco as submodule