### PR TITLE
chore(p3-shim): add release automation, docs for p3-shim

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
     directories:
       - '/'
       - '/packages/preview2-shim'
+      - '/packages/preview3-shim'
       - '/examples/components/*'
     groups:
       example-dependencies:

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -14,6 +14,7 @@ on:
           - jco
           - js-component-bindgen
           - preview2-shim
+          - preview3-shim
         description: |
           Project to prep for release (ex. `0.1.0`)
 
@@ -84,6 +85,11 @@ jobs:
               export IS_JS_PROJECT=true;
               ;;
             preview2-shim)
+              export PROJECT_DIR="$PWD/packages/$PROJECT";
+              export CURRENT_VERSION=$(node -e "process.stdout.write(require(process.env.PROJECT_DIR + '/package.json').version)");
+              export IS_JS_PROJECT=true;
+              ;;
+            preview3-shim)
               export PROJECT_DIR="$PWD/packages/$PROJECT";
               export CURRENT_VERSION=$(node -e "process.stdout.write(require(process.env.PROJECT_DIR + '/package.json').version)");
               export IS_JS_PROJECT=true;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ on:
       - "jco-v[0-9]+.[0-9]+.[0-9]+-*"
       - "preview2-shim-v[0-9]+.[0-9]+.[0-9]+*"
       - "preview2-shim-v[0-9]+.[0-9]+.[0-9]+-*"
+      - "preview3-shim-v[0-9]+.[0-9]+.[0-9]+*"
+      - "preview3-shim-v[0-9]+.[0-9]+.[0-9]+-*"
       - "js-component-bindgen-v[0-9]+.[0-9]+.[0-9]+*"
       - "js-component-bindgen-v[0-9]+.[0-9]+.[0-9]+-*"
     branches:
@@ -16,6 +18,8 @@ on:
       - "prep-release-jco-v[0-9]+.[0-9]+.[0-9]+-*"
       - "prep-release-preview2-shim-v[0-9]+.[0-9]+.[0-9]+*"
       - "prep-release-preview2-shim-v[0-9]+.[0-9]+.[0-9]+-*"
+      - "prep-release-preview3-shim-v[0-9]+.[0-9]+.[0-9]+*"
+      - "prep-release-preview3-shim-v[0-9]+.[0-9]+.[0-9]+-*"
       - "prep-release-js-component-bindgen-v[0-9]+.[0-9]+.[0-9]+*"
       - "prep-release-js-component-bindgen-v[0-9]+.[0-9]+.[0-9]+-*"
 
@@ -29,6 +33,7 @@ on:
           - jco
           - js-component-bindgen
           - preview2-shim
+          - preview3-shim
         description: |
           Project to tag for release (ex. `0.1.0`)
 
@@ -126,6 +131,13 @@ jobs:
               export IS_JS_PROJECT=true;
               export ARTIFACTS_GLOB="packages/preview2-shim/bytecodealliance-preview2-shim-*.tgz";
               export ARTIFACT_NAME="bytecodealliance-preview2-shim-$NEXT_VERSION.tgz";
+              ;;
+            preview3-shim)
+              export PROJECT_DIR="$PWD/packages/$PROJECT";
+              export CURRENT_VERSION=$(node -e "process.stdout.write(require(process.env.PROJECT_DIR + '/package.json').version)");
+              export IS_JS_PROJECT=true;
+              export ARTIFACTS_GLOB="packages/preview3-shim/bytecodealliance-preview3-shim-*.tgz";
+              export ARTIFACT_NAME="bytecodealliance-preview3-shim-$NEXT_VERSION.tgz";
               ;;
             js-component-bindgen)
               export PROJECT_DIR="$PWD/crates/${{ steps.meta.outputs.project }}";

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -19,6 +19,7 @@ on:
           - jco
           - js-component-bindgen
           - preview2-shim
+          - preview3-shim
         description: |
           Project to tag for release (ex. `0.1.0`)
 

--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ With Jco (and related projects in this repository), you can:
 
 As Jco aims to do many things, it contains many subprojects that are organized in this repository:
 
-| Subproject                          | Language   | Directory                               | Description                                                                                     |
+| Subproject                       | Language   | Directory                               | Description                                                                                     |
 |----------------------------------|------------|-----------------------------------------|-------------------------------------------------------------------------------------------------|
 | `jco`                            | Javascript | `packages/jco`                          | The `jco` CLI                                                                                   |
