### PR TITLE
Fix: `getCoreModule` type for async `instantiate`

### DIFF
--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -254,7 +254,7 @@ pub fn ts_bindgen(
                         instantiateCore?: (module: WebAssembly.Module, imports: Record<string, any>) => WebAssembly.Instance
                     ): {camel};
                     export function instantiate(
-                        getCoreModule: (path: string) => WebAssembly.Module,
+                        getCoreModule: (path: string) => WebAssembly.Module | Promise<WebAssembly.Module>,
                         imports: ImportObject,
                         instantiateCore?: (module: WebAssembly.Module, imports: Record<string, any>) => WebAssembly.Instance | Promise<WebAssembly.Instance>
                     ): {camel} | Promise<{camel}>;


### PR DESCRIPTION
Fixes https://github.com/bytecodealliance/jco/issues/472

In async mode, `getCoreModule` should have `Promise<WebAssembly.Module>` return type.