### PR TITLE
fix: ComponentizeJS bindgen bug

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1142,7 +1142,6 @@ impl Bindgen for FunctionBindgen<'_> {
                                     drop(rsc[{symbol_resource_handle}]);
                                     delete rsc[{symbol_resource_handle}];
                                 }}
-                                {cur_resource_borrows}[i][{symbol_resource_handle}] = null;
                             }}
                             {cur_resource_borrows} = [];"
                         );


### PR DESCRIPTION
This fixes a bug with ComponentizeJS bindgen on the Jco upgrade path for it.