### PR TITLE
Added JS globals ArrayBuffer, TextDecoder, TextEncoder

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics.rs
+++ b/crates/js-component-bindgen/src/intrinsics.rs
@@ -712,6 +712,7 @@ impl Intrinsic {
             "validateGuestChar",
             "validateHostChar",
             // JS Globals / non intrinsic names
+            "ArrayBuffer",
             "BigInt",
             "BigInt64Array",
             "DataView",
@@ -725,6 +726,8 @@ impl Intrinsic {
             "Object",
             "process",
             "String",
+            "TextDecoder",
+            "TextEncoder",
             "toUint64",
             "TypeError",
             "Uint16Array",


### PR DESCRIPTION
Adds ArrayBuffer, TextDecoder, TextEncoder, to global names.

Currently, components that export resources with any of these names override JS's types of the same name. This causes problems in Jco glue code, as these types are used there.
