### PR TITLE
fix(tests): evaluation of fixture binaries

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -16,8 +16,14 @@ import { env, platform } from 'node:process';
 import { readdir } from 'node:fs/promises';
 
 const componentFixtures = env.COMPONENT_FIXTURES
-  ? env.COMPONENT_FIXTURES.split(',')
-  : (await readdir('test/fixtures/components')).filter(name => name !== 'dummy_reactor.component.wasm');
+  ? env.COMPONENT_FIXTURES.split(",")
+  : (await readdir("test/fixtures/components", { withFileTypes: true }))
+      .filter(
+        (f) =>
+          f.isFile() &&
+          f.name !== "dummy_reactor.component.wasm",
+      )
+      .map((f) => f.name);
 
 import { browserTest } from './browser.js';
 import { codegenTest } from './codegen.js';


### PR DESCRIPTION
This commit fixes the issue with tests that was causing folders to be picked up when present in the test component fixtures, along with some quality-of-life changes for error output