### PR TITLE
docs: fix rendering for | in code blocks in table

### DIFF
--- a/docs/src/wit-type-representations.md
+++ b/docs/src/wit-type-representations.md
@@ -137,8 +137,8 @@ Jco represents options as an optional value or undefined, so some examples:
 
 | Type                  | Representation (TS)                     | Example                               |
 |-----------------------|-----------------------------------------|---------------------------------------|
-| `option<u32>`         | `number | undefined`                    | `option<u32>` -> `number | undefined` |
-| `option<option<u32>>` | `{ tag: "some" | "none", val: number }` | `option<u32>` -> `number | undefined` |
+| `option<u32>`         | <code>number \| undefined</code>                    | `option<u32>` -> <code>number \| undefined</code> |
+| `option<option<u32>>` | <code>{ tag: "some" \| "none", val: number }</code> | `option<u32>` -> <code>number \| undefined</code> |
 
 > [!WARNING]
 > "single level" `option`s are easy to reason about, but the doubly nested case (`option<option<_>>`) is more complex.


### PR DESCRIPTION
In https://bytecodealliance.github.io/jco/wit-type-representations.html#options-option

before
<img width="661" alt="Screenshot 2025-04-02 at 17 07 02" src="https://github.com/user-attachments/assets/94645726-b50c-4a87-8a51-ebc89cf5e86a" />


after
<img width="741" alt="Screenshot 2025-04-02 at 17 08 11" src="https://github.com/user-attachments/assets/c055e228-34b6-49e4-9021-b08fb1ce9601" />


The `|` was not rendering correctly inside code blocks within tables when processed by `mdbook`. https://github.com/rust-lang/mdBook/issues/637

Ideally, this should be addressed by the upstream. The root cause of this problem in `pulldown-cmark` has recently been fixed. https://github.com/pulldown-cmark/pulldown-cmark/issues/356 However, `mdbook` seems to expose the `pulldown-cmark` types as a public API, and is currently facing difficulties updating its dependencies. https://github.com/rust-lang/mdBook/pull/2386
Therefore, the upstream fix may not available in any time soon.

As a workaround for the time being, use `<code>` tag instead of code blocks in tables with `|`.