### PR TITLE
feat(ux): add hint for incorrect witPath setting

### DIFF
--- a/src/cmd/componentize.js
+++ b/src/cmd/componentize.js
@@ -1,51 +1,51 @@
-import { readFile, writeFile } from "node:fs/promises";
-import { resolve, basename } from "node:path";
+import { readFile, writeFile } from 'node:fs/promises';
+import { resolve, basename } from 'node:path';
 
-import c from "chalk-template";
+import c from 'chalk-template';
 
 export async function componentize(jsSource, opts) {
-  const { componentize: componentizeFn } = await eval(
-    'import("@bytecodealliance/componentize-js")',
-  );
-  if (opts.disable?.includes("all")) {
-    opts.disable = ["stdio", "random", "clocks", "http"];
-  }
-  const source = await readFile(jsSource, "utf8");
-
-  const witPath = resolve(opts.wit);
-  const sourceName = basename(jsSource);
-
-  let component;
-  try {
-    const result = await componentizeFn(source, {
-      enableAot: opts.aot,
-      aotMinStackSizeBytes: opts.aotMinStackSizeBytes,
-      wevalBin: opts.wevalBin,
-      sourceName,
-      witPath,
-      worldName: opts.worldName,
-      disableFeatures: opts.disable,
-      enableFeatures: opts.enable,
-      preview2Adapter: opts.preview2Adapter,
-    });
-    component = result.component;
-  } catch (err) {
-    // Detect package resolution issues that usually mean a misconfigured "witPath"
-    if (err.toString().includes("no known packages")) {
-      const isFile = await stat(witPath).then((s) => s.isFile());
-      if (isFile) {
-        const hint = await printWITPathHint(witPath);
-        if (err.message) {
-          err.message += `\n${hint}`;
-        }
-      }
+    const { componentize: componentizeFn } = await eval(
+        'import("@bytecodealliance/componentize-js")'
+    );
+    if (opts.disable?.includes('all')) {
+        opts.disable = ['stdio', 'random', 'clocks', 'http'];
     }
-    throw err;
-  }
+    const source = await readFile(jsSource, 'utf8');
 
-  await writeFile(opts.out, component);
+    const witPath = resolve(opts.wit);
+    const sourceName = basename(jsSource);
 
-  console.log(c`{green OK} Successfully written {bold ${opts.out}}.`);
+    let component;
+    try {
+        const result = await componentizeFn(source, {
+            enableAot: opts.aot,
+            aotMinStackSizeBytes: opts.aotMinStackSizeBytes,
+            wevalBin: opts.wevalBin,
+            sourceName,
+            witPath,
+            worldName: opts.worldName,
+            disableFeatures: opts.disable,
+            enableFeatures: opts.enable,
+            preview2Adapter: opts.preview2Adapter,
+        });
+        component = result.component;
+    } catch (err) {
+        // Detect package resolution issues that usually mean a misconfigured "witPath"
+        if (err.toString().includes('no known packages')) {
+            const isFile = await stat(witPath).then((s) => s.isFile());
+            if (isFile) {
+                const hint = await printWITPathHint(witPath);
+                if (err.message) {
+                    err.message += `\n${hint}`;
+                }
+            }
+        }
+        throw err;
+    }
+
+    await writeFile(opts.out, component);
+
+    console.log(c`{green OK} Successfully written {bold ${opts.out}}.`);
 }
 
 /**
@@ -55,14 +55,14 @@ export async function componentize(jsSource, opts) {
  * @returns {string} user-visible, highlighted output that can be printed
  */
 async function printWITPathHint(witPath) {
-  const pathMeta = await stat(witPath);
-  let output = "\n";
-  if (!pathMeta.isFile() && !pathMeta.isDirectory()) {
-    output += c`{yellow.bold warning} The supplited WIT path [${witPath}] is neither a file or directory.\n`;
+    const pathMeta = await stat(witPath);
+    let output = '\n';
+    if (!pathMeta.isFile() && !pathMeta.isDirectory()) {
+        output += c`{yellow.bold warning} The supplited WIT path [${witPath}] is neither a file or directory.\n`;
+        return output;
+    }
+    output += c`{yellow.bold warning} Your WIT path option [${witPath}] may be incorrect\n`;
+    output += c`{yellow.bold warning} When using a world with dependencies, you must pass the enclosing WIT folder, not a single file.\n`;
+    output += c`{yellow.bold warning} (e.g. 'wit/', rather than 'wit/component.wit').\n`;
     return output;
-  }
-  output += c`{yellow.bold warning} Your WIT path option [${witPath}] may be incorrect\n`;
-  output += c`{yellow.bold warning} When using a world with dependencies, you must pass the enclosing WIT folder, not a single file.\n`;
-  output += c`{yellow.bold warning} (e.g. 'wit/', rather than 'wit/component.wit').\n`;
-  return output;
 }

--- a/src/cmd/componentize.js
+++ b/src/cmd/componentize.js
@@ -11,17 +11,58 @@ export async function componentize(jsSource, opts) {
     opts.disable = ["stdio", "random", "clocks", "http"];
   }
   const source = await readFile(jsSource, "utf8");
-  const { component } = await componentizeFn(source, {
-    enableAot: opts.aot,
-    aotMinStackSizeBytes: opts.aotMinStackSizeBytes,
-    wevalBin: opts.wevalBin,
-    sourceName: basename(jsSource),
-    witPath: resolve(opts.wit),
-    worldName: opts.worldName,
-    disableFeatures: opts.disable,
-    enableFeatures: opts.enable,
-    preview2Adapter: opts.preview2Adapter,
-  });
+
+  const witPath = resolve(opts.wit);
+  const sourceName = basename(jsSource);
+
+  let component;
+  try {
+    const result = await componentizeFn(source, {
+      enableAot: opts.aot,
+      aotMinStackSizeBytes: opts.aotMinStackSizeBytes,
+      wevalBin: opts.wevalBin,
+      sourceName,
+      witPath,
+      worldName: opts.worldName,
+      disableFeatures: opts.disable,
+      enableFeatures: opts.enable,
+      preview2Adapter: opts.preview2Adapter,
+    });
+    component = result.component;
+  } catch (err) {
+    // Detect package resolution issues that usually mean a misconfigured "witPath"
+    if (err.toString().includes("no known packages")) {
+      const isFile = await stat(witPath).then((s) => s.isFile());
+      if (isFile) {
+        const hint = await printWITPathHint(witPath);
+        if (err.message) {
+          err.message += `\n${hint}`;
+        }
+      }
+    }
+    throw err;
+  }
+
   await writeFile(opts.out, component);
+
   console.log(c`{green OK} Successfully written {bold ${opts.out}}.`);
+}
+
+/**
+ * Print a hint about the witPath option that may be incorrect
+ *
+ * @param {string} witPath - witPath option that was used (which is a path that resolves to a file or directory)
+ * @returns {string} user-visible, highlighted output that can be printed
+ */
+async function printWITPathHint(witPath) {
+  const pathMeta = await stat(witPath);
+  let output = "\n";
+  if (!pathMeta.isFile() && !pathMeta.isDirectory()) {
+    output += c`{yellow.bold warning} The supplited WIT path [${witPath}] is neither a file or directory.\n`;
+    return output;
+  }
+  output += c`{yellow.bold warning} Your WIT path option [${witPath}] may be incorrect\n`;
+  output += c`{yellow.bold warning} When using a world with dependencies, you must pass the enclosing WIT folder, not a single file.\n`;
+  output += c`{yellow.bold warning} (e.g. 'wit/', rather than 'wit/component.wit').\n`;
+  return output;
 }

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -144,18 +144,18 @@ export async function typesComponent(witPath, opts) {
  * @param {(string, any) => void} consoleFn
  */
 async function printWITLayoutHint(witPath) {
-  const pathMeta = await stat(witPath);
-  let output = "\n";
-  if (!pathMeta.isFile() && !pathMeta.isDirectory()) {
-    output += c`{yellow.bold warning} The supplited WIT path [${witPath}] is neither a file or directory.\n`;
+    const pathMeta = await stat(witPath);
+    let output = '\n';
+    if (!pathMeta.isFile() && !pathMeta.isDirectory()) {
+        output += c`{yellow.bold warning} The supplited WIT path [${witPath}] is neither a file or directory.\n`;
+        return output;
+    }
+    const ftype = pathMeta.isDirectory() ? 'directory' : 'file';
+    output += c`{yellow.bold warning} Your WIT ${ftype} [${witPath}] may be laid out incorrectly\n`;
+    output += c`{yellow.bold warning} Keep in mind the following rules:\n`;
+    output += c`{yellow.bold warning}     - Top level WIT files are in the same package (i.e. "ns:pkg" in "wit/*.wit")\n`;
+    output += c`{yellow.bold warning}     - All package dependencies should be in "wit/deps" (i.e. "some:dep" in "wit/deps/some-dep.wit"\n`;
     return output;
-  }
-  const ftype = pathMeta.isDirectory() ? "directory" : "file";
-  output += c`{yellow.bold warning} Your WIT ${ftype} [${witPath}] may be laid out incorrectly\n`;
-  output += c`{yellow.bold warning} Keep in mind the following rules:\n`;
-  output += c`{yellow.bold warning}     - Top level WIT files are in the same package (i.e. "ns:pkg" in "wit/*.wit")\n`;
-  output += c`{yellow.bold warning}     - All package dependencies should be in "wit/deps" (i.e. "some:dep" in "wit/deps/some-dep.wit"\n`;
-  return output;
 }
 
 async function writeFiles(files, summaryTitle) {

--- a/src/cmd/transpile.js
+++ b/src/cmd/transpile.js
@@ -1,5 +1,5 @@
 import { platform } from 'node:process';
-import { writeFile, lstat } from 'node:fs/promises';
+import { writeFile, stat } from 'node:fs/promises';
 import { mkdir } from 'node:fs/promises';
 import { dirname, extname, basename, resolve } from 'node:path';
 
@@ -144,18 +144,18 @@ export async function typesComponent(witPath, opts) {
  * @param {(string, any) => void} consoleFn
  */
 async function printWITLayoutHint(witPath) {
-    const stat = await lstat(witPath);
-    let output = '\n';
-    if (!stat.isFile() && !stat.isDirectory()) {
-        output += c`{yellow.bold warning} The supplited WIT path [${witPath}] is neither a file or directory.\n`;
-        return output;
-    }
-    const ftype = stat.isDirectory() ? 'directory' : 'file';
-    output += c`{yellow.bold warning} Your WIT ${ftype} [${witPath}] may be laid out incorrectly\n`;
-    output += c`{yellow.bold warning} Keep in mind the following rules:\n`;
-    output += c`{yellow.bold warning}     - Top level WIT files are in the same package (i.e. "ns:pkg" in "wit/*.wit")\n`;
-    output += c`{yellow.bold warning}     - All package dependencies should be in "wit/deps" (i.e. "some:dep" in "wit/deps/some-dep.wit"\n`;
+  const pathMeta = await stat(witPath);
+  let output = "\n";
+  if (!pathMeta.isFile() && !pathMeta.isDirectory()) {
+    output += c`{yellow.bold warning} The supplited WIT path [${witPath}] is neither a file or directory.\n`;
     return output;
+  }
+  const ftype = pathMeta.isDirectory() ? "directory" : "file";
+  output += c`{yellow.bold warning} Your WIT ${ftype} [${witPath}] may be laid out incorrectly\n`;
+  output += c`{yellow.bold warning} Keep in mind the following rules:\n`;
+  output += c`{yellow.bold warning}     - Top level WIT files are in the same package (i.e. "ns:pkg" in "wit/*.wit")\n`;
+  output += c`{yellow.bold warning}     - All package dependencies should be in "wit/deps" (i.e. "some:dep" in "wit/deps/some-dep.wit"\n`;
+  return output;
 }
 
 async function writeFiles(files, summaryTitle) {


### PR DESCRIPTION
This PR adds a hint that shows users when they use an *incorrect* WIT path (ex. using `wit/world.wit` when there are deps, and `wit/` should be used).

Ideally we can automatically determine this for them in the future (ex. when the WIT path is optional), but for now at least common errors should have good guiding error messages.

![warning-txt](https://github.com/user-attachments/assets/01033a84-d448-47b1-9ba8-4a3c59d0da8d)
