### PR TITLE
use `require.resolve` shim instead of hard-coded paths

### DIFF
--- a/src/cmd/opt.js
+++ b/src/cmd/opt.js
@@ -6,13 +6,6 @@ import c from 'chalk-template';
 import { readFile, sizeStr, fixedDigitDisplay, table, spawnIOTmp, setShowSpinner, getShowSpinner } from '../common.js';
 import ora from '#ora';
 
-let WASM_OPT;
-try {
-  WASM_OPT = fileURLToPath(new URL('../../node_modules/binaryen/bin/wasm-opt', import.meta.url));
-} catch {
-  WASM_OPT = new URL('../../node_modules/binaryen/bin/wasm-opt', import.meta.url);
-}
-
 export async function opt (componentPath, opts, program) {
   await $init;
   const varIdx = program.parent.rawArgs.indexOf('--');
@@ -139,9 +132,11 @@ export async function optimizeComponent (componentBytes, opts) {
  * @param {Uint8Array} source 
  * @returns {Promise<Uint8Array>}
  */
-async function wasmOpt (source, args = ['-O1', '--low-memory-unused', '--enable-bulk-memory']) {
+async function wasmOpt(source, args = ['-O1', '--low-memory-unused', '--enable-bulk-memory']) {
+  const wasmOptPath = fileURLToPath(import.meta.resolve('binaryen/bin/wasm-opt'));
+
   try {
-    return await spawnIOTmp(WASM_OPT, source, [
+    return await spawnIOTmp(wasmOptPath, source, [
       ...args, '-o'
     ]);
   } catch (e) {

--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -85,9 +85,9 @@ async function runComponent (componentPath, args, opts, executor) {
 
     await writeFile(resolve(outDir, 'package.json'), JSON.stringify({ type: 'module' }));
 
-    let preview2ShimPath
+    let preview2ShimPath;
     try {
-      preview2ShimPath = fileURLToPath(new URL('../..', import.meta.resolve('@bytecodealliance/preview2-shim')));
+      preview2ShimPath = resolve(fileURLToPath(import.meta.resolve('@bytecodealliance/preview2-shim')), '../../../');
     } catch {
       throw c`Unable to locate the {bold @bytecodealliance/preview2-shim} package, make sure it is installed.`;
     }

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -102,20 +102,15 @@ export async function transpile (componentPath, opts, program) {
   await writeFiles(files, opts.quiet ? false : 'Transpiled JS Component Files');
 }
 
-let WASM_2_JS;
-try {
-  WASM_2_JS = fileURLToPath(new URL('../../node_modules/binaryen/bin/wasm2js', import.meta.url));
-} catch {
-  WASM_2_JS = new URL('../../node_modules/binaryen/bin/wasm2js', import.meta.url);
-}
-
 /**
  * @param {Uint8Array} source
  * @returns {Promise<Uint8Array>}
  */
 async function wasm2Js (source) {
+  const wasm2jsPath = fileURLToPath(import.meta.resolve('binaryen/bin/wasm2js'));
+
   try {
-    return await spawnIOTmp(WASM_2_JS, source, ['-Oz', '-o']);
+    return await spawnIOTmp(wasm2jsPath, source, ['-Oz', '-o']);
   } catch (e) {
     if (e.toString().includes('BasicBlock requested'))
       return wasm2Js(source);


### PR DESCRIPTION
the existing hard-coded paths fail when the project is installed/ran via a source/git dependency, instead of `npx`, because `jco`'s own dependencies are installed in parent `node_modules` directories.

This change reuses NodeJS's own resolution mechanism to find the correct paths directly, without having to hardcode them, which should work everywhere.

---

NOTE: there are two tests failing, because (I suspect) they are using a custom directory layout that doesn't follow `node_modules/*`. I wasn't able yet to figure out how they are set up, and I want to make sure this is the right change first.

Please let me know if you have any suggestions.
