### PR TITLE
chore(deps): use published version of webidl2wit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,6 +187,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -263,7 +272,7 @@ dependencies = [
  "wasmtime-environ",
  "wit-bindgen-core",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.220.0",
 ]
 
 [[package]]
@@ -650,7 +659,7 @@ dependencies = [
  "wat",
  "wit-bindgen",
  "wit-component",
- "wit-parser",
+ "wit-parser 0.220.0",
 ]
 
 [[package]]
@@ -769,13 +778,16 @@ dependencies = [
 [[package]]
 name = "webidl2wit"
 version = "0.1.0"
-source = "git+https://github.com/wasi-gfx/webidl2wit?rev=9cf1e53c5393e02e4b5ecc437012caf23ef1002f#9cf1e53c5393e02e4b5ecc437012caf23ef1002f"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5b1ccfd70bb63fe9733d3a65a47dbbc5511fb229a1c8e4ab637f0a366b7cf09"
 dependencies = [
  "anyhow",
+ "hashlink",
  "heck 0.5.0",
  "itertools",
  "weedle",
- "wit-encoder",
+ "wit-encoder 0.221.2",
+ "wit-parser 0.221.2",
 ]
 
 [[package]]
@@ -909,7 +921,7 @@ checksum = "b632a5a0fa2409489bd49c9e6d99fcc61bb3d4ce9d1907d44662e75a28c71172"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser",
+ "wit-parser 0.220.0",
 ]
 
 [[package]]
@@ -969,7 +981,7 @@ dependencies = [
  "wasm-metadata",
  "wasmparser 0.220.0",
  "wat",
- "wit-parser",
+ "wit-parser 0.220.0",
 ]
 
 [[package]]
@@ -981,6 +993,16 @@ dependencies = [
  "pretty_assertions",
  "semver",
  "serde",
+]
+
+[[package]]
+name = "wit-encoder"
+version = "0.221.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c2921dd7e71ae11b6e28b33d42cc0eed4fa6ad3fe3ed1f9c5df80dacfec6a28"
+dependencies = [
+ "pretty_assertions",
+ "semver",
 ]
 
 [[package]]
@@ -999,6 +1021,20 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser 0.220.0",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.221.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbe1538eea6ea5ddbe5defd0dc82539ad7ba751e1631e9185d24a931f0a5adc8"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1027,7 +1063,7 @@ dependencies = [
  "webidl2wit",
  "weedle",
  "wit-component",
- "wit-encoder",
+ "wit-encoder 0.214.0",
  "xshell",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ wasmtime-environ = { version = "29.0.0", features = [
     "compile",
 ] }
 wat = "1.220.0"
+webidl2wit = "0.1.0"
 wit-bindgen = "0.36.0"
 wit-bindgen-core = "0.36.0"
 wit-component = { version = "0.220.0", features = ["dummy-module"] }

--- a/crates/js-component-bindgen/src/core.rs
+++ b/crates/js-component-bindgen/src/core.rs
@@ -39,7 +39,6 @@
 use anyhow::{bail, Result};
 use std::collections::{HashMap, HashSet};
 use wasm_encoder::*;
-use wasmparser::collections::IndexMap;
 use wasmparser::*;
 use wasmtime_environ::component::CoreDef;
 use wasmtime_environ::{EntityIndex, MemoryIndex, ModuleTranslation, PrimaryMap};

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,7 +9,7 @@ anyhow = { workspace = true }
 js-component-bindgen = { workspace = true }
 semver = "1.0.23"
 structopt = { workspace = true }
-webidl2wit = { git = "https://github.com/wasi-gfx/webidl2wit", rev = "9cf1e53c5393e02e4b5ecc437012caf23ef1002f" }
+webidl2wit = { workspace = true }
 weedle = "0.13.0"
 wit-component = { workspace = true }
 wit-encoder = "0.214.0"

--- a/xtask/src/generate/webidl_tests.rs
+++ b/xtask/src/generate/webidl_tests.rs
@@ -6,7 +6,6 @@ use std::{
 use anyhow::Result;
 
 use webidl2wit::{webidl_to_wit, ConversionOptions, HandleUnsupported};
-use wit_encoder::PackageName;
 
 const IDL_VERSION_MAJOR: u64 = 0;
 const IDL_VERSION_MINOR: u64 = 0;
@@ -29,7 +28,7 @@ pub(crate) fn run() -> Result<()> {
         let wit = webidl_to_wit(
             idl,
             ConversionOptions {
-                package_name: PackageName::new(
+                package_name: webidl2wit::PackageName::new(
                     "webidl",
                     name.to_string(),
                     Some(semver::Version {
@@ -52,6 +51,7 @@ pub(crate) fn run() -> Result<()> {
                     None
                 },
                 global_singletons,
+                ..Default::default()
             },
         )?;
 


### PR DESCRIPTION
Now that [`webidl2wit`](https://crates.io/crates/webidl2wit) is a published crate, we can use the released version (and later use [`webidl2wit-cli`](https://crates.io/crates/webidl2wit-cli) in docs and tests!)