### PR TITLE
fix: pass open flags to getChildEntry in statAt

### DIFF
--- a/packages/preview2-shim/lib/browser/filesystem.js
+++ b/packages/preview2-shim/lib/browser/filesystem.js
@@ -198,7 +198,7 @@ class Descriptor {
   }
   
   statAt(_pathFlags, path) {
-    const entry = getChildEntry(this.#entry, path);
+    const entry = getChildEntry(this.#entry, path, { create: false, directory: false });
     let type = 'unknown', size = BigInt(0);
     if (entry.source) {
       type = 'regular-file';


### PR DESCRIPTION
Otherwise, we get the following error:

```
filesystem.js:44 Uncaught TypeError: Cannot read properties of undefined (reading 'create')
    at getChildEntry (filesystem.js:44:47)
    at Descriptor.statAt (filesystem.js:201:19)
    at trampoline75 (ruby.js:1430:38)
    at wit-component:shim.indirect-wasi:filesystem/types@0.2.0-[method]descriptor.stat-at (ruby.core106.wasm:0x1e1)
```