### PR TITLE
fix: make package build steps prepack

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lint:fix": "npm run lint -- --fix",
     "test": "vitest run -c test/vitest.ts",
     "test:lts": "vitest run -c test/vitest.lts.ts",
-    "prepublishOnly": "cargo xtask build release && npm run test"
+    "prepack": "cargo xtask build release && npm run test"
   },
   "files": [
     "lib",


### PR DESCRIPTION
This commit fixes the automated release issue caused by `obj/*` files not being included in the packaged tarball. This step should have been pre pack rather than prepublish.