### PR TITLE
release: jco v1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [jco-v1.11.0] - 2025-04-28
+
+### 🚀 Features
+
+* *(jco)* expose comoponentizejs's debugBuild option on command line (#633) by @pchickey in #633
+
+
+
+## New Contributors
+* @tanishiking made their first contribution in [#631](https://github.com/bytecodealliance/jco/pull/631)
+* @marosset made their first contribution in [#609](https://github.com/bytecodealliance/jco/pull/609)
+* @MendyBerger made their first contribution in [#591](https://github.com/bytecodealliance/jco/pull/591)

--- a/examples/components/add/package.json
+++ b/examples/components/add/package.json
@@ -9,7 +9,7 @@
     "all": "npm run build && npm run transpile && npm run transpiled-js"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.10.2",
+    "@bytecodealliance/jco": "^1.11.0",
     "@bytecodealliance/componentize-js": "0.17.0"
   }
 }

--- a/examples/components/http-hello-world/package.json
+++ b/examples/components/http-hello-world/package.json
@@ -10,7 +10,7 @@
     "all": "npm run build && npm run demo"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.10.2",
+    "@bytecodealliance/jco": "^1.11.0",
     "@bytecodealliance/componentize-js": "0.17.0"
   },
   "devDependencies": {

--- a/examples/components/node-fetch/package.json
+++ b/examples/components/node-fetch/package.json
@@ -9,7 +9,7 @@
     "all": "npm run build:component && npm run transpile && npm run demo"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.10.2",
+    "@bytecodealliance/jco": "^1.11.0",
     "@bytecodealliance/componentize-js": "0.17.0"
   }
 }

--- a/examples/components/string-reverse-upper/package.json
+++ b/examples/components/string-reverse-upper/package.json
@@ -11,7 +11,7 @@
     "all": "npm run build:dep ; npm run build ; npm run compose ; npm run transpile ; npm run transpiled-js"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.10.2",
+    "@bytecodealliance/jco": "^1.11.0",
     "@bytecodealliance/componentize-js": "0.17.0"
   }
 }

--- a/examples/components/string-reverse/package.json
+++ b/examples/components/string-reverse/package.json
@@ -9,7 +9,7 @@
     "all": "npm run build; npm run transpile; npm run transpiled-js"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.10.2",
+    "@bytecodealliance/jco": "^1.11.0",
     "@bytecodealliance/componentize-js": "0.17.0"
   }
 }

--- a/examples/components/webidl-book-library/package.json
+++ b/examples/components/webidl-book-library/package.json
@@ -10,7 +10,7 @@
     "all": "npm run generate:wit && npm run generate:types && npm run build && npm run transpile && node demo.js"
   },
   "devDependencies": {
-    "@bytecodealliance/jco": "1.10.2",
+    "@bytecodealliance/jco": "1.11.0",
     "@bytecodealliance/componentize-js": "0.17.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bytecodealliance/jco",
-  "version": "1.10.2",
+  "version": "1.11.0",
   "description": "JavaScript tooling for working with WebAssembly Components",
   "author": "Guy Bedford",
   "bin": {


### PR DESCRIPTION
This is a release prep branch for `jco` release `v1.11.0`.

To ensure this release is ready to be merged:
  - [x] Review updated CHANGELOG(s)

After merging this PR, please do the following:
  - [ ] Run the `tag-release` CI workflow (specifying the commit hash of this PR once fast-forwarded onto `main`)
  - [ ] Run the `release` CI workflow (specifying the released tag)
  - [ ] Make releases to downstream repositories (e.g. NPM) for the released artifacts as necessary