### PR TITLE
fix(tests): intermittent windows CI timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,8 +62,8 @@
     "build:release": "cargo xtask build release",
     "build:types:preview2-shim": "cargo xtask generate wasi-types",
     "lint": "eslint -c eslintrc.cjs src/**/*.js packages/*/lib/**/*.js",
-    "test:lts": "mocha -u tdd test/test.js --timeout 120000",
-    "test": "node --stack-trace-limit=100 node_modules/mocha/bin/mocha.js -u tdd test/test.js --timeout 120000",
+    "test:lts": "mocha -u tdd test/test.js --timeout 240000",
+    "test": "node --stack-trace-limit=100 node_modules/mocha/bin/mocha.js -u tdd test/test.js --timeout 240000",
     "prepublishOnly": "cargo xtask build release && npm run test"
   },
   "files": [


### PR DESCRIPTION
This commit increases the timeout for windows failures in test/cli.js, which on the windows runner *sometimes* took slightly too long.

The runs below (done on my fork) are what surfaced the issue -- the failure is just intermittent on CI runner perf:
![re-runs](https://github.com/user-attachments/assets/381a26a1-e8eb-4f61-b2f1-08535c8c05e9)
(i.e. the exact same code would *sometimes complete* and sometimes not, when the tests were severely reduced.

[EDIT] With the timeout raised here's how long the componentize test w/ AOT took:

```
    ✔ Componentize (152987ms)
```

Ideally we should *also* have a non-AOT componentize test w/ transpile mapping but I'll settle for getting CI back to green for now