### PR TITLE
chore(deps): update to v225.0 of wasmtime upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,12 +392,12 @@ dependencies = [
  "heck 0.5.0",
  "log",
  "semver",
- "wasm-encoder 0.224.0",
- "wasmparser 0.224.0",
+ "wasm-encoder 0.225.0",
+ "wasmparser 0.225.0",
  "wasmtime-environ",
  "wit-bindgen-core",
  "wit-component",
- "wit-parser 0.224.0",
+ "wit-parser 0.225.0",
 ]
 
 [[package]]
@@ -422,6 +422,12 @@ name = "leb128"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
+
+[[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "litemap"
@@ -782,19 +788,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.224.0"
+version = "0.225.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7249cf8cb0c6b9cb42bce90c0a5feb276fbf963fa385ff3d818ab3d90818ed6"
+checksum = "6f7eac0445cac73bcf09e6a97f83248d64356dccf9f2b100199769b6b42464e5"
 dependencies = [
- "leb128",
- "wasmparser 0.224.0",
+ "leb128fmt",
+ "wasmparser 0.225.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.224.0"
+version = "0.225.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79d13d93febc749413cb6f327e4fdba8c84e4d03bd69fcc4a220c66f113c8de1"
+checksum = "f1d20d0bf2c73c32a5114cf35a5c10ccf9f9aa37a3a2c0114b3e11cbf6faac12"
 dependencies = [
  "anyhow",
  "indexmap",
@@ -803,8 +809,8 @@ dependencies = [
  "serde_json",
  "spdx",
  "url",
- "wasm-encoder 0.224.0",
- "wasmparser 0.224.0",
+ "wasm-encoder 0.225.0",
+ "wasmparser 0.225.0",
 ]
 
 [[package]]
@@ -812,14 +818,14 @@ name = "wasm-tools-js"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "wasm-encoder 0.224.0",
+ "wasm-encoder 0.225.0",
  "wasm-metadata",
- "wasmparser 0.224.0",
- "wasmprinter 0.224.0",
+ "wasmparser 0.225.0",
+ "wasmprinter 0.225.0",
  "wat",
  "wit-bindgen",
  "wit-component",
- "wit-parser 0.224.0",
+ "wit-parser 0.225.0",
 ]
 
 [[package]]
@@ -837,9 +843,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.224.0"
+version = "0.225.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65881a664fdd43646b647bb27bf186ab09c05bf56779d40aed4c6dce47d423f5"
+checksum = "36e5456165f81e64cb9908a0fe9b9d852c2c74582aa3fe2be3c2da57f937d3ae"
 dependencies = [
  "bitflags 2.8.0",
  "hashbrown 0.15.2",
@@ -860,13 +866,13 @@ dependencies = [
 
 [[package]]
 name = "wasmprinter"
-version = "0.224.0"
+version = "0.225.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc039e211f6c2137425726f0d76fdd9c439a442e5272bc3627a19274d0eb9686"
+checksum = "8c32de8f41929f40bb595d1309549c58bbe1b43b05627fe42517e23a50230e0a"
 dependencies = [
  "anyhow",
  "termcolor",
- "wasmparser 0.224.0",
+ "wasmparser 0.225.0",
 ]
 
 [[package]]
@@ -902,22 +908,22 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "224.0.0"
+version = "225.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d722a51e62b669d17e5a9f6bc8ec210178b37d869114355aa46989686c5c6391"
+checksum = "c61496027ff707f9fa9e0b22c34ec163eb7adb1070df565e32a9180a76e4300b"
 dependencies = [
  "bumpalo",
- "leb128",
+ "leb128fmt",
  "memchr",
  "unicode-width 0.2.0",
- "wasm-encoder 0.224.0",
+ "wasm-encoder 0.225.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.224.0"
+version = "1.225.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71dece6a7dd5bcbcf8d256606c7fb3faa36286d46bf3f98185407719a5ceede2"
+checksum = "89e72a33942234fd0794bcdac30e43b448de3187512414267678e511c6755f11"
 dependencies = [
  "wast",
 ]
@@ -1030,9 +1036,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b550e454e4cce8984398539a94a0226511e1f295b14afdc8f08b4e2e2ff9de3a"
+checksum = "e4dd9a372b25d6f35456b0a730d2adabeb0c4878066ba8f8089800349be6ecb5"
 dependencies = [
  "wit-bindgen-rt",
  "wit-bindgen-rust-macro",
@@ -1040,29 +1046,29 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e2f98d49960a416074c5d72889f810ed3032a32ffef5e4760094426fefbfe8"
+checksum = "f108fa9b77a346372858b30c11ea903680e7e2b9d820b1a5883e9d530bf51c7e"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.224.0",
+ "wit-parser 0.225.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed6f8d372a2d4a1227f2556e051cc24b2a5f15768d53451c84ff91e2527139e3"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.8.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cc49091f84e4f2ace078bbc86082b57e667b9e789baece4b1184e0963382b6e"
+checksum = "e5ba5b852e976d35dbf6cb745746bf1bd4fc26782bab1e0c615fc71a7d8aac05"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -1076,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3545a699dc9d72298b2064ce71b771fc10fc6b757d29306b1e54a4283a75abba"
+checksum = "401529c9af9304a20ed99fa01799e467b7d37727126f0c9a958895471268ad7a"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -1091,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.224.0"
+version = "0.225.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad555ab4f4e676474df746d937823c7279c2d6dd36c3e97a61db893d4ef64ee5"
+checksum = "2505c917564c1d74774563bbcd3e4f8c216a6508050862fd5f449ee56e3c5125"
 dependencies = [
  "anyhow",
  "bitflags 2.8.0",
@@ -1102,11 +1108,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.224.0",
+ "wasm-encoder 0.225.0",
  "wasm-metadata",
- "wasmparser 0.224.0",
+ "wasmparser 0.225.0",
  "wat",
- "wit-parser 0.224.0",
+ "wit-parser 0.225.0",
 ]
 
 [[package]]
@@ -1146,9 +1152,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.224.0"
+version = "0.225.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e2925a7365d2c6709ae17bdbb5777ffd8154fd70906b413fc01b75f0dba59e"
+checksum = "ebefaa234e47224f10ce60480c5bfdece7497d0f3b87a12b41ff39e5c8377a78"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -1159,7 +1165,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "unicode-xid",
- "wasmparser 0.224.0",
+ "wasmparser 0.225.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,20 +42,20 @@ log = { version = "0.4.22", default-features = false }
 semver = { version = "1.0.25", default-features = false }
 js-component-bindgen = { path = "./crates/js-component-bindgen" }
 structopt = { version = "0.3.26", default-features = false }
-wasm-encoder = { version = "0.224.0", default-features = false }
-wasm-metadata = { version = "0.224.0", default-features = false }
-wasmparser = { version = "0.224.0", default-features = false }
-wasmprinter = { version = "0.224.0", default-features = false }
+wasm-encoder = { version = "0.225.0", default-features = false }
+wasm-metadata = { version = "0.225.0", default-features = false }
+wasmparser = { version = "0.225.0", default-features = false }
+wasmprinter = { version = "0.225.0", default-features = false }
 wasmtime-environ = { version = "29.0.0", features = [
   "component-model",
   "compile",
 ] }
-wat = { version = "1.224.0", default-features = false }
+wat = { version = "1.225.0", default-features = false }
 webidl2wit = { version = "0.1.0", default-features = false }
-wit-bindgen = { version = "0.38.0", default-features = false }
-wit-bindgen-core = { version = "0.38.0", default-features = false }
-wit-component = { version = "0.224.0", features = ["dummy-module"] }
-wit-parser = { version = "0.224.0", default-features = false }
+wit-bindgen = { version = "0.39.0", default-features = false }
+wit-bindgen-core = { version = "0.39.0", default-features = false }
+wit-component = { version = "0.225.0", features = ["dummy-module"] }
+wit-parser = { version = "0.225.0", default-features = false }
 xshell = { version = "0.2.6", default-features = false }
 
 [dev-dependencies]

--- a/test/api.js
+++ b/test/api.js
@@ -169,7 +169,7 @@ export async function apiTest(_fixtures) {
         [
           "processed-by",
           [
-            ["wit-component", "0.224.0"],
+            ["wit-component", "0.225.0"],
             ["dummy-gen", "test"],
           ],
         ],
@@ -210,7 +210,7 @@ export async function apiTest(_fixtures) {
         [
           "processed-by",
           [
-            ["wit-component", "0.224.0"],
+            ["wit-component", "0.225.0"],
             ["dummy-gen", "test"],
           ],
         ],

--- a/test/cli.js
+++ b/test/cli.js
@@ -567,7 +567,7 @@ export async function cliTest(_fixtures) {
           [
             "processed-by",
             [
-              ["wit-component", "0.224.0"],
+              ["wit-component", "0.225.0"],
               ["dummy-gen", "test"],
             ],
           ],


### PR DESCRIPTION
This commit updates the repo to 225.x and related in upstream wasmtime crates.

This was found to be necessary thanks to @calvinrp for charging ahead on trying built async components locally.