### PR TITLE
fix: appending to const value raises error

### DIFF
--- a/src/cmd/run.js
+++ b/src/cmd/run.js
@@ -117,7 +117,7 @@ async function runComponent(componentPath, args, opts, executor) {
                 '../../../'
             );
         } catch (err) {
-            const msg = c`{red.bold error} Failed to resolve {bold @bytecodealliance/preview2-shim}, ensure it is installed.`;
+            let msg = c`{red.bold error} Failed to resolve {bold @bytecodealliance/preview2-shim}, ensure it is installed.`;
             msg += `\nERROR:\n${err.toString()}`;
             throw new Error(msg);
         }


### PR DESCRIPTION
Small fix, it did an append to a const variable. This crashes the error handling.