### PR TITLE
chore: ensure package-lock.json isn't checked in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 
 # Test output
 test/fixtures/modules/hello_stdout.component.wasm
+package-lock.json


### PR DESCRIPTION
This commit ensures that package-lock.json isn't checked in, as npm version v7 and up uses "hidden" lockfiles in node_modules.