### PR TITLE
chore(deps): update upstream deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ dependencies = [
  "wasmparser 0.224.0",
  "wasmtime-environ",
  "wit-bindgen-core",
- "wit-component 0.224.0",
+ "wit-component",
  "wit-parser 0.224.0",
 ]
 
@@ -772,16 +772,6 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.220.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebf48234b389415b226a4daef6562933d38c7b28a8b8f64c5c4130dad1561ab7"
-dependencies = [
- "leb128",
- "wasmparser 0.220.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.221.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17a3bd88f2155da63a1f2fcb8a56377a24f0b6dfed12733bb5f544e86f690c5"
@@ -798,22 +788,6 @@ checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
 dependencies = [
  "leb128",
  "wasmparser 0.224.0",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.220.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f3e5f5920c5abfc45573c89b07b38efdaae1515ef86f83dad12d60e50ecd62b"
-dependencies = [
- "anyhow",
- "indexmap",
- "serde",
- "serde_derive",
- "serde_json",
- "spdx",
- "wasm-encoder 0.220.0",
- "wasmparser 0.220.0",
 ]
 
 [[package]]
@@ -839,26 +813,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "wasm-encoder 0.224.0",
- "wasm-metadata 0.224.0",
+ "wasm-metadata",
  "wasmparser 0.224.0",
  "wasmprinter 0.224.0",
  "wat",
  "wit-bindgen",
- "wit-component 0.224.0",
+ "wit-component",
  "wit-parser 0.224.0",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.220.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e246c2772ce3ebc83f89a2d4487ac5794cad6c309b2071818a88c7db7c36d87b"
-dependencies = [
- "ahash",
- "bitflags 2.8.0",
- "hashbrown 0.14.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -1069,9 +1030,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a2b3e15cd6068f233926e7d8c7c588b2ec4fb7cc7bf3824115e7c7e2a8485a3"
+checksum = "b550e454e4cce8984398539a94a0226511e1f295b14afdc8f08b4e2e2ff9de3a"
 dependencies = [
  "wit-bindgen-rt",
  "wit-bindgen-rust-macro",
@@ -1079,45 +1040,45 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b632a5a0fa2409489bd49c9e6d99fcc61bb3d4ce9d1907d44662e75a28c71172"
+checksum = "70e2f98d49960a416074c5d72889f810ed3032a32ffef5e4760094426fefbfe8"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.220.0",
+ "wit-parser 0.224.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7947d0131c7c9da3f01dfde0ab8bd4c4cf3c5bd49b6dba0ae640f1fa752572ea"
+checksum = "ed6f8d372a2d4a1227f2556e051cc24b2a5f15768d53451c84ff91e2527139e3"
 dependencies = [
  "bitflags 2.8.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4329de4186ee30e2ef30a0533f9b3c123c019a237a7c82d692807bf1b3ee2697"
+checksum = "1cc49091f84e4f2ace078bbc86082b57e667b9e789baece4b1184e0963382b6e"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn 2.0.96",
- "wasm-metadata 0.220.0",
+ "wasm-metadata",
  "wit-bindgen-core",
- "wit-component 0.220.0",
+ "wit-component",
 ]
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.36.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "177fb7ee1484d113b4792cc480b1ba57664bbc951b42a4beebe573502135b1fc"
+checksum = "3545a699dc9d72298b2064ce71b771fc10fc6b757d29306b1e54a4283a75abba"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -1126,25 +1087,6 @@ dependencies = [
  "syn 2.0.96",
  "wit-bindgen-core",
  "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.220.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73ccedf54cc65f287da268d64d2bf4f7530d2cfb2296ffbe3ad5f65567e4cf53"
-dependencies = [
- "anyhow",
- "bitflags 2.8.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder 0.220.0",
- "wasm-metadata 0.220.0",
- "wasmparser 0.220.0",
- "wit-parser 0.220.0",
 ]
 
 [[package]]
@@ -1161,7 +1103,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.224.0",
- "wasm-metadata 0.224.0",
+ "wasm-metadata",
  "wasmparser 0.224.0",
  "wat",
  "wit-parser 0.224.0",
@@ -1186,24 +1128,6 @@ checksum = "1c2921dd7e71ae11b6e28b33d42cc0eed4fa6ad3fe3ed1f9c5df80dacfec6a28"
 dependencies = [
  "pretty_assertions",
  "semver",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.220.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7117ce3adc0b4354b46dc1cf3190b00b333e65243d244c613ffcc58bdec84d"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser 0.220.0",
 ]
 
 [[package]]
@@ -1275,7 +1199,7 @@ dependencies = [
  "structopt",
  "webidl2wit",
  "weedle",
- "wit-component 0.224.0",
+ "wit-component",
  "wit-encoder 0.214.0",
  "xshell",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,6 +104,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +143,15 @@ name = "foldhash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
 
 [[package]]
 name = "gimli"
@@ -186,10 +206,149 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25a2bc672d1148e28034f176e01fffebb08b35768468cc954630da77a1449005"
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -233,12 +392,12 @@ dependencies = [
  "heck 0.5.0",
  "log",
  "semver",
- "wasm-encoder 0.220.0",
- "wasmparser 0.220.0",
+ "wasm-encoder 0.224.0",
+ "wasmparser 0.224.0",
  "wasmtime-environ",
  "wit-bindgen-core",
- "wit-component",
- "wit-parser 0.220.0",
+ "wit-component 0.224.0",
+ "wit-parser 0.224.0",
 ]
 
 [[package]]
@@ -263,6 +422,12 @@ name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "litemap"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "log"
@@ -303,6 +468,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "postcard"
@@ -444,6 +615,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +667,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,6 +699,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
 ]
 
 [[package]]
@@ -542,6 +740,29 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "version_check"
@@ -576,6 +797,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
 dependencies = [
  "leb128",
+ "wasmparser 0.224.0",
 ]
 
 [[package]]
@@ -595,18 +817,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-metadata"
+version = "0.224.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79d13d93febc749413cb6f327e4fdba8c84e4d03bd69fcc4a220c66f113c8de1"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "spdx",
+ "url",
+ "wasm-encoder 0.224.0",
+ "wasmparser 0.224.0",
+]
+
+[[package]]
 name = "wasm-tools-js"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "wasm-encoder 0.220.0",
- "wasm-metadata",
- "wasmparser 0.220.0",
- "wasmprinter 0.220.0",
+ "wasm-encoder 0.224.0",
+ "wasm-metadata 0.224.0",
+ "wasmparser 0.224.0",
+ "wasmprinter 0.224.0",
  "wat",
  "wit-bindgen",
- "wit-component",
- "wit-parser 0.220.0",
+ "wit-component 0.224.0",
+ "wit-parser 0.224.0",
 ]
 
 [[package]]
@@ -636,14 +875,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmprinter"
-version = "0.220.0"
+name = "wasmparser"
+version = "0.224.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae749f2c66587777ce9ad0e8c632e72c77574336b17d2f040a47cffbd92198c7"
+checksum = "65881a664fdd43646b647bb27bf186ab09c05bf56779d40aed4c6dce47d423f5"
 dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.220.0",
+ "bitflags 2.8.0",
+ "hashbrown 0.15.2",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -655,6 +895,17 @@ dependencies = [
  "anyhow",
  "termcolor",
  "wasmparser 0.221.2",
+]
+
+[[package]]
+name = "wasmprinter"
+version = "0.224.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc039e211f6c2137425726f0d76fdd9c439a442e5272bc3627a19274d0eb9686"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.224.0",
 ]
 
 [[package]]
@@ -857,9 +1108,9 @@ dependencies = [
  "indexmap",
  "prettyplease",
  "syn 2.0.96",
- "wasm-metadata",
+ "wasm-metadata 0.220.0",
  "wit-bindgen-core",
- "wit-component",
+ "wit-component 0.220.0",
 ]
 
 [[package]]
@@ -891,10 +1142,29 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "wasm-encoder 0.220.0",
- "wasm-metadata",
+ "wasm-metadata 0.220.0",
  "wasmparser 0.220.0",
- "wat",
  "wit-parser 0.220.0",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.224.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad555ab4f4e676474df746d937823c7279c2d6dd36c3e97a61db893d4ef64ee5"
+dependencies = [
+ "anyhow",
+ "bitflags 2.8.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder 0.224.0",
+ "wasm-metadata 0.224.0",
+ "wasmparser 0.224.0",
+ "wat",
+ "wit-parser 0.224.0",
 ]
 
 [[package]]
@@ -951,6 +1221,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-parser"
+version = "0.224.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23e2925a7365d2c6709ae17bdbb5777ffd8154fd70906b413fc01b75f0dba59e"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser 0.224.0",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
 name = "xshell"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -975,7 +1275,7 @@ dependencies = [
  "structopt",
  "webidl2wit",
  "weedle",
- "wit-component",
+ "wit-component 0.224.0",
  "wit-encoder 0.214.0",
  "xshell",
 ]
@@ -985,6 +1285,30 @@ name = "yansi"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
+
+[[package]]
+name = "yoke"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "synstructure",
+]
 
 [[package]]
 name = "zerocopy"
@@ -1000,6 +1324,49 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+ "synstructure",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,30 +15,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "base64"
@@ -76,13 +56,9 @@ version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
 dependencies = [
- "ansi_term",
- "atty",
  "bitflags 1.3.2",
- "strsim",
  "textwrap",
  "unicode-width 0.1.14",
- "vec_map",
 ]
 
 [[package]]
@@ -173,7 +149,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
  "ahash",
- "serde",
 ]
 
 [[package]]
