### PR TITLE
refactor: pass more debug options to componentize

### DIFF
--- a/packages/jco/src/cmd/componentize.js
+++ b/packages/jco/src/cmd/componentize.js
@@ -28,7 +28,20 @@ export async function componentize(jsSource, opts) {
             enableFeatures: opts.enable,
             preview2Adapter: opts.preview2Adapter,
             debugBuild: opts.debugStarlingmonkeyBuild,
+            debug: {
+                bindings: opts.debugBindings,
+                bindingsDir: opts.debugBindingsDir,
+                binary: opts.debugBinary,
+                binaryPath: opts.debugBinaryPath,
+                enableWizerLogging: opts.debugEnableWizerLogging,
+            },
         });
+        if (result.debug) {
+            console.error(
+                c`{cyan DEBUG} Debug output\n${JSON.stringify(debug, null, 2)}\n`
+            );
+        }
+
         component = result.component;
     } catch (err) {
         // Detect package resolution issues that usually mean a misconfigured "witPath"

--- a/packages/jco/src/jco.js
+++ b/packages/jco/src/jco.js
@@ -68,6 +68,23 @@ program
         'use a debug build of StarlingMonkey'
     )
     .requiredOption('-o, --out <out>', 'output component file')
+    .option(
+        '--debug-bindings',
+        'Output debug bindings and metadata during componentization (by default to stderr)'
+    )
+    .option(
+        '--debug-bindings-dir <dir>',
+        'Directory to which to output generated bindings and metadata'
+    )
+    .option(
+        '--debug-binary',
+        'Output binary (without component metadata) created during componentization (by default to tmp dir)'
+    )
+    .option(
+        '--debug-binary-path <path>',
+        'Path to which to write the generated debug binary'
+    )
+    .option('--debug-enable-wizer-logging', 'Enable wizer call debugging')
     .action(asyncAction(componentize));
 
 program


### PR DESCRIPTION
This commit makes use of new functionality in componentize that enables passing in more debug options, and outputs information from debugging during the jco build.

NOTE: this depends on some unreleased code for `componentize-js`:
https://github.com/bytecodealliance/ComponentizeJS/pull/203