### PR TITLE
feat(bindgen): implement yield

### DIFF
--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -986,8 +986,11 @@ impl<'a> Instantiator<'a, '_> {
             }
 
             Trampoline::Yield { async_ } => {
-                let _ = async_;
-                todo!("Trampoline::Yield");
+                let yield_fn = self.gen.intrinsic(Intrinsic::Yield);
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = () => {{ {yield_fn}({async_}); }};\n",
+                );
             }
 
             Trampoline::StreamNew { ty } => {


### PR DESCRIPTION
This commit adds the initial implementation of canon yield, *without* full implementation of the Task primitive.

While yield is not fully operational with just this PR, it matches the spec pseudo-code, and has the appropriate internal wait stubbed out.