### PR TITLE
fix: wait 500ms before running a browser request

### DIFF
--- a/test/browser.js
+++ b/test/browser.js
@@ -53,6 +53,7 @@ suite("Browser", () => {
       }
     }).listen(port);
 
+    await new Promise(resolve => setTimeout(resolve, 500));
     browser = await puppeteer.launch();
   });
 


### PR DESCRIPTION
This is an attempt to fix https://github.com/bytecodealliance/jco/issues/600.