-| `preview2-shim`                  | Javascript | `packages/preview2-shim`                | Library that provides a mapping of [WASI Preview2][wasi-p2] for NodeJS and Browsers             |
+| `preview2-shim`                  | Javascript | `packages/preview2-shim`                | Library that provides a mapping of [WASI Preview 2][wasi-p2] for NodeJS and Browsers            |
+| `preview3-shim`                  | Javascript | `packages/preview3-shim`                | Library that provides a mapping of WASI Preview 3 for NodeJS                                    |
 | `js-component-bindgen`           | Rust       | `crates/js-component-bindgen`           | Enables `jco transpile` and other features, reusing the Rust WebAssembly ecosystem              |
 | `js-component-bindgen-component` | Rust       | `crates/js-component-bindgen-component` | WebAssembly component that (when transipled) makes `js-component-bindgen` available in JS `jco` |
 | `wasm-tools-component`           | Rust       | `crates/wasm-tools-component`           | WebAssembly component containing pieces of [`wasm-tools`][wt] used by `jco`                     |

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -24,7 +24,7 @@ const config = {
         'scope-enum': [
             1,
             'always',
-            ['jco', 'bindgen', 'p2-shim', 'deps', 'ci'],
+            ['jco', 'bindgen', 'p2-shim', 'p3-shim', 'deps', 'ci'],
         ],
         'scope-case': [2, 'always', 'lower-case'],
         'body-max-line-length': [1, 'always', 100],

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -38,6 +38,7 @@ jco is effectively a monorepo consisting of the following projects:
 * `src/api.js`: The jco API which can be used as a library dependency on npm. Published as https://npmjs.org/package/@bytecodealliance/jco.
 * `src/jco.js`: The jco CLI. Published as https://npmjs.org/package/@bytecodealliance/jco.
 * `packages/preview2-shim`: The WASI Preview2 host implementations for Node.js & browsers. Published as https://www.npmjs.com/package/@bytecodealliance/preview2-shim.
+* `packages/preview3-shim`: The WASI Preview3 host implementations for Node.js
 
 ## Building
 
@@ -54,6 +55,7 @@ There are three test suites in jco:
 
 * `npm run test`: Project-level transpilation, CLI & API tests.
 * `npm run test --workspace packages/preview2-shim`: `preview2-shim` unit tests.
+* `npm run test --workspace packages/preview3-shim`: `preview3-shim` unit tests.
 * `test/browser.html`: Bare-minimum browser validation test.
 * `cargo test`: Wasmtime preview2 conformance tests (not currently passing).
 

--- a/packages/preview3-shim/cliff.toml
+++ b/packages/preview3-shim/cliff.toml
@@ -1,0 +1,87 @@
+# https://git-cliff.org/docs/configuration
+
+[changelog]
+header = """
+# Changelog\n
+"""
+# template for the changelog body
+# https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="preview3-shim-v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        * {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+          {% if commit.breaking %}[**breaking**] {% endif %}\
+          {{ commit.message | split(pat="\n") | first | trim }}\
+          {% if commit.remote.username %} by @{{ commit.remote.username }}{%- endif %}\
+          {% if commit.remote.pr_number %} in #{{ commit.remote.pr_number }}{%- endif %}
+    {% endfor %}
+{% endfor %}\n
+
+{%- if github -%}
+{% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
+  {% raw %}\n{% endraw -%}
+  ## New Contributors
+{%- endif %}\
+{% for contributor in github.contributors | filter(attribute="is_first_time", value=true) %}
+  * @{{ contributor.username }} made their first contribution
+    {%- if contributor.pr_number %} in \
+      [#{{ contributor.pr_number }}]({{ self::remote_url() }}/pull/{{ contributor.pr_number }}) \
+    {%- endif %}
+{%- endfor -%}
+{% raw %}\n{% endraw -%}
+{% raw %}\n{% endraw -%}
+{% raw %}\n{% endraw -%}
+{%- endif -%}
+
+{%- macro remote_url() -%}
+  https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}
+{%- endmacro -%}
+"""
+# remove the leading and trailing spaces
+trim = true
+
+[git]
+# parse the commits based on https://www.conventionalcommits.org
+
+# regex for parsing and grouping commits
+commit_parsers = [
+  { message = '^feat\(p3-shim\)', group = '<!-- 0 -->🚀 Features' },
+  { message = '^fix\(p3-shim\)', group = '<!-- 1 -->🐛 Bug Fixes' },
+  { message = '^doc\(p3-shim\)', group = '<!-- 3 -->📚 Documentation' },
+  { message = '^perf\(p3-shim\)', group = '<!-- 4 -->⚡ Performance' },
+  { message = '^refactor\(p3-shim\)', group = '<!-- 3 -->🚜 Refactor' },
+  { message = '^style\(p3-shim\)', group = '<!-- 5 -->🎨 Styling' },
+  { message = '^test\(p3-shim\)', group = '<!-- 6 -->🧪 Testing' },
+  { message = '^release', skip = true },
+  { message = '^chore\(p3-shim\)', group = '<!-- 7 -->⚙️ Miscellaneous Tasks' },
+]
+
+# filter out the commits that are not matched by commit parsers
+filter_commits = true
+
+filter = { exclude = { scopes = ["ci", "infra", "ops"] } }
+
+# sort the tags topologically
+topo_order = false
+
+# sort the commits inside sections by oldest/newest order
+sort_commits = "newest"
+
+# glob pattern for matching git tags
+tag_pattern = "preview3-shim-v[0-9]*"
+
+# regex for skipping tags
+#
+# NOTE: we don't skip taks for beta/rc/alpha since we want their features
+# to be included in the next stable release
+#
+#skip_tags = "beta|rc|alpha"
+
+# tags to ignore
+ignore_tags = "beta|rc|alpha"


### PR DESCRIPTION
The changes in here are un-tested (we haven't done a release of p3-shim), but should generally work the same in CI (we can test when release `0.1.0-rc.0` of `preview3-shim` and have the appropriate repos, creds, etc in place).