@@ -209,15 +184,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "id-arena"
@@ -297,12 +263,6 @@ name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
-
-[[package]]
-name = "libc"
-version = "0.2.169"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "log"
@@ -484,12 +444,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
 name = "structopt"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -590,12 +544,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -628,7 +576,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
 dependencies = [
  "leb128",
- "wasmparser 0.224.0",
 ]
 
 [[package]]
@@ -673,7 +620,6 @@ dependencies = [
  "hashbrown 0.14.5",
  "indexmap",
  "semver",
- "serde",
 ]
 
 [[package]]
@@ -687,17 +633,6 @@ dependencies = [
  "indexmap",
  "semver",
  "serde",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.224.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65881a664fdd43646b647bb27bf186ab09c05bf56779d40aed4c6dce47d423f5"
-dependencies = [
- "bitflags 2.8.0",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -800,22 +735,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -823,12 +742,6 @@ checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
  "windows-sys",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
 name = "jco"
-version = { workspace = true }
-edition = { workspace = true }
 publish = false
+
+version.workspace = true
+edition.workspace = true
 
 [[bin]]
 name = "dummy"
@@ -34,28 +35,28 @@ rpath = false
 strip = true
 
 [workspace.dependencies]
-anyhow = "1.0.95"
-base64 = "0.22.1"
-heck = "0.5.0"
-log = "0.4.22"
-semver = "1.0.25"
+anyhow = { version = "1.0.95", default-features = false }
+base64 = { version = "0.22.1", default-features = false }
+heck = { version = "0.5.0", default-features = false }
+log = { version = "0.4.22", default-features = false }
+semver = { version = "1.0.25", default-features = false }
 js-component-bindgen = { path = "./crates/js-component-bindgen" }
-structopt = "0.3.26"
-wasm-encoder = "0.220.0"
-wasm-metadata = "0.220.0"
-wasmparser = "0.220.0"
-wasmprinter = "0.220.0"
+structopt = { version = "0.3.26", default-features = false }
+wasm-encoder = { version = "0.220.0", default-features = false }
+wasm-metadata = { version = "0.220.0", default-features = false }
+wasmparser = { version = "0.220.0", default-features = false }
+wasmprinter = { version = "0.220.0", default-features = false }
 wasmtime-environ = { version = "29.0.0", features = [
     "component-model",
     "compile",
 ] }
-wat = "1.220.0"
-webidl2wit = "0.1.0"
-wit-bindgen = "0.36.0"
-wit-bindgen-core = "0.36.0"
+wat = { version = "1.220.0", default-features = false }
+webidl2wit = { version = "0.1.0", default-features = false }
+wit-bindgen = { version = "0.36.0", default-features = false }
+wit-bindgen-core = { version = "0.36.0", default-features = false }
 wit-component = { version = "0.220.0", features = ["dummy-module"] }
-wit-parser = "0.220.0"
-xshell = "0.2.6"
+wit-parser = { version = "0.220.0", default-features = false }
+xshell = { version = "0.2.6", default-features = false }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,20 +42,20 @@ log = { version = "0.4.22", default-features = false }
 semver = { version = "1.0.25", default-features = false }
 js-component-bindgen = { path = "./crates/js-component-bindgen" }
 structopt = { version = "0.3.26", default-features = false }
-wasm-encoder = { version = "0.220.0", default-features = false }
-wasm-metadata = { version = "0.220.0", default-features = false }
-wasmparser = { version = "0.220.0", default-features = false }
-wasmprinter = { version = "0.220.0", default-features = false }
+wasm-encoder = { version = "0.224.0", default-features = false }
+wasm-metadata = { version = "0.224.0", default-features = false }
+wasmparser = { version = "0.224.0", default-features = false }
+wasmprinter = { version = "0.224.0", default-features = false }
 wasmtime-environ = { version = "29.0.0", features = [
     "component-model",
     "compile",
 ] }
-wat = { version = "1.220.0", default-features = false }
+wat = { version = "1.224.0", default-features = false }
 webidl2wit = { version = "0.1.0", default-features = false }
 wit-bindgen = { version = "0.36.0", default-features = false }
 wit-bindgen-core = { version = "0.36.0", default-features = false }
-wit-component = { version = "0.220.0", features = ["dummy-module"] }
-wit-parser = { version = "0.220.0", default-features = false }
+wit-component = { version = "0.224.0", features = ["dummy-module"] }
+wit-parser = { version = "0.224.0", default-features = false }
 xshell = { version = "0.2.6", default-features = false }
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,10 @@ path = "bin/dummy.rs"
 
 [workspace]
 members = [
-    "crates/js-component-bindgen",
-    "crates/js-component-bindgen-component",
-    "crates/wasm-tools-component",
-    "xtask",
+  "crates/js-component-bindgen",
+  "crates/js-component-bindgen-component",
+  "crates/wasm-tools-component",
+  "xtask",
 ]
 resolver = "2"
 
@@ -47,13 +47,13 @@ wasm-metadata = { version = "0.224.0", default-features = false }
 wasmparser = { version = "0.224.0", default-features = false }
 wasmprinter = { version = "0.224.0", default-features = false }
 wasmtime-environ = { version = "29.0.0", features = [
-    "component-model",
-    "compile",
+  "component-model",
+  "compile",
 ] }
 wat = { version = "1.224.0", default-features = false }
 webidl2wit = { version = "0.1.0", default-features = false }
-wit-bindgen = { version = "0.36.0", default-features = false }
-wit-bindgen-core = { version = "0.36.0", default-features = false }
+wit-bindgen = { version = "0.38.0", default-features = false }
+wit-bindgen-core = { version = "0.38.0", default-features = false }
 wit-component = { version = "0.224.0", features = ["dummy-module"] }
 wit-parser = { version = "0.224.0", default-features = false }
 xshell = { version = "0.2.6", default-features = false }

--- a/crates/js-component-bindgen-component/Cargo.toml
+++ b/crates/js-component-bindgen-component/Cargo.toml
@@ -12,6 +12,6 @@ crate-type = ["cdylib"]
 [dependencies]
 anyhow = { workspace = true }
 js-component-bindgen = { path = "../js-component-bindgen" }
-wasmtime-environ = { workspace = true }
+wasmtime-environ = { workspace = true, features = [ "component-model" ] }
 wit-bindgen = { workspace = true }
-wat = { workspace = true }
+wat = { workspace = true, features = [ "component-model" ]}

--- a/crates/js-component-bindgen/Cargo.toml
+++ b/crates/js-component-bindgen/Cargo.toml
@@ -22,12 +22,12 @@ transpile-bindgen = []
 
 [dependencies]
 anyhow = { workspace = true }
-base64 = { workspace = true }
+base64 = { workspace = true, features = [ "alloc" ] }
 heck = { workspace = true }
 log = { workspace = true }
 semver = { workspace = true }
 wasm-encoder = { workspace = true }
-wasmparser = { workspace = true }
+wasmparser = { workspace = true, features = [ "features", "component-model" ] }
 wasmtime-environ = { workspace = true, features = ['component-model'] }
 wit-bindgen-core = { workspace = true }
 wit-component = { workspace = true }

--- a/crates/js-component-bindgen/src/core.rs
+++ b/crates/js-component-bindgen/src/core.rs
@@ -563,7 +563,7 @@ impl<'a> VisitSimdOperator<'a> for CollectMemOps<'_, 'a> {
 
 impl AugmentedOp {
     fn encode_type(&self, section: &mut TypeSection) {
-        use wasm_encoder::ValType::*;
+        use wasm_encoder::ValType::{F32, F64, I32, I64};
         match self {
             // Loads take two arguments: the first is the address being loaded
             // from and the second is the static offset that was listed on the
@@ -843,7 +843,7 @@ impl Translator<'_, '_> {
         insn: fn(wasm_encoder::MemArg) -> wasm_encoder::Instruction<'static>,
         memarg: wasmparser::MemArg,
     ) {
-        use wasm_encoder::Instruction::*;
+        use wasm_encoder::Instruction::{Call, I32Const};
         if memarg.memory < 1 {
             self.func.instruction(&insn(self.memarg(memarg)));
             return;

--- a/crates/js-component-bindgen/src/core.rs
+++ b/crates/js-component-bindgen/src/core.rs
@@ -36,10 +36,14 @@
 //! Additionally core wasm sections such as data sections and tables are not
 //! supported because, again, Wasmtime doesn't use it at this time.
 
-use anyhow::{bail, Result};
 use std::collections::{HashMap, HashSet};
+
+use anyhow::{bail, Result};
 use wasm_encoder::*;
-use wasmparser::*;
+use wasmparser::{
+    Export, ExternalKind, FunctionBody, Import, Parser, Payload, TypeRef, Validator, VisitOperator,
+    VisitSimdOperator, WasmFeatures,
+};
 use wasmtime_environ::component::CoreDef;
 use wasmtime_environ::{EntityIndex, MemoryIndex, ModuleTranslation, PrimaryMap};
 
@@ -547,7 +551,13 @@ macro_rules! define_visit {
 impl<'a> VisitOperator<'a> for CollectMemOps<'_, 'a> {
     type Output = ();
 
-    wasmparser::for_each_operator!(define_visit);
+    wasmparser::for_each_visit_operator!(define_visit);
+}
+
+impl<'a> VisitorSimdOperator<'a> for CollectMemOps<'_, 'a> {
+    type Output = ();
+
+    wasmparser::for_each_visit_simd_operator!(define_visit);
 }
 
 impl AugmentedOp {
@@ -773,7 +783,11 @@ macro_rules! define_translate {
 impl<'a> VisitOperator<'a> for Translator<'_, 'a> {
     type Output = ();
 
-    wasmparser::for_each_operator!(define_translate);
+    wasmparser::for_each_visit_operator!(define_translate);
+}
+
+impl<'a> VisitSimdOperator<'a> for Translator<'_, 'a> {
+    wasmparser::for_each_visit_simd_operator!(define_simd_translate);
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]

--- a/crates/js-component-bindgen/src/core.rs
+++ b/crates/js-component-bindgen/src/core.rs
@@ -39,7 +39,10 @@
 use std::collections::{HashMap, HashSet};
 
 use anyhow::{bail, Result};
-use wasm_encoder::*;
+use wasm_encoder::{
+    CodeSection, EntityType, ExportKind, ExportSection, Function, FunctionSection, ImportSection,
+    Module, TypeSection,
+};
 use wasmparser::{
     Export, ExternalKind, FunctionBody, Import, Parser, Payload, TypeRef, Validator, VisitOperator,
     VisitSimdOperator, WasmFeatures,
@@ -554,9 +557,7 @@ impl<'a> VisitOperator<'a> for CollectMemOps<'_, 'a> {
     wasmparser::for_each_visit_operator!(define_visit);
 }
 
-impl<'a> VisitorSimdOperator<'a> for CollectMemOps<'_, 'a> {
-    type Output = ();
-
+impl<'a> VisitSimdOperator<'a> for CollectMemOps<'_, 'a> {
     wasmparser::for_each_visit_simd_operator!(define_visit);
 }
 
@@ -787,7 +788,7 @@ impl<'a> VisitOperator<'a> for Translator<'_, 'a> {
 }
 
 impl<'a> VisitSimdOperator<'a> for Translator<'_, 'a> {
-    wasmparser::for_each_visit_simd_operator!(define_simd_translate);
+    wasmparser::for_each_visit_simd_operator!(define_translate);
 }
 
 #[derive(Debug, Hash, Eq, PartialEq, Copy, Clone)]

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -2,12 +2,12 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::mem;
 
-use heck::*;
+use heck::{ToLowerCamelCase, ToUpperCamelCase};
 use wasmtime_environ::component::{ResourceIndex, TypeResourceTableIndex};
 use wit_bindgen_core::abi::{Bindgen, Bitcast, Instruction};
 use wit_component::StringEncoding;
 use wit_parser::abi::WasmType;
-use wit_parser::*;
+use wit_parser::{ArchitectureSize, Handle, Resolve, SizeAlign, Type, TypeDefKind, TypeId};
 
 use crate::intrinsics::Intrinsic;
 use crate::source;

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1526,7 +1526,12 @@ impl Bindgen for FunctionBindgen<'_> {
             | Instruction::AsyncCallReturn { .. }
             | Instruction::Flush { .. }
             | Instruction::ErrorContextLift { .. }
-            | Instruction::ErrorContextLower { .. } => unimplemented!("async not yet implemented"),
+            | Instruction::ErrorContextLower { .. } => {
+                uwrite!(
+                    self.src,
+                    "throw new Error('async is not yet implemented');"
+                );
+            }
 
             Instruction::GuestDeallocate { .. }
             | Instruction::GuestDeallocateString

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1,15 +1,17 @@
-use crate::intrinsics::Intrinsic;
-use crate::source;
-use crate::{uwrite, uwriteln};
-use heck::*;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fmt::Write;
 use std::mem;
+
+use heck::*;
 use wasmtime_environ::component::{ResourceIndex, TypeResourceTableIndex};
 use wit_bindgen_core::abi::{Bindgen, Bitcast, Instruction};
 use wit_component::StringEncoding;
 use wit_parser::abi::WasmType;
 use wit_parser::*;
+
+use crate::intrinsics::Intrinsic;
+use crate::source;
+use crate::{uwrite, uwriteln};
 
 #[derive(PartialEq)]
 pub enum ErrHandling {
@@ -1071,7 +1073,7 @@ impl Bindgen for FunctionBindgen<'_> {
                 }
             }
 
-            Instruction::CallInterface { func } => {
+            Instruction::CallInterface { func, .. } => {
                 let results_length = func.results.len();
                 let maybe_async_await = if self.is_async { "await " } else { "" };
                 let call = if self.callee_resource_dynamic {
@@ -1512,6 +1514,20 @@ impl Bindgen for FunctionBindgen<'_> {
                 }
                 results.push(handle);
             }
+
+            // TODO: implement async
+            Instruction::FutureLower { .. }
+            | Instruction::FutureLift { .. }
+            | Instruction::StreamLower { .. }
+            | Instruction::StreamLift { .. }
+            | Instruction::AsyncMalloc { .. }
+            | Instruction::AsyncCallWasm { .. }
+            | Instruction::AsyncPostCallInterface { .. }
+            | Instruction::AsyncCallReturn { .. }
+            | Instruction::Flush { .. }
+            | Instruction::ErrorContextLift { .. }
+            | Instruction::ErrorContextLower { .. } => unimplemented!("async not yet implemented"),
+
             Instruction::GuestDeallocate { .. }
             | Instruction::GuestDeallocateString
             | Instruction::GuestDeallocateList { .. }

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -4,7 +4,7 @@ use std::fmt::Write;
 use std::mem;
 
 use base64::{engine::general_purpose, Engine as _};
-use heck::*;
+use heck::{ToKebabCase, ToLowerCamelCase, ToUpperCamelCase};
 use wasmtime_environ::component::{ExportIndex, NameMap, NameMapNoIntern, Transcode};
 use wasmtime_environ::{
     component,
@@ -1746,7 +1746,6 @@ impl<'a> Instantiator<'a, '_> {
                 AbiVariant::GuestImportAsync => todo!("async not yet implemented"),
                 AbiVariant::GuestExportAsync => todo!("async not yet implemented"),
                 AbiVariant::GuestExportAsyncStackful => todo!("async not yet implemented"),
-
             },
             func,
             &mut f,

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -1,19 +1,10 @@
-use crate::core;
-use crate::esm_bindgen::EsmBindgen;
-use crate::files::Files;
-use crate::function_bindgen::{
-    ErrHandling, FunctionBindgen, ResourceData, ResourceMap, ResourceTable,
-};
-use crate::intrinsics::{render_intrinsics, Intrinsic};
-use crate::names::{is_js_reserved_word, maybe_quote_id, maybe_quote_member, LocalNames};
-use crate::source;
-use crate::{uwrite, uwriteln};
-use base64::{engine::general_purpose, Engine as _};
-use heck::*;
 use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::fmt::Write;
 use std::mem;
+
+use base64::{engine::general_purpose, Engine as _};
+use heck::*;
 use wasmtime_environ::component::{ExportIndex, NameMap, NameMapNoIntern, Transcode};
 use wasmtime_environ::{
     component,
@@ -33,6 +24,17 @@ use wit_parser::{
     Function, FunctionKind, Handle, Resolve, SizeAlign, Type, TypeDefKind, TypeId, WorldId,
     WorldItem, WorldKey,
 };
+
+use crate::core;
+use crate::esm_bindgen::EsmBindgen;
+use crate::files::Files;
+use crate::function_bindgen::{
+    ErrHandling, FunctionBindgen, ResourceData, ResourceMap, ResourceTable,
+};
+use crate::intrinsics::{render_intrinsics, Intrinsic};
+use crate::names::{is_js_reserved_word, maybe_quote_id, maybe_quote_member, LocalNames};
+use crate::source;
+use crate::{uwrite, uwriteln};
 
 #[derive(Default, Clone)]
 pub struct TranspileOpts {
@@ -1705,6 +1707,9 @@ impl<'a> Instantiator<'a, '_> {
                 match abi {
                     AbiVariant::GuestExport => ErrHandling::ThrowResultErr,
                     AbiVariant::GuestImport => ErrHandling::ResultCatchHandler,
+                    AbiVariant::GuestImportAsync => todo!("async not yet implemented"),
+                    AbiVariant::GuestExportAsync => todo!("async not yet implemented"),
+                    AbiVariant::GuestExportAsyncStackful => todo!("async not yet implemented"),
                 }
             } else {
                 ErrHandling::None
@@ -1738,9 +1743,15 @@ impl<'a> Instantiator<'a, '_> {
             match abi {
                 AbiVariant::GuestImport => LiftLower::LiftArgsLowerResults,
                 AbiVariant::GuestExport => LiftLower::LowerArgsLiftResults,
+                AbiVariant::GuestImportAsync => todo!("async not yet implemented"),
+                AbiVariant::GuestExportAsync => todo!("async not yet implemented"),
+                AbiVariant::GuestExportAsyncStackful => todo!("async not yet implemented"),
+
             },
             func,
             &mut f,
+            // TODO: implement async
+            false,
         );
         self.src.js(&f.src);
         self.src.js("}");

--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -1,19 +1,21 @@
+use std::collections::btree_map::Entry;
+use std::collections::{BTreeMap, HashSet};
+use std::fmt::Write;
+
+use anyhow::{Context as _, Result};
+use heck::{ToKebabCase, ToUpperCamelCase, ToLowerCamelCase};
+use log::debug;
+use wit_bindgen_core::wit_parser::{
+    Docs, Enum, Flags, Function, FunctionKind, Handle, InterfaceId, Record, Resolve, Result_,
+    Tuple, Type, TypeDefKind, TypeId, TypeOwner, Variant, WorldId, WorldItem, WorldKey,
+};
+
 use crate::files::Files;
 use crate::function_bindgen::{array_ty, as_nullable, maybe_null};
 use crate::names::{is_js_identifier, maybe_quote_id, LocalNames, RESERVED_KEYWORDS};
 use crate::source::Source;
 use crate::transpile_bindgen::{parse_world_key, AsyncMode, InstantiationMode, TranspileOpts};
 use crate::{dealias, feature_gate_allowed, uwrite, uwriteln};
-use anyhow::{Context as _, Result};
-use heck::*;
-use log::debug;
-use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, HashSet};
-use std::fmt::Write;
-use wit_bindgen_core::wit_parser::{
-    Docs, Enum, Flags, Function, FunctionKind, Handle, InterfaceId, Record, Resolve, Result_,
-    Tuple, Type, TypeDefKind, TypeId, TypeOwner, Variant, WorldId, WorldItem, WorldKey,
-};
 
 struct TsBindgen {
     /// The source code for the "main" file that's going to be created for the

--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeMap, HashSet};
 use std::fmt::Write;
 
 use anyhow::{Context as _, Result};
-use heck::{ToKebabCase, ToUpperCamelCase, ToLowerCamelCase};
+use heck::{ToKebabCase, ToLowerCamelCase, ToUpperCamelCase};
 use log::debug;
 use wit_bindgen_core::wit_parser::{
     Docs, Enum, Flags, Function, FunctionKind, Handle, InterfaceId, Record, Resolve, Result_,

--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -168,8 +168,11 @@ pub fn ts_bindgen(
                         TypeDefKind::Result(r) => gen.type_result(*tid, name, r, &ty.docs),
                         TypeDefKind::List(t) => gen.type_list(*tid, name, t, &ty.docs),
                         TypeDefKind::Type(t) => gen.type_alias(*tid, name, t, None, &ty.docs),
-                        TypeDefKind::Future(_) => todo!("generate for future"),
-                        TypeDefKind::Stream(_) => todo!("generate for stream"),
+                        TypeDefKind::Future(_) => todo!("(async impl) generate for future"),
+                        TypeDefKind::Stream(_) => todo!("(async impl) generate for stream"),
+                        TypeDefKind::ErrorContext => {
+                            todo!("(async impl) generate for error-context")
+                        }
                         TypeDefKind::Unknown => unreachable!(),
                         TypeDefKind::Resource => {}
                         TypeDefKind::Handle(_) => todo!(),
@@ -669,8 +672,11 @@ impl<'a> TsInterface<'a> {
                 TypeDefKind::Result(r) => self.type_result(*id, name, r, &ty.docs),
                 TypeDefKind::List(t) => self.type_list(*id, name, t, &ty.docs),
                 TypeDefKind::Type(t) => self.type_alias(*id, name, t, Some(iface_id), &ty.docs),
-                TypeDefKind::Future(_) => todo!("generate for future"),
-                TypeDefKind::Stream(_) => todo!("generate for stream"),
+                TypeDefKind::Future(_) => todo!("(async impl) generate for future"),
+                TypeDefKind::Stream(_) => todo!("(async impl) generate for stream"),
+                TypeDefKind::ErrorContext { .. } => {
+                    todo!("(async impl) generate for error-context")
+                }
                 TypeDefKind::Unknown => unreachable!(),
                 TypeDefKind::Resource => {}
                 TypeDefKind::Handle(_) => todo!(),
@@ -739,6 +745,7 @@ impl<'a> TsInterface<'a> {
                         }
                         panic!("anonymous resource handle");
                     }
+                    TypeDefKind::ErrorContext => todo!("(async impl) anonymous error-context)"),
                 }
             }
         }

--- a/crates/wasm-tools-component/Cargo.toml
+++ b/crates/wasm-tools-component/Cargo.toml
@@ -14,8 +14,8 @@ anyhow = { workspace = true }
 wasm-encoder = { workspace = true }
 wasm-metadata = { workspace = true }
 wasmparser = { workspace = true }
-wasmprinter = { workspace = true }
+wasmprinter = { workspace = true, features = ["component-model"] }
 wat = { workspace = true }
-wit-bindgen = { workspace = true }
+wit-bindgen = { workspace = true, features = ["macros"] }
 wit-component = { workspace = true }
 wit-parser = { workspace = true }

--- a/test/api.js
+++ b/test/api.js
@@ -166,7 +166,7 @@ export async function apiTest(_fixtures) {
         [
           "processed-by",
           [
-            ["wit-component", "0.220.0"],
+            ["wit-component", "0.224.0"],
             ["dummy-gen", "test"],
           ],
         ],
@@ -207,7 +207,7 @@ export async function apiTest(_fixtures) {
         [
           "processed-by",
           [
-            ["wit-component", "0.220.0"],
+            ["wit-component", "0.224.0"],
             ["dummy-gen", "test"],
           ],
         ],

--- a/test/api.js
+++ b/test/api.js
@@ -16,6 +16,9 @@ import { platform } from "node:process";
 
 const isWindows = platform === "win32";
 
+// - (2025/02/04) incrased due to incoming implementations of async and new flush impl
+const FLAVORFUL_WASM_TRANSPILED_CODE_CHAR_LIMIT = 28_500;
+
 export async function apiTest(_fixtures) {
   suite("API", () => {
     test("Transpile", async () => {
@@ -46,7 +49,7 @@ export async function apiTest(_fixtures) {
       strictEqual(imports.length, 4);
       strictEqual(exports.length, 3);
       deepStrictEqual(exports[0], ["test", "instance"]);
-      ok(files[name + ".js"].length < 28_000);
+      ok(files[name + ".js"].length < FLAVORFUL_WASM_TRANSPILED_CODE_CHAR_LIMIT);
     });
 
     test("Transpile to JS", async () => {

--- a/test/cli.js
+++ b/test/cli.js
@@ -567,7 +567,7 @@ export async function cliTest(_fixtures) {
           [
             "processed-by",
             [
-              ["wit-component", "0.220.0"],
+              ["wit-component", "0.224.0"],
               ["dummy-gen", "test"],
             ],
           ],


### PR DESCRIPTION
This PR does a few things: 

- upgrade upstream deps to `x.224.x` variants
- light refactoring around use of dependencies to avoid unnecessary code being pulled in
- add codegen implementation for new flush (this was necessary due to checks that would cause build to fail w/ updated upstream deps)
- mark places where async impl will be needed