### PR TITLE
fix(docs): generation of gh pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,4 +33,4 @@ jobs:
         if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/book
+          publish_dir: ./docs/book/html


### PR DESCRIPTION
Just noticed that the [jco book](https://bytecodealliance.github.io/jco) is not accessible -- it looks like the path of the generated code from mdbook was wrong -- the generated code now lives in `docs/book/html`, I think due to the introduction of `mdbook-linkcheck`.