### PR TITLE
Fix hidden exception in `runNext`

### DIFF
--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -316,7 +316,7 @@ impl<'a> JsBindgen<'a> {
                                     ({{ value, done }} = gen.next(value));
                                 }} while (!(value instanceof Promise) && !done);
                                 if (done) {{
-                                    if (resolve) resolve(value);
+                                    if (resolve) return resolve(value);
                                     else return value;
                                 }}
                                 if (!promise) promise = new Promise((_resolve, _reject) => (resolve = _resolve, reject = _reject));


### PR DESCRIPTION
Abscence of return causes a hidden exception, which is handled by `catch` block and then passed to the `reject` callback while promise is already resolved

`TypeError: Cannot read properties of undefined (reading 'then')`
at:
```js
value.then(nextVal => done ? resolve() : runNext(nextVal), reject);
   // ^
```

You can reproduce it by following this [guide](https://component-model.bytecodealliance.org/language-support/javascript.html#running-a-component-from-javascript-applications) and running wasm component in nodejs with this handler (and yeah, "multipleResolves" event is [deprecated](https://github.com/nodejs/node/issues/41554) but it's the only way I know of to observe this bug)
```js
process.on('multipleResolves', (...args) =>{
  console.log('multipleResolves', args)
})
```

