### PR TITLE
chore(examples): re-add componentize-js dep for examples

### DIFF
--- a/examples/components/add/package.json
+++ b/examples/components/add/package.json
@@ -9,6 +9,7 @@
     "all": "npm run build && npm run transpile && npm run transpiled-js"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.10.2"
+    "@bytecodealliance/jco": "^1.10.2",
+    "@bytecodealliance/componentize-js": "0.17.0"
   }
 }

--- a/examples/components/http-hello-world/package.json
+++ b/examples/components/http-hello-world/package.json
@@ -10,7 +10,8 @@
     "all": "npm run build && npm run demo"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.10.2"
+    "@bytecodealliance/jco": "^1.10.2",
+    "@bytecodealliance/componentize-js": "0.17.0"
   },
   "devDependencies": {
     "terminate": "^2.8.0"

--- a/examples/components/node-fetch/package.json
+++ b/examples/components/node-fetch/package.json
@@ -9,6 +9,7 @@
     "all": "npm run build:component && npm run transpile && npm run demo"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.10.2"
+    "@bytecodealliance/jco": "^1.10.2",
+    "@bytecodealliance/componentize-js": "0.17.0"
   }
 }

--- a/examples/components/string-reverse-upper/package.json
+++ b/examples/components/string-reverse-upper/package.json
@@ -11,6 +11,7 @@
     "all": "npm run build:dep ; npm run build ; npm run compose ; npm run transpile ; npm run transpiled-js"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.10.2"
+    "@bytecodealliance/jco": "^1.10.2",
+    "@bytecodealliance/componentize-js": "0.17.0"
   }
 }

--- a/examples/components/string-reverse/package.json
+++ b/examples/components/string-reverse/package.json
@@ -9,6 +9,7 @@
     "all": "npm run build; npm run transpile; npm run transpiled-js"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.10.2"
+    "@bytecodealliance/jco": "^1.10.2",
+    "@bytecodealliance/componentize-js": "0.17.0"
   }
 }

--- a/examples/components/webidl-book-library/package.json
+++ b/examples/components/webidl-book-library/package.json
@@ -10,6 +10,7 @@
     "all": "npm run generate:wit && npm run generate:types && npm run build && npm run transpile && node demo.js"
   },
   "devDependencies": {
-    "@bytecodealliance/jco": "1.10.2"
+    "@bytecodealliance/jco": "1.10.2",
+    "@bytecodealliance/componentize-js": "0.17.0"
   }
 }


### PR DESCRIPTION
This commit re-adds the componentize-js dep for examples, as when building components jco will dynamically import.