### PR TITLE
fix: post-return on error return bindgen

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1155,8 +1155,7 @@ impl Bindgen for FunctionBindgen<'_> {
                     if let Some(f) = &self.post_return {
                         uwriteln!(self.src, "{f}();");
                     }
-                }
-                else if *amt == 1 && self.err == ErrHandling::ThrowResultErr {
+                } else if *amt == 1 && self.err == ErrHandling::ThrowResultErr {
                     let component_err = self.intrinsic(Intrinsic::ComponentError);
                     let op = &operands[0];
                     uwriteln!(self.src, "const retVal = {op}.val;");

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1158,16 +1158,16 @@ impl Bindgen for FunctionBindgen<'_> {
                 } else if *amt == 1 && self.err == ErrHandling::ThrowResultErr {
                     let component_err = self.intrinsic(Intrinsic::ComponentError);
                     let op = &operands[0];
-                    uwriteln!(self.src, "const retVal = {op}.val;");
+                    uwriteln!(self.src, "const retVal = {op};");
                     if let Some(f) = &self.post_return {
                         uwriteln!(self.src, "{f}(ret);");
                     }
                     uwriteln!(
                         self.src,
-                        "if (typeof {op} === 'object' && {op}.tag === 'err') {{
-                            throw new {component_err}(retVal);
+                        "if (typeof retVal === 'object' && retVal.tag === 'err') {{
+                            throw new {component_err}(retVal.val);
                         }}
-                        return retVal;"
+                        return retVal.val;"
                     );
                 } else {
                     let ret_assign = if self.post_return.is_some() {

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1153,38 +1153,41 @@ impl Bindgen for FunctionBindgen<'_> {
             Instruction::Return { amt, .. } => {
                 if *amt == 0 {
                     if let Some(f) = &self.post_return {
-                        uwriteln!(self.src, "{f}()");
+                        uwriteln!(self.src, "{f}();");
                     }
-                    return;
                 }
-                let ret_assign = if self.post_return.is_some() {
-                    "const retVal ="
-                } else {
-                    "return"
-                };
-                if *amt == 1 {
-                    if self.err == ErrHandling::ThrowResultErr {
-                        let component_err = self.intrinsic(Intrinsic::ComponentError);
-                        let op = &operands[0];
-                        uwriteln!(
-                            self.src,
-                            "if (typeof {op} === 'object' && {op}.tag === 'err') {{
-                                throw new {component_err}({op}.val);
-                            }}
-                            {ret_assign} {op}.val;"
-                        );
-                    } else {
-                        uwriteln!(self.src, "{ret_assign} {};", operands[0]);
+                else if *amt == 1 && self.err == ErrHandling::ThrowResultErr {
+                    let component_err = self.intrinsic(Intrinsic::ComponentError);
+                    let op = &operands[0];
+                    uwriteln!(self.src, "const retVal = {op}.val;");
+                    if let Some(f) = &self.post_return {
+                        uwriteln!(self.src, "{f}(ret);");
                     }
-                } else {
-                    uwriteln!(self.src, "{ret_assign} [{}];", operands.join(", "));
-                }
-                if let Some(f) = &self.post_return {
                     uwriteln!(
                         self.src,
-                        "{f}(ret);
+                        "if (typeof {op} === 'object' && {op}.tag === 'err') {{
+                            throw new {component_err}(retVal);
+                        }}
                         return retVal;"
                     );
+                } else {
+                    let ret_assign = if self.post_return.is_some() {
+                        "const retVal ="
+                    } else {
+                        "return"
+                    };
+                    if *amt == 1 {
+                        uwriteln!(self.src, "{ret_assign} {};", operands[0]);
+                    } else {
+                        uwriteln!(self.src, "{ret_assign} [{}];", operands.join(", "));
+                    }
+                    if let Some(f) = &self.post_return {
+                        uwriteln!(
+                            self.src,
+                            "{f}(ret);
+                            return retVal;"
+                        );
+                    }
                 }
             }
 

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -1307,13 +1307,6 @@ impl<'a> Instantiator<'a, '_> {
             // mapping can be used to construct virtual nested namespaces
             // which is used eg to support WASI interface groupings
             if let Some(iface_member) = iface_member {
-                // if local_name.starts_with("Poll") {
-                //     dbg!( &[
-                //         &import_specifier,
-                //         &iface_member.to_lower_camel_case(),
-                //         &import_binding.as_ref().unwrap().to_string(),
-                //     ], &local_name);
-                // }
                 self.gen.esm_bindgen.add_import_binding(
                     &[
                         import_specifier,


### PR DESCRIPTION
This fixes another issue with error returns in the new post-return handling following https://github.com/bytecodealliance/jco/pull/487 and https://github.com/bytecodealliance/jco/pull/489 (again caught and tested through ComponentizeJS test suite, and another reason to upstream it here).