### PR TITLE
Set `/` as the default initial working directory for browser p2 shim

### DIFF
--- a/packages/preview2-shim/lib/browser/cli.js
+++ b/packages/preview2-shim/lib/browser/cli.js
@@ -4,7 +4,7 @@ const { InputStream, OutputStream } = streams;
 
 const symbolDispose = Symbol.dispose ?? Symbol.for('dispose');
 
-let _env = [], _args = [], _cwd = null;
+let _env = [], _args = [], _cwd = "/";
 export function _setEnv (envObj) {
   _env = Object.entries(envObj);
 }

--- a/packages/preview2-shim/lib/browser/filesystem.js
+++ b/packages/preview2-shim/lib/browser/filesystem.js
@@ -3,7 +3,7 @@ import { environment } from './cli.js';
 
 const { InputStream, OutputStream } = streams;
 
-let _cwd = null;
+let _cwd = "/";
 
 export function _setCwd (cwd) {
   _cwd = cwd;


### PR DESCRIPTION
Close https://github.com/bytecodealliance/jco/issues/497

I'll try to make time to set up more test suites for the browser shim, but for now, just make it work with ruby.