### PR TITLE
fix: Wrap lists in Array to handle optional types

### DIFF
--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -638,8 +638,9 @@ impl<'a> TsInterface<'a> {
             Some("Uint8Array") => self.src.push_str("Uint8Array"),
             Some(ty) => self.src.push_str(ty),
             None => {
+                self.src.push_str("Array<");
                 self.print_ty(ty);
-                self.src.push_str("[]");
+                self.src.push_str(">");
             }
         }
     }

--- a/test/fixtures/wits/issue-480/issue-480.wit
+++ b/test/fixtures/wits/issue-480/issue-480.wit
@@ -1,0 +1,15 @@
+package test:issue;
+
+interface types {
+  variant value {
+    foo,
+    bar,
+    baz
+  }
+
+  foobarbaz: func() -> list<option<value>>;
+}
+
+world issue {
+  import types;
+}

--- a/test/typescript.js
+++ b/test/typescript.js
@@ -49,5 +49,29 @@ export function tsTest() {
         )
       );
     });
+
+    test(`TS types`, async () => {
+      const component = await componentNew(
+        await componentEmbed({
+          witSource: await readFile(
+            `test/fixtures/wits/issue-480/issue-480.wit`,
+            "utf8"
+          ),
+          dummy: true,
+        }),
+      );
+
+      const { files } = await transpile(component, { name: "issue" });
+
+      const dtsSource = new TextDecoder().decode(
+        files["interfaces/test-issue-types.d.ts"]
+      );
+
+      ok(
+        dtsSource.includes(
+          `export function foobarbaz(): Array<Value | undefined>;`
+        )
+      );
+    });
   });
 }


### PR DESCRIPTION
Closes #480 

This changes the types generated for a WIT `list` to use `Array<>` syntax, which allows for something like `option<foo>` to be expanded to `foo | undefined` without generating the wrong type signature. Using `Array<>` also avoids the need to wrapping too much stuff in parens.