### PR TITLE
wip(fix): import mapping resource overlap

### DIFF
--- a/test/cli.js
+++ b/test/cli.js
@@ -1,7 +1,14 @@
-import { resolve, join } from "node:path";
-import { execArgv } from "node:process";
+import { resolve } from "node:path";
+import { execArgv, env } from "node:process";
 import { deepStrictEqual, ok, strictEqual } from "node:assert";
-import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 
 import { fileURLToPath, pathToFileURL } from "url";
 import { exec, jcoPath, getTmpDir } from "./helpers.js";
@@ -9,8 +16,6 @@ import { exec, jcoPath, getTmpDir } from "./helpers.js";
 const multiMemory = execArgv.includes("--experimental-wasm-multi-memory")
   ? ["--multi-memory"]
   : [];
-
-const AsyncFunction = (async () => {}).constructor;
 
 export async function cliTest(_fixtures) {
   suite("CLI", () => {
@@ -27,7 +32,7 @@ export async function cliTest(_fixtures) {
       await symlink(
         fileURLToPath(new URL("../packages/preview2-shim", import.meta.url)),
         resolve(modulesDir, "preview2-shim"),
-        "dir",
+        "dir"
       );
     });
     suiteTeardown(async function () {
@@ -43,575 +48,481 @@ export async function cliTest(_fixtures) {
       } catch {}
     });
 
-    test("Transcoding", async () => {
-      const { stderr } = await exec(
-        jcoPath,
-        "transpile",
-        `test/fixtures/env-allow.composed.wasm`,
-        ...multiMemory,
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      await writeFile(
-        `${outDir}/package.json`,
-        JSON.stringify({ type: "module" }),
-      );
-      const m = await import(`${pathToFileURL(outDir)}/env-allow.composed.js`);
-      deepStrictEqual(m.testGetEnv(), [["CUSTOM", "VAL"]]);
-    });
+    // test("Transcoding", async () => {
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "transpile",
+    //     `test/fixtures/env-allow.composed.wasm`,
+    //     ...multiMemory,
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   await writeFile(
+    //     `${outDir}/package.json`,
+    //     JSON.stringify({ type: "module" })
+    //   );
+    //   const m = await import(`${pathToFileURL(outDir)}/env-allow.composed.js`);
+    //   deepStrictEqual(m.testGetEnv(), [["CUSTOM", "VAL"]]);
+    // });
 
-    test("Resource transfer", async () => {
-      const { stderr } = await exec(
-        jcoPath,
-        "transpile",
-        `test/fixtures/stdio.composed.wasm`,
-        ...multiMemory,
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      await writeFile(
-        `${outDir}/package.json`,
-        JSON.stringify({ type: "module" }),
-      );
-      const m = await import(`${pathToFileURL(outDir)}/stdio.composed.js`);
-      m.testStdio();
-    });
+    // test("Resource transfer", async () => {
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "transpile",
+    //     `test/fixtures/stdio.composed.wasm`,
+    //     ...multiMemory,
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   await writeFile(
+    //     `${outDir}/package.json`,
+    //     JSON.stringify({ type: "module" })
+    //   );
+    //   const m = await import(`${pathToFileURL(outDir)}/stdio.composed.js`);
+    //   m.testStdio();
+    // });
 
-    test("Resource transfer valid lifting", async () => {
-      const { stderr } = await exec(
-        jcoPath,
-        "transpile",
-        `test/fixtures/stdio.composed.wasm`,
-        ...multiMemory,
-        "--valid-lifting-optimization",
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      await writeFile(
-        `${outDir}/package.json`,
-        JSON.stringify({ type: "module" }),
-      );
-      const m = await import(`${pathToFileURL(outDir)}/stdio.composed.js`);
-      m.testStdio();
-    });
+    // test("Resource transfer valid lifting", async () => {
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "transpile",
+    //     `test/fixtures/stdio.composed.wasm`,
+    //     ...multiMemory,
+    //     "--valid-lifting-optimization",
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   await writeFile(
+    //     `${outDir}/package.json`,
+    //     JSON.stringify({ type: "module" })
+    //   );
+    //   const m = await import(`${pathToFileURL(outDir)}/stdio.composed.js`);
+    //   m.testStdio();
+    // });
 
-    test("Transpile", async () => {
-      const name = "flavorful";
-      const { stderr } = await exec(
-        jcoPath,
-        "transpile",
-        `test/fixtures/components/${name}.component.wasm`,
-        "--no-wasi-shim",
-        "--name",
-        name,
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(`${outDir}/${name}.js`);
-      ok(source.toString().includes("export { test"));
-    });
+    // test("Transpile", async () => {
+    //   const name = "flavorful";
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "transpile",
+    //     `test/fixtures/components/${name}.component.wasm`,
+    //     "--no-wasi-shim",
+    //     "--name",
+    //     name,
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/${name}.js`);
+    //   ok(source.toString().includes("export { test"));
+    // });
 
-    if (typeof WebAssembly.Suspending === "function") {
-      test("Transpile with Async Mode for JSPI", async () => {
-        const name = "async_call";
-        const { stderr } = await exec(
-          jcoPath,
-          "transpile",
-          `test/fixtures/components/${name}.component.wasm`,
-          `--name=${name}`,
-          "--valid-lifting-optimization",
-          "--tla-compat",
-          "--instantiation=async",
-          "--base64-cutoff=0",
-          "--async-mode=jspi",
-          "--async-imports=something:test/test-interface#call-async",
-          "--async-exports=run-async",
-          "-o",
-          outDir,
-        );
-        strictEqual(stderr, "");
-        await writeFile(
-          `${outDir}/package.json`,
-          JSON.stringify({ type: "module" }),
-        );
-        const m = await import(`${pathToFileURL(outDir)}/${name}.js`);
-        const inst = await m.instantiate(undefined, {
-          "something:test/test-interface": {
-            callAsync: async () => "called async",
-            callSync: () => "called sync",
-          },
-        });
-        strictEqual(inst.runSync instanceof AsyncFunction, false);
-        strictEqual(inst.runAsync instanceof AsyncFunction, true);
+    // test("Transpile & Optimize & Minify", async () => {
+    //   const name = "flavorful";
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "transpile",
+    //     `test/fixtures/components/${name}.component.wasm`,
+    //     "--name",
+    //     name,
+    //     "--valid-lifting-optimization",
+    //     "--tla-compat",
+    //     "--optimize",
+    //     "--minify",
+    //     "--base64-cutoff=0",
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/${name}.js`);
+    //   ok(source.toString().includes("as test,"));
+    // });
 
-        strictEqual(inst.runSync(), "called sync");
-        strictEqual(await inst.runAsync(), "called async");
-      });
-    }
+    // test("Transpile with tracing", async () => {
+    //   const name = "flavorful";
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "transpile",
+    //     `test/fixtures/components/${name}.component.wasm`,
+    //     "--name",
+    //     name,
+    //     "--map",
+    //     "testwasi=./wasi.js",
+    //     "--tracing",
+    //     "--base64-cutoff=0",
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/${name}.js`, "utf8");
+    //   ok(source.includes("function toResultString("));
+    //   ok(
+    //     source.includes(
+    //       'console.error(`[module="test:flavorful/test", function="f-list-in-record1"] call a'
+    //     )
+    //   );
+    //   ok(
+    //     source.includes(
+    //       'console.error(`[module="test:flavorful/test", function="list-of-variants"] return result=${toResultString(ret)}`);'
+    //     )
+    //   );
+    // });
 
-    test("Transpile & Optimize & Minify", async () => {
-      const name = "flavorful";
-      const { stderr } = await exec(
-        jcoPath,
-        "transpile",
-        `test/fixtures/components/${name}.component.wasm`,
-        "--name",
-        name,
-        "--valid-lifting-optimization",
-        "--tla-compat",
-        "--optimize",
-        "--minify",
-        "--base64-cutoff=0",
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(`${outDir}/${name}.js`);
-      ok(source.toString().includes("as test,"));
-    });
+    // test("Type generation", async () => {
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "types",
+    //     "test/fixtures/wit",
+    //     "--world-name",
+    //     "test:flavorful/flavorful",
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/flavorful.d.ts`, "utf8");
+    //   ok(source.includes("export const test"));
+    //   const iface = await readFile(`${outDir}/interfaces/test-flavorful-test.d.ts`, "utf8");
+    //   ok(iface.includes("export namespace TestFlavorfulTest {"));
+    // });
 
-    test("Transpile with tracing", async () => {
-      const name = "flavorful";
-      const { stderr } = await exec(
-        jcoPath,
-        "transpile",
-        `test/fixtures/components/${name}.component.wasm`,
-        "--name",
-        name,
-        "--map",
-        "testwasi=./wasi.js",
-        "--tracing",
-        "--base64-cutoff=0",
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(`${outDir}/${name}.js`, "utf8");
-      ok(source.includes("function toResultString("));
-      ok(
-        source.includes(
-          'console.error(`[module="test:flavorful/test", function="f-list-in-record1"] call a',
-        ),
-      );
-      ok(
-        source.includes(
-          'console.error(`[module="test:flavorful/test", function="list-of-variants"] return result=${toResultString(ret)}`);',
-        ),
-      );
-    });
+    // test("Type generation (specific features)", async () => {
+    //   const { stderr, stdout } = await exec(
+    //     jcoPath,
+    //     "types",
+    //     "test/fixtures/wits/feature-gates-unstable.wit",
+    //     "--world-name",
+    //     "test:feature-gates-unstable/gated",
+    //     "--feature",
+    //     "enable-c",
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`, "utf8");
+    //   ok(source.includes("export function a(): void;"));
+    //   ok(!source.includes("export function b(): void;"));
+    //   ok(source.includes("export function c(): void;"));
+    // });
 
-    test("Type generation", async () => {
-      const { stderr } = await exec(
-        jcoPath,
-        "types",
-        "test/fixtures/wit",
-        "--world-name",
-        "test:flavorful/flavorful",
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(`${outDir}/flavorful.d.ts`, "utf8");
-      ok(source.includes("export const test"));
-      const iface = await readFile(`${outDir}/interfaces/test-flavorful-test.d.ts`, "utf8");
-      ok(iface.includes("export namespace TestFlavorfulTest {"));
-    });
+    // test("Type generation (all features)", async () => {
+    //   const { stderr, stdout } = await exec(
+    //     jcoPath,
+    //     "types",
+    //     "test/fixtures/wits/feature-gates-unstable.wit",
+    //     "--world-name",
+    //     "test:feature-gates-unstable/gated",
+    //     "--all-features",
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`, "utf8");
+    //   ok(source.includes("export function a(): void;"));
+    //   ok(source.includes("export function b(): void;"));
+    //   ok(source.includes("export function c(): void;"));
+    // });
 
-    test("Type generation (specific features)", async () => {
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "types",
-        "test/fixtures/wits/feature-gates-unstable.wit",
-        "--world-name",
-        "test:feature-gates-unstable/gated",
-        "--feature",
-        "enable-c",
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(
-        `${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`,
-        "utf8",
-      );
-      ok(source.includes("export function a(): void;"));
-      ok(!source.includes("export function b(): void;"));
-      ok(source.includes("export function c(): void;"));
-    });
+    // // NOTE: enabling all features and a specific feature means --all-features takes precedence
+    // test("Type generation (all features + feature)", async () => {
+    //   const { stderr, stdout } = await exec(
+    //     jcoPath,
+    //     "types",
+    //     "test/fixtures/wits/feature-gates-unstable.wit",
+    //     "--world-name",
+    //     "test:feature-gates-unstable/gated",
+    //     "--all-features",
+    //     "--feature",
+    //     "enable-c",
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`, "utf8");
+    //   ok(source.includes("export function a(): void;"));
+    //   ok(source.includes("export function b(): void;"));
+    //   ok(source.includes("export function c(): void;"));
+    // });
 
-    test("Type generation (all features)", async () => {
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "types",
-        "test/fixtures/wits/feature-gates-unstable.wit",
-        "--world-name",
-        "test:feature-gates-unstable/gated",
-        "--all-features",
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(
-        `${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`,
-        "utf8",
-      );
-      ok(source.includes("export function a(): void;"));
-      ok(source.includes("export function b(): void;"));
-      ok(source.includes("export function c(): void;"));
-    });
+    // test("Type generation (declare imports)", async () => {
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "guest-types",
+    //     "test/fixtures/wit",
+    //     "--world-name",
+    //     "test:flavorful/flavorful",
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/interfaces/test-flavorful-test.d.ts`, "utf8");
+    //   ok(source.includes("declare module 'test:flavorful/test' {"));
+    // });
 
-    // NOTE: enabling all features and a specific feature means --all-features takes precedence
-    test("Type generation (all features + feature)", async () => {
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "types",
-        "test/fixtures/wits/feature-gates-unstable.wit",
-        "--world-name",
-        "test:feature-gates-unstable/gated",
-        "--all-features",
-        "--feature",
-        "enable-c",
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(
-        `${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`,
-        "utf8",
-      );
-      ok(source.includes("export function a(): void;"));
-      ok(source.includes("export function b(): void;"));
-      ok(source.includes("export function c(): void;"));
-    });
+    // test("TypeScript naming checks", async () => {
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "transpile",
+    //     `test/fixtures/wit/deps/ts-check/ts-check.wit`,
+    //     "--stub",
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   {
+    //     const source = await readFile(`${outDir}/ts-check.d.ts`);
+    //     ok(source.toString().includes("declare function _class(): void"));
+    //     ok(source.toString().includes("export { _class as class }"));
+    //   }
+    //   {
+    //     const source = await readFile(
+    //       `${outDir}/interfaces/ts-naming-blah.d.ts`
+    //     );
+    //     ok(source.toString().includes("declare function _class(): void"));
+    //     ok(source.toString().includes("export { _class as class }"));
+    //   }
+    // });
 
-    test("Type generation (declare imports)", async () => {
-      const { stderr } = await exec(
-        jcoPath,
-        "guest-types",
-        "test/fixtures/wit",
-        "--world-name",
-        "test:flavorful/flavorful",
-        "-o",
-        outDir
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(`${outDir}/interfaces/test-flavorful-test.d.ts`, "utf8");
-      // NOTE: generation of guest types *no longer* produces an explicitly exported module
-      // but rather contains an typescript ambient module (w/ opt-in for producing explicit
-      // module declarations if necessary)
-      //
-      // see: https://github.com/bytecodealliance/jco/pull/528
-      ok(source.includes("declare module 'test:flavorful/test' {"));
-    });
+    // test("Transpile to JS", async () => {
+    //   const name = "flavorful";
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "transpile",
+    //     `test/fixtures/components/${name}.component.wasm`,
+    //     "--name",
+    //     name,
+    //     "--map",
+    //     "test:flavorful/test=./flavorful.js",
+    //     "--valid-lifting-optimization",
+    //     "--tla-compat",
+    //     "--js",
+    //     "--base64-cutoff=0",
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/${name}.js`, "utf8");
+    //   ok(source.includes("./flavorful.js"));
+    //   ok(source.includes("FUNCTION_TABLE"));
+    //   ok(source.includes("export {\n  $init"));
+    // });
 
-    test("TypeScript naming checks", async () => {
-      const { stderr } = await exec(
-        jcoPath,
-        "transpile",
-        `test/fixtures/wit/deps/ts-check/ts-check.wit`,
-        "--stub",
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      {
-        const source = await readFile(`${outDir}/ts-check.d.ts`);
-        ok(source.toString().includes("declare function _class(): void"));
-        ok(source.toString().includes("export { _class as class }"));
-      }
-      {
-        const source = await readFile(
-          `${outDir}/interfaces/ts-naming-blah.d.ts`,
-        );
-        ok(source.toString().includes("declare function _class(): void"));
-        ok(source.toString().includes("export { _class as class }"));
-      }
-    });
+    // test("Transpile without namespaced exports", async () => {
+    //   const name = "flavorful";
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "transpile",
+    //     `test/fixtures/components/${name}.component.wasm`,
+    //     "--no-namespaced-exports",
+    //     "--no-wasi-shim",
+    //     "--name",
+    //     name,
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/${name}.js`);
+    //   const finalLine = source.toString().split("\n").at(-1);
+    //   //Check final line is the export statement
+    //   ok(finalLine.toString().includes("export {"));
+    //   //Check that it does not contain the namespaced export
+    //   ok(!finalLine.toString().includes("test:flavorful/test"));
+    // });
 
-    test("Transpile to JS", async () => {
-      const name = "flavorful";
-      const { stderr } = await exec(
-        jcoPath,
-        "transpile",
-        `test/fixtures/components/${name}.component.wasm`,
-        "--name",
-        name,
-        "--map",
-        "test:flavorful/test=./flavorful.js",
-        "--valid-lifting-optimization",
-        "--tla-compat",
-        "--js",
-        "--base64-cutoff=0",
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(`${outDir}/${name}.js`, "utf8");
-      ok(source.includes("./flavorful.js"));
-      ok(source.includes("FUNCTION_TABLE"));
-      ok(source.includes("export {\n  $init"));
-    });
+    // test("Transpile with namespaced exports", async () => {
+    //   const name = "flavorful";
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "transpile",
+    //     `test/fixtures/components/${name}.component.wasm`,
+    //     "--no-wasi-shim",
+    //     "--name",
+    //     name,
+    //     "-o",
+    //     outDir
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/${name}.js`);
+    //   const finalLine = source.toString().split("\n").at(-1);
+    //   //Check final line is the export statement
+    //   ok(finalLine.toString().includes("export {"));
+    //   //Check that it does contain the namespaced export
+    //   ok(finalLine.toString().includes("test as 'test:flavorful/test'"));
+    // });
 
-    test("Transpile without namespaced exports", async () => {
-      const name = "flavorful";
-      const { stderr } = await exec(
-        jcoPath,
-        "transpile",
-        `test/fixtures/components/${name}.component.wasm`,
-        "--no-namespaced-exports",
-        "--no-wasi-shim",
-        "--name",
-        name,
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(`${outDir}/${name}.js`);
-      const finalLine = source.toString().split("\n").at(-1);
-      //Check final line is the export statement
-      ok(finalLine.toString().includes("export {"));
-      //Check that it does not contain the namespaced export
-      ok(!finalLine.toString().includes("test:flavorful/test"));
-    });
+    // test("Optimize", async () => {
+    //   const component = await readFile(
+    //     `test/fixtures/components/flavorful.component.wasm`
+    //   );
+    //   const { stderr, stdout } = await exec(
+    //     jcoPath,
+    //     "opt",
+    //     `test/fixtures/components/flavorful.component.wasm`,
+    //     "-o",
+    //     outFile
+    //   );
+    //   strictEqual(stderr, "");
+    //   ok(stdout.includes("Core Module 1:"));
+    //   const optimizedComponent = await readFile(outFile);
+    //   ok(optimizedComponent.byteLength < component.byteLength);
+    // });
 
-    test("Transpile with namespaced exports", async () => {
-      const name = "flavorful";
-      const { stderr } = await exec(
-        jcoPath,
-        "transpile",
-        `test/fixtures/components/${name}.component.wasm`,
-        "--no-wasi-shim",
-        "--name",
-        name,
-        "-o",
-        outDir,
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(`${outDir}/${name}.js`);
-      const finalLine = source.toString().split("\n").at(-1);
-      //Check final line is the export statement
-      ok(finalLine.toString().includes("export {"));
-      //Check that it does contain the namespaced export
-      ok(finalLine.toString().includes("test as 'test:flavorful/test'"));
-    });
+    // test("Print & Parse", async () => {
+    //   const { stderr, stdout } = await exec(
+    //     jcoPath,
+    //     "print",
+    //     `test/fixtures/components/flavorful.component.wasm`
+    //   );
+    //   strictEqual(stderr, "");
+    //   strictEqual(stdout.slice(0, 10), "(component");
+    //   {
+    //     const { stderr, stdout } = await exec(
+    //       jcoPath,
+    //       "print",
+    //       `test/fixtures/components/flavorful.component.wasm`,
+    //       "-o",
+    //       outFile
+    //     );
+    //     strictEqual(stderr, "");
+    //     strictEqual(stdout, "");
+    //   }
+    //   {
+    //     const { stderr, stdout } = await exec(
+    //       jcoPath,
+    //       "parse",
+    //       outFile,
+    //       "-o",
+    //       outFile
+    //     );
+    //     strictEqual(stderr, "");
+    //     strictEqual(stdout, "");
+    //     ok(await readFile(outFile));
+    //   }
+    // });
 
-    test("Optimize", async () => {
-      const component = await readFile(
-        `test/fixtures/components/flavorful.component.wasm`,
-      );
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "opt",
-        `test/fixtures/components/flavorful.component.wasm`,
-        "-o",
-        outFile,
-      );
-      strictEqual(stderr, "");
-      ok(stdout.includes("Core Module 1:"));
-      const optimizedComponent = await readFile(outFile);
-      ok(optimizedComponent.byteLength < component.byteLength);
-    });
+    // test("Wit shadowing stub test", async () => {
+    //   const { stderr, stdout } = await exec(
+    //     jcoPath,
+    //     "transpile",
+    //     `test/fixtures/wit/deps/app/app.wit`,
+    //     "-o",
+    //     outDir,
+    //     "--stub"
+    //   );
+    //   strictEqual(stderr, "");
+    //   const source = await readFile(`${outDir}/app.js`);
+    //   ok(source.includes("class PString$1{"));
+    // });
 
-    test("Optimize nested component", async () => {
-      const component = await readFile(
-        `test/fixtures/components/simple-nested.component.wasm`
-      );
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "opt",
-        `test/fixtures/components/simple-nested.component.wasm`,
-        "-o",
-        outFile
-      );
-      strictEqual(stderr, "");
-      ok(stdout.includes("Core Module 1:"));
-      const optimizedComponent = await readFile(outFile);
-      ok(optimizedComponent.byteLength < component.byteLength);
-    });
+    // test("Wit & New", async () => {
+    //   const { stderr, stdout } = await exec(
+    //     jcoPath,
+    //     "wit",
+    //     `test/fixtures/components/flavorful.component.wasm`
+    //   );
+    //   strictEqual(stderr, "");
+    //   ok(stdout.includes("world root {"));
 
-    test("Optimize component with Asyncify pass", async () => {
-      const component = await readFile(
-        `test/fixtures/components/simple-nested-optimized.component.wasm`
-      );
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "opt",
-        `test/fixtures/components/simple-nested-optimized.component.wasm`,
-        "--asyncify",
-        "-o",
-        outFile,
-      );
-      strictEqual(stderr, "");
-      ok(stdout.includes("Core Module 1:"));
-      const asyncifiedComponent = await readFile(outFile);
-      ok(asyncifiedComponent.byteLength > component.byteLength); // should be larger
-    });
+    //   {
+    //     const { stderr, stdout } = await exec(
+    //       jcoPath,
+    //       "embed",
+    //       "--dummy",
+    //       "--wit",
+    //       "test/fixtures/wit/deps/flavorful/flavorful.wit",
+    //       "-m",
+    //       "language=javascript",
+    //       "-m",
+    //       "processed-by=dummy-gen@test",
+    //       "-o",
+    //       outFile
+    //     );
+    //     strictEqual(stderr, "");
+    //     strictEqual(stdout, "");
+    //   }
 
-    test("Print & Parse", async () => {
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "print",
-        `test/fixtures/components/flavorful.component.wasm`,
-      );
-      strictEqual(stderr, "");
-      strictEqual(stdout.slice(0, 10), "(component");
-      {
-        const { stderr, stdout } = await exec(
-          jcoPath,
-          "print",
-          `test/fixtures/components/flavorful.component.wasm`,
-          "-o",
-          outFile,
-        );
-        strictEqual(stderr, "");
-        strictEqual(stdout, "");
-      }
-      {
-        const { stderr, stdout } = await exec(
-          jcoPath,
-          "parse",
-          outFile,
-          "-o",
-          outFile,
-        );
-        strictEqual(stderr, "");
-        strictEqual(stdout, "");
-        ok(await readFile(outFile));
-      }
-    });
+    //   {
+    //     const { stderr, stdout } = await exec(jcoPath, "print", outFile);
+    //     strictEqual(stderr, "");
+    //     strictEqual(stdout.slice(0, 7), "(module");
+    //   }
+    //   {
+    //     const { stderr, stdout } = await exec(
+    //       jcoPath,
+    //       "new",
+    //       outFile,
+    //       "-o",
+    //       outFile
+    //     );
+    //     strictEqual(stderr, "");
+    //     strictEqual(stdout, "");
+    //   }
+    //   {
+    //     const { stderr, stdout } = await exec(jcoPath, "print", outFile);
+    //     strictEqual(stderr, "");
+    //     strictEqual(stdout.slice(0, 10), "(component");
+    //   }
+    //   {
+    //     const { stdout, stderr } = await exec(
+    //       jcoPath,
+    //       "metadata-show",
+    //       outFile,
+    //       "--json"
+    //     );
+    //     strictEqual(stderr, "");
+    //     const meta = JSON.parse(stdout);
+    //     deepStrictEqual(meta[0].metaType, { tag: "component", val: 5 });
+    //     deepStrictEqual(meta[1].producers, [
+    //       [
+    //         "processed-by",
+    //         [
+    //           ["wit-component", "0.220.0"],
+    //           ["dummy-gen", "test"],
+    //         ],
+    //       ],
+    //       ["language", [["javascript", ""]]],
+    //     ]);
+    //   }
+    // });
 
-    test("Wit shadowing stub test", async () => {
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "transpile",
-        `test/fixtures/wit/deps/app/app.wit`,
-        "-o",
-        outDir,
-        "--stub",
-      );
-      strictEqual(stderr, "");
-      const source = await readFile(`${outDir}/app.js`);
-      ok(source.includes("class PString$1{"));
-    });
+    // test("Component new adapt", async () => {
+    //   const { stderr } = await exec(
+    //     jcoPath,
+    //     "new",
+    //     "test/fixtures/modules/exitcode.wasm",
+    //     "--wasi-reactor",
+    //     "-o",
+    //     outFile
+    //   );
+    //   strictEqual(stderr, "");
+    //   {
+    //     const { stderr, stdout } = await exec(jcoPath, "print", outFile);
+    //     strictEqual(stderr, "");
+    //     strictEqual(stdout.slice(0, 10), "(component");
+    //   }
+    // });
 
-    test("Wit & New", async () => {
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "wit",
-        `test/fixtures/components/flavorful.component.wasm`,
-      );
-      strictEqual(stderr, "");
-      ok(stdout.includes("world root {"));
-
-      {
-        const { stderr, stdout } = await exec(
-          jcoPath,
-          "embed",
-          "--dummy",
-          "--wit",
-          "test/fixtures/wit/deps/flavorful/flavorful.wit",
-          "-m",
-          "language=javascript",
-          "-m",
-          "processed-by=dummy-gen@test",
-          "-o",
-          outFile,
-        );
-        strictEqual(stderr, "");
-        strictEqual(stdout, "");
-      }
-
-      {
-        const { stderr, stdout } = await exec(jcoPath, "print", outFile);
-        strictEqual(stderr, "");
-        strictEqual(stdout.slice(0, 7), "(module");
-      }
-      {
-        const { stderr, stdout } = await exec(
-          jcoPath,
-          "new",
-          outFile,
-          "-o",
-          outFile,
-        );
-        strictEqual(stderr, "");
-        strictEqual(stdout, "");
-      }
-      {
-        const { stderr, stdout } = await exec(jcoPath, "print", outFile);
-        strictEqual(stderr, "");
-        strictEqual(stdout.slice(0, 10), "(component");
-      }
-      {
-        const { stdout, stderr } = await exec(
-          jcoPath,
-          "metadata-show",
-          outFile,
-          "--json",
-        );
-        strictEqual(stderr, "");
-        const meta = JSON.parse(stdout);
-        // NOTE: the check below is depends on *how many* modules *and* components are
-        // generated by wit-component (as used by the wasm-tools rust dep in this project)
-        // and componentize-js.
-        //
-        // As such, this is subject to optimizations or changes in operation of
-        // upstream functionality and may change with upstream releases -- for example
-        // the addition of a "glue" or redirection-heavy module/component
-        deepStrictEqual(meta[0].metaType, { tag: "component", val: 5 });
-        deepStrictEqual(meta[1].producers, [
-          [
-            "processed-by",
-            [
-              ["wit-component", "0.225.0"],
-              ["dummy-gen", "test"],
-            ],
-          ],
-          ["language", [["javascript", ""]]],
-        ]);
-      }
-    });
-
-    test("Component new adapt", async () => {
-      const { stderr } = await exec(
-        jcoPath,
-        "new",
-        "test/fixtures/modules/exitcode.wasm",
-        "--wasi-reactor",
-        "-o",
-        outFile,
-      );
-      strictEqual(stderr, "");
-      {
-        const { stderr, stdout } = await exec(jcoPath, "print", outFile);
-        strictEqual(stderr, "");
-        strictEqual(stdout.slice(0, 10), "(component");
-      }
-    });
-
-    test("Extract metadata", async () => {
-      const { stdout, stderr } = await exec(
-        jcoPath,
-        "metadata-show",
-        "test/fixtures/modules/exitcode.wasm",
-        "--json",
-      );
-      strictEqual(stderr, "");
-      deepStrictEqual(JSON.parse(stdout), [
-        {
-          metaType: { tag: "module" },
-          producers: [],
-          range: [0, 262],
-        },
-      ]);
-    });
+    // test("Extract metadata", async () => {
+    //   const { stdout, stderr } = await exec(
+    //     jcoPath,
+    //     "metadata-show",
+    //     "test/fixtures/modules/exitcode.wasm",
+    //     "--json"
+    //   );
+    //   strictEqual(stderr, "");
+    //   deepStrictEqual(JSON.parse(stdout), [
+    //     {
+    //       metaType: { tag: "module" },
+    //       producers: [],
+    //       range: [0, 262],
+    //     },
+    //   ]);
+    // });
 
     test("Componentize", async () => {
-      const { stdout, stderr } = await exec(
+      const args = [
         jcoPath,
         "componentize",
         "test/fixtures/componentize/source.js",
@@ -621,8 +532,13 @@ export async function cliTest(_fixtures) {
         "-w",
         "test/fixtures/componentize/source.wit",
         "-o",
-        outFile,
-      );
+        outFile
+      ];
+      if (env.WEVAL_BIN_PATH) {
+        args.push("--weval-bin", env.WEVAL_BIN_PATH);
+      }
+
+      const { stdout, stderr } = await exec(...args);
       strictEqual(stderr, "");
       {
         const { stderr } = await exec(
@@ -634,13 +550,13 @@ export async function cliTest(_fixtures) {
           "--map",
           "local:test/foo=./foo.js",
           "-o",
-          outDir,
+          outDir
         );
         strictEqual(stderr, "");
       }
       await writeFile(
         `${outDir}/package.json`,
-        JSON.stringify({ type: "module" }),
+        JSON.stringify({ type: "module" })
       );
       await writeFile(`${outDir}/foo.js`, `export class Bar {}`);
       const m = await import(`${pathToFileURL(outDir)}/componentize.js`);
@@ -648,33 +564,4 @@ export async function cliTest(_fixtures) {
       strictEqual(m.consumeBar(m.createBar()), 'bar1');
     });
   });
-}
-
-// Cache of componentize byte outputs
-const CACHE_COMPONENTIZE_OUTPUT = {};
-
-/**
- * Small cache for componentizations to save build time by storing componentize
- * output in memory
- *
- * @param {string} outputPath - path to where to write the component
- * @param {string[]} args - arguments to be fed to `jco componentize` (*without* "compnentize" or "-o/--output")
- */
-async function cachedComponentize(outputPath, args) {
-  const cacheKey = args.join("+");
-  if (cacheKey in CACHE_COMPONENTIZE_OUTPUT) {
-    await writeFile(outputPath, CACHE_COMPONENTIZE_OUTPUT[cacheKey]);
-    return;
-  }
-
-  const { stdout, stderr } = await exec(
-    jcoPath,
-    "componentize",
-    ...args,
-    "-o",
-    outputPath,
-  );
-  strictEqual(stderr, "");
-
-  CACHE_COMPONENTIZE_OUTPUT[cacheKey] = await readFile(outputPath);
 }

--- a/test/cli.js
+++ b/test/cli.js
@@ -645,7 +645,7 @@ export async function cliTest(_fixtures) {
       await writeFile(`${outDir}/foo.js`, `export class Bar {}`);
       const m = await import(`${pathToFileURL(outDir)}/componentize.js`);
       strictEqual(m.hello(), "world");
-      // strictEqual(m.consumeBar(m.createBar()), 'bar1');
+      strictEqual(m.consumeBar(m.createBar()), 'bar1');
     });
   });
 }

--- a/test/test.js
+++ b/test/test.js
@@ -16,37 +16,27 @@ import { env, platform } from 'node:process';
 import { readdir } from 'node:fs/promises';
 
 const componentFixtures = env.COMPONENT_FIXTURES
-  ? env.COMPONENT_FIXTURES.split(",")
-  : (await readdir("test/fixtures/components", { withFileTypes: true }))
-      .filter(
-        (f) =>
-          f.isFile() &&
-          f.name !== "dummy_reactor.component.wasm",
-      )
-      .map((f) => f.name);
+  ? env.COMPONENT_FIXTURES.split(',')
+  : (await readdir('test/fixtures/components')).filter(name => name !== 'dummy_reactor.component.wasm');
 
-import { asyncBrowserTest } from './async.browser.js';
-import { asyncTest } from './async.js';
-import { browserTest } from './browser.js';
-import { codegenTest } from './codegen.js';
-import { runtimeTest } from './runtime.js';
-import { commandsTest } from './commands.js';
-import { apiTest } from './api.js';
+// import { browserTest } from './browser.js';
+// import { codegenTest } from './codegen.js';
+// import { runtimeTest } from './runtime.js';
+// import { commandsTest } from './commands.js';
+// import { apiTest } from './api.js';
 import { cliTest } from './cli.js';
-import { preview2Test } from './preview2.js';
-import { witTest } from './wit.js';
-import { tsTest } from './typescript.js';
+// import { preview2Test } from './preview2.js';
+// import { witTest } from './wit.js';
+// import { tsTest } from './typescript.js';
 
-await codegenTest(componentFixtures);
-tsTest();
-await preview2Test();
-await runtimeTest(componentFixtures);
-await commandsTest();
-await apiTest(componentFixtures);
+// await codegenTest(componentFixtures);
+// tsTest();
+// await preview2Test();
+// await runtimeTest(componentFixtures);
+// await commandsTest();
+// await apiTest(componentFixtures);
 await cliTest(componentFixtures);
-await witTest();
-await asyncTest();
-await asyncBrowserTest();
+// await witTest();
 
-if (platform !== 'win32')
-  await browserTest();
+// if (platform !== 'win32')
+//   await browserTest();


### PR DESCRIPTION
This commit attempts to fix the case of an import map that perfectly overlaps an existing component resource.

When a resource that exists in a component is overriden with an import map, the interface can change arbitrarily.

---

[This handle failure](https://github.com/bytecodealliance/jco/blob/46e729c8383fb54f33055498d3e36531bdb0fd48/test/cli.js#L564) seems to actually be much deeper... **Where I've landed is that resources are broken when import mapped over.** 

I've been able to figure out that the import map'd resource that overlaps with the local one is being interpreted as a host & imported & owned resource.

They basically are being detected as owned when they *should not* be -- while it is possible to have a  `ResourceData::Host` that is imported *and* owned, in this case the resource is actually coming from the import map (it's not the same resource as the component created/is in the WIT).

I can't tell if the right move here is to:

- Disable host-mapping over resources that are defined by the component in question
- Modify bindgen to figure out that import-mapped things (which are missing/don't construct properly) and use them differently somehow
- make changes to componentize.js to maybe avoid producing lowering code (???) that may be causing the failures

I'm thinking it might be a componentize problem because the function in the WASM has no idea about the import mapping above, and is probably trying to lower using the definitions in the component (that don't match the import map).

The first issue was attempting to *remove* the resource that wasn't actually successfully created which I found a way to work around (that *maybe* makes sense), but I'm finding that while you can *create* the resource, you can't *consume* it (i.e. from `consumeBar`) inside the component.