### PR TITLE
chore: always install puppeteer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -144,7 +144,6 @@ jobs:
           path: |
             /home/runner/.cache/puppeteer
       - name: Install puppeteer
-        if: steps.cache-puppeteer.outputs.cache-hit != 'true'
         run: |
           npx puppeteer browsers install chrome
 


### PR DESCRIPTION
This commit changes puppeteer to always be installed, in case the version is missing