### PR TITLE
fix(jco): run linter on jco package source code

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -13,7 +13,7 @@ const config = defineConfig([
             'no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
             'no-fallthrough': 0,
             'no-constant-condition': 0,
-            'curly': ['error', 'all'],
+            curly: ['error', 'all'],
             'prettier/prettier': ['error', prettierConfig],
         },
     },

--- a/packages/jco/package.json
+++ b/packages/jco/package.json
@@ -52,7 +52,7 @@
     "build": "cargo xtask build debug",
     "build:release": "cargo xtask build release",
     "build:types:preview2-shim": "npm run build:types:preview2-shim --include-workspace-root",
-    "lint": "eslint -c ../../eslint.config.mjs ./src/**/*.js",
+    "lint": "eslint -c ../../eslint.config.mjs --ext .js src test",
     "lint:fix": "npm run lint -- --fix",
     "test": "vitest run -c test/vitest.ts",
     "test:lts": "vitest run -c test/vitest.lts.ts",

--- a/packages/jco/src/api.js
+++ b/packages/jco/src/api.js
@@ -1,69 +1,86 @@
 export { optimizeComponent as opt } from './cmd/opt.js';
-export { transpileComponent as transpile, typesComponent as types } from './cmd/transpile.js';
-import { $init, tools } from "../obj/wasm-tools.js";
-const { print: printFn, parse: parseFn, componentWit: componentWitFn, componentNew: componentNewFn, componentEmbed: componentEmbedFn, metadataAdd: metadataAddFn, metadataShow: metadataShowFn } = tools;
+export {
+    transpileComponent as transpile,
+    typesComponent as types,
+} from './cmd/transpile.js';
+import { $init, tools } from '../obj/wasm-tools.js';
+const {
+    print: printFn,
+    parse: parseFn,
+    componentWit: componentWitFn,
+    componentNew: componentNewFn,
+    componentEmbed: componentEmbedFn,
+    metadataAdd: metadataAddFn,
+    metadataShow: metadataShowFn,
+} = tools;
 
 /**
  * @param {Parameters<import('../obj/wasm-tools.js').print>[0]} binary
  * @return {Promise<ReturnType<import('../obj/wasm-tools.js').print>>}
  */
-export async function print (binary) {
-  await $init;
-  return printFn(binary);
+export async function print(binary) {
+    await $init;
+    return printFn(binary);
 }
 /**
  * @param {Parameters<import('../obj/wasm-tools.js').parse>[0]} wat
  * @return {Promise<ReturnType<import('../obj/wasm-tools.js').parse>>}
  */
-export async function parse (wat) {
-  await $init;
-  return parseFn(wat);
+export async function parse(wat) {
+    await $init;
+    return parseFn(wat);
 }
 /**
  * @param {Parameters<import('../obj/wasm-tools.js').componentWit>[0]} binary
  * @return {Promise<ReturnType<import('../obj/wasm-tools.js').componentWit>>}
  */
-export async function componentWit (binary) {
-  await $init;
-  return componentWitFn(binary);
+export async function componentWit(binary) {
+    await $init;
+    return componentWitFn(binary);
 }
 /**
  * @param {Parameters<import('../obj/wasm-tools.js').componentNew>[0]} binary
  * @param {Parameters<import('../obj/wasm-tools.js').componentNew>[1]} adapters
  * @return {Promise<ReturnType<import('../obj/wasm-tools.js').componentNew>>}
  */
-export async function componentNew (binary, adapters) {
-  await $init;
-  return componentNewFn(binary, adapters);
+export async function componentNew(binary, adapters) {
+    await $init;
+    return componentNewFn(binary, adapters);
 }
 /**
  * @param {Parameters<import('../obj/wasm-tools.js').componentEmbed>[0]} embedOpts
  * @return {Promise<ReturnType<import('../obj/wasm-tools.js').componentEmbed>>}
  */
-export async function componentEmbed (embedOpts) {
-  await $init;
-  return componentEmbedFn(embedOpts);
+export async function componentEmbed(embedOpts) {
+    await $init;
+    return componentEmbedFn(embedOpts);
 }
 /**
  * @param {Parameters<import('../obj/wasm-tools.js').metadataAdd>[0]} binary
  * @param {Parameters<import('../obj/wasm-tools.js').metadataAdd>[1]} metadata
  * @return {Promise<ReturnType<import('../obj/wasm-tools.js').metadataAdd>>}
  */
-export async function metadataAdd (binary, metadata) {
-  await $init;
-  return metadataAddFn(binary, metadata);
+export async function metadataAdd(binary, metadata) {
+    await $init;
+    return metadataAddFn(binary, metadata);
 }
 /**
  * @param {Parameters<import('../obj/wasm-tools.js').metadataShow>[0]} binary
  * @return {Promise<ReturnType<import('../obj/wasm-tools.js').metadataShow>>}
  */
-export async function metadataShow (binary) {
-  await $init;
-  return metadataShowFn(binary);
+export async function metadataShow(binary) {
+    await $init;
+    return metadataShowFn(binary);
 }
-export function preview1AdapterCommandPath () {
-  return new URL('../lib/wasi_snapshot_preview1.command.wasm', import.meta.url);
+export function preview1AdapterCommandPath() {
+    return new URL(
+        '../lib/wasi_snapshot_preview1.command.wasm',
+        import.meta.url
+    );
 }
-export function preview1AdapterReactorPath () {
-  return new URL('../lib/wasi_snapshot_preview1.reactor.wasm', import.meta.url);
+export function preview1AdapterReactorPath() {
+    return new URL(
+        '../lib/wasi_snapshot_preview1.reactor.wasm',
+        import.meta.url
+    );
 }

--- a/packages/jco/src/browser.js
+++ b/packages/jco/src/browser.js
@@ -1,14 +1,18 @@
-import { $init, generate as _generate, generateTypes as _generateTypes } from '../obj/js-component-bindgen-component.js';
+import {
+    $init,
+    generate as _generate,
+    generateTypes as _generateTypes,
+} from '../obj/js-component-bindgen-component.js';
 
-export async function generate () {
-  await $init;
-  return _generate.apply(this, arguments);
+export async function generate() {
+    await $init;
+    return _generate.apply(this, arguments);
 }
 
-export async function generateTypes () {
-  await $init;
-  return _generateTypes.apply(this, arguments);
+export async function generateTypes() {
+    await $init;
+    return _generateTypes.apply(this, arguments);
 }
 
 // for backwards compat
-export { generate as transpile }
+export { generate as transpile };

--- a/packages/jco/src/common.js
+++ b/packages/jco/src/common.js
@@ -9,53 +9,62 @@ import { platform } from 'node:process';
 export const isWindows = platform === 'win32';
 
 let _showSpinner = false;
-export function setShowSpinner (val) {
-  _showSpinner = val;
+export function setShowSpinner(val) {
+    _showSpinner = val;
 }
-export function getShowSpinner () {
-  const showSpinner = _showSpinner;
-  _showSpinner = false;
-  return showSpinner;
-}
-
-export function sizeStr (num) {
-  num /= 1024;
-  if (num < 1000)
-    return `${fixedDigitDisplay(num, 4)} KiB`;
-  num /= 1024;
-  if (num < 1000)
-    return `${fixedDigitDisplay(num, 4)} MiB`;
+export function getShowSpinner() {
+    const showSpinner = _showSpinner;
+    _showSpinner = false;
+    return showSpinner;
 }
 
-export function fixedDigitDisplay (num, maxChars) {
-  const significantDigits = String(num).split('.')[0].length;
-  let str;
-  if (significantDigits >= maxChars - 1) {
-    str = String(Math.round(num));
-  } else {
-    const decimalPlaces = maxChars - significantDigits - 1;
-    const rounding = 10 ** decimalPlaces;
-    str = String(Math.round(num * rounding) / rounding);
-  }
-  if (maxChars - str.length < 0)
-    return str;
-  return ' '.repeat(maxChars - str.length) + str;
-}
-
-export function table (data, align = []) {
-  if (data.length === 0) return '';
-  const colLens = data.reduce((maxLens, cur) => maxLens.map((len, i) => Math.max(len, cur[i].length)), data[0].map(cell => cell.length));
-  let outTable = '';
-  for (const row of data) {
-    for (const [i, cell] of row.entries()) {
-      if (align[i] === 'right')
-        outTable += ' '.repeat(colLens[i] - cell.length) + cell;
-      else
-        outTable += cell + ' '.repeat(colLens[i] - cell.length);
+export function sizeStr(num) {
+    num /= 1024;
+    if (num < 1000) {
+        return `${fixedDigitDisplay(num, 4)} KiB`;
     }
-    outTable += '\n';
-  }
-  return outTable;
+    num /= 1024;
+    if (num < 1000) {
+        return `${fixedDigitDisplay(num, 4)} MiB`;
+    }
+}
+
+export function fixedDigitDisplay(num, maxChars) {
+    const significantDigits = String(num).split('.')[0].length;
+    let str;
+    if (significantDigits >= maxChars - 1) {
+        str = String(Math.round(num));
+    } else {
+        const decimalPlaces = maxChars - significantDigits - 1;
+        const rounding = 10 ** decimalPlaces;
+        str = String(Math.round(num * rounding) / rounding);
+    }
+    if (maxChars - str.length < 0) {
+        return str;
+    }
+    return ' '.repeat(maxChars - str.length) + str;
+}
+
+export function table(data, align = []) {
+    if (data.length === 0) {
+        return '';
+    }
+    const colLens = data.reduce(
+        (maxLens, cur) => maxLens.map((len, i) => Math.max(len, cur[i].length)),
+        data[0].map((cell) => cell.length)
+    );
+    let outTable = '';
+    for (const row of data) {
+        for (const [i, cell] of row.entries()) {
+            if (align[i] === 'right') {
+                outTable += ' '.repeat(colLens[i] - cell.length) + cell;
+            } else {
+                outTable += cell + ' '.repeat(colLens[i] - cell.length);
+            }
+        }
+        outTable += '\n';
+    }
+    return outTable;
 }
 
 /**
@@ -63,48 +72,50 @@ export function table (data, align = []) {
  *
  * The new directory is created using `fsPromises.mkdtemp()`.
  */
-export async function getTmpDir () {
-  return await mkdtemp(normalize(tmpdir() + sep));
+export async function getTmpDir() {
+    return await mkdtemp(normalize(tmpdir() + sep));
 }
 
-async function readFileCli (file, encoding) {
-  try {
-    return await readFile(file, encoding)
-  }
-  catch (e) {
-    throw c`Unable to read file {bold ${file}}`;
-  }
+async function readFileCli(file, encoding) {
+    try {
+        return await readFile(file, encoding);
+    } catch {
+        throw c`Unable to read file {bold ${file}}`;
+    }
 }
-export { readFileCli as readFile }
+export { readFileCli as readFile };
 
-export async function spawnIOTmp (cmd, input, args) {
-  const tmpDir = await getTmpDir();
-  try {
-    const inFile = resolve(tmpDir, 'in.wasm');
-    let outFile = resolve(tmpDir, 'out.wasm');
+export async function spawnIOTmp(cmd, input, args) {
+    const tmpDir = await getTmpDir();
+    try {
+        const inFile = resolve(tmpDir, 'in.wasm');
+        let outFile = resolve(tmpDir, 'out.wasm');
 
-    await writeFile(inFile, input);
+        await writeFile(inFile, input);
 
-    const cp = spawn(argv0, [cmd, inFile, ...args, outFile], { stdio: 'pipe' });
+        const cp = spawn(argv0, [cmd, inFile, ...args, outFile], {
+            stdio: 'pipe',
+        });
 
-    let stderr = '';
-    const p = new Promise((resolve, reject) => {
-      cp.stderr.on('data', data => stderr += data.toString());
-      cp.on('error', e => {
-        reject(e);
-      });
-      cp.on('exit', code => {
-        if (code === 0)
-          resolve();
-        else
-          reject(stderr);
-      });
-    });
+        let stderr = '';
+        const p = new Promise((resolve, reject) => {
+            cp.stderr.on('data', (data) => (stderr += data.toString()));
+            cp.on('error', (e) => {
+                reject(e);
+            });
+            cp.on('exit', (code) => {
+                if (code === 0) {
+                    resolve();
+                } else {
+                    reject(stderr);
+                }
+            });
+        });
 
-    await p;
-    var output = await readFile(outFile);
-    return output;
-  } finally {
-    await rm(tmpDir, { recursive: true });
-  }
+        await p;
+        var output = await readFile(outFile);
+        return output;
+    } finally {
+        await rm(tmpDir, { recursive: true });
+    }
 }

--- a/packages/jco/src/jco.js
+++ b/packages/jco/src/jco.js
@@ -6,236 +6,439 @@ import { program, Option } from 'commander';
 import { opt } from './cmd/opt.js';
 import { transpile, types, guestTypes } from './cmd/transpile.js';
 import { run as runCmd, serve as serveCmd } from './cmd/run.js';
-import { parse, print, componentNew, componentEmbed, metadataAdd, metadataShow, componentWit } from './cmd/wasm-tools.js';
+import {
+    parse,
+    print,
+    componentNew,
+    componentEmbed,
+    metadataAdd,
+    metadataShow,
+    componentWit,
+} from './cmd/wasm-tools.js';
 import { componentize } from './cmd/componentize.js';
 
 program
-  .name('jco')
-  .description(c`{bold jco - WebAssembly JS Component Tools}\n      JS Component Transpilation Bindgen & Wasm Tools for JS`)
-  .usage('<command> [options]')
-  .version('1.11.2');
+    .name('jco')
+    .description(
+        c`{bold jco - WebAssembly JS Component Tools}\n      JS Component Transpilation Bindgen & Wasm Tools for JS`
+    )
+    .usage('<command> [options]')
+    .version('1.11.2');
 
 function myParseInt(value) {
-  return parseInt(value, 10);
+    return parseInt(value, 10);
 }
 
 /**
-* Option parsing that allows for collecting repeated arguments
-*
-* @param {string} value - the new value that is added
-* @param {string[]} previous - the existing list of values
-*/
+ * Option parsing that allows for collecting repeated arguments
+ *
+ * @param {string} value - the new value that is added
+ * @param {string[]} previous - the existing list of values
+ */
 function collectOptions(value, previous) {
-  return previous.concat([value]);
+    return previous.concat([value]);
 }
 
-program.command('componentize')
-  .description('Create a component from a JavaScript module')
-  .usage('<js-source> --wit wit-world.wit -o <component-path>')
-  .argument('<js-source>', 'JS source file to build')
-  .requiredOption('-w, --wit <path>', 'WIT path to build with')
-  .option('-n, --world-name <name>', 'WIT world to build')
-  .option('--aot', 'Enable Weval AOT compilation of JS')
-  .option('--aot-min-stack-size-bytes <number>', 'Set the min stack size to be used during AOT')
-  .option('--weval-bin <path>', 'Specify a custom weval binary to use')
-  .addOption(new Option('-d, --disable <feature...>', 'disable WASI features').choices(['clocks', 'http', 'random', 'stdio', 'all']))
-  // .addOption(new Option('-e, --enable <feature...>', 'enable WASI features').choices(['http']))
-  .option('--preview2-adapter <adapter>', 'provide a custom preview2 adapter path')
-  .option('--debug-starlingmonkey-build', 'use a debug build of StarlingMonkey')
-  .requiredOption('-o, --out <out>', 'output component file')
-  .action(asyncAction(componentize));
+program
+    .command('componentize')
+    .description('Create a component from a JavaScript module')
+    .usage('<js-source> --wit wit-world.wit -o <component-path>')
+    .argument('<js-source>', 'JS source file to build')
+    .requiredOption('-w, --wit <path>', 'WIT path to build with')
+    .option('-n, --world-name <name>', 'WIT world to build')
+    .option('--aot', 'Enable Weval AOT compilation of JS')
+    .option(
+        '--aot-min-stack-size-bytes <number>',
+        'Set the min stack size to be used during AOT'
+    )
+    .option('--weval-bin <path>', 'Specify a custom weval binary to use')
+    .addOption(
+        new Option(
+            '-d, --disable <feature...>',
+            'disable WASI features'
+        ).choices(['clocks', 'http', 'random', 'stdio', 'all'])
+    )
+    // .addOption(new Option('-e, --enable <feature...>', 'enable WASI features').choices(['http']))
+    .option(
+        '--preview2-adapter <adapter>',
+        'provide a custom preview2 adapter path'
+    )
+    .option(
+        '--debug-starlingmonkey-build',
+        'use a debug build of StarlingMonkey'
+    )
+    .requiredOption('-o, --out <out>', 'output component file')
+    .action(asyncAction(componentize));
 
-program.command('transpile')
-  .description('Transpile a WebAssembly Component to JS + core Wasm for JavaScript execution')
-  .usage('<component-path> -o <out-dir>')
-  .argument('<component-path>', 'Wasm component binary filepath')
-  .option('--name <name>', 'custom output name')
-  .requiredOption('-o, --out-dir <out-dir>', 'output directory')
-  .option('-m, --minify', 'minify the JS output (--optimize / opt cmd still required)')
-  .option('-O, --optimize', 'optimize the component first')
-  .option('--no-typescript', 'do not output TypeScript .d.ts types')
-  .option('--valid-lifting-optimization', 'optimize component binary validations assuming all lifted values are valid')
-  .addOption(new Option('--import-bindings [mode]', 'bindings mode for imports').choices(['js', 'optimized', 'hybrid', 'direct-optimized']).preset('js'))
-  .addOption(new Option('--async-mode [mode]', 'EXPERIMENTAL: use async imports and exports').choices(['sync', 'jspi']).preset('sync'))
-  .option('--async-wasi-imports', 'EXPERIMENTAL: async component imports from WASI interfaces')
-  .option('--async-wasi-exports', 'EXPERIMENTAL: async component exports from WASI interfaces')
-  .option('--async-imports <imports...>', 'EXPERIMENTAL: async component imports (examples: "wasi:io/poll@0.2.0#poll", "wasi:io/poll#[method]pollable.block")')
-  .option('--async-exports <exports...>', 'EXPERIMENTAL: async component exports (examples: "wasi:cli/run@#run", "handle")')
-  .option('--tracing', 'emit `tracing` calls on function entry/exit')
-  .option('-b, --base64-cutoff <bytes>', 'set the byte size under which core Wasm binaries will be inlined as base64', myParseInt)
-  .option('--tla-compat', 'enables compatibility for JS environments without top-level await support via an async $init promise export')
-  .option('--no-nodejs-compat', 'disables compatibility in Node.js without a fetch global')
-  .option('-M, --map <mappings...>', 'specifier=./output custom mappings for the component imports')
-  .option('--no-wasi-shim', 'disable automatic rewriting of WASI imports to use @bytecodealliance/preview2-shim')
-  .option('--stub', 'generate a stub implementation from a WIT file directly')
-  .option('--js', 'output JS instead of core WebAssembly')
-  .addOption(new Option('-I, --instantiation [mode]', 'output for custom module instantiation').choices(['async', 'sync']).preset('async'))
-  .option('-q, --quiet', 'disable output summary')
-  .option('--no-namespaced-exports', 'disable namespaced exports for typescript compatibility')
-  .option('--multi-memory', 'optimized output for Wasm multi-memory')
-  .option('--', 'for --optimize, custom wasm-opt arguments (defaults to best size optimization)')
-  .action(asyncAction(transpile));
+program
+    .command('transpile')
+    .description(
+        'Transpile a WebAssembly Component to JS + core Wasm for JavaScript execution'
+    )
+    .usage('<component-path> -o <out-dir>')
+    .argument('<component-path>', 'Wasm component binary filepath')
+    .option('--name <name>', 'custom output name')
+    .requiredOption('-o, --out-dir <out-dir>', 'output directory')
+    .option(
+        '-m, --minify',
+        'minify the JS output (--optimize / opt cmd still required)'
+    )
+    .option('-O, --optimize', 'optimize the component first')
+    .option('--no-typescript', 'do not output TypeScript .d.ts types')
+    .option(
+        '--valid-lifting-optimization',
+        'optimize component binary validations assuming all lifted values are valid'
+    )
+    .addOption(
+        new Option('--import-bindings [mode]', 'bindings mode for imports')
+            .choices(['js', 'optimized', 'hybrid', 'direct-optimized'])
+            .preset('js')
+    )
+    .addOption(
+        new Option(
+            '--async-mode [mode]',
+            'EXPERIMENTAL: use async imports and exports'
+        )
+            .choices(['sync', 'jspi'])
+            .preset('sync')
+    )
+    .option(
+        '--async-wasi-imports',
+        'EXPERIMENTAL: async component imports from WASI interfaces'
+    )
+    .option(
+        '--async-wasi-exports',
+        'EXPERIMENTAL: async component exports from WASI interfaces'
+    )
+    .option(
+        '--async-imports <imports...>',
+        'EXPERIMENTAL: async component imports (examples: "wasi:io/poll@0.2.0#poll", "wasi:io/poll#[method]pollable.block")'
+    )
+    .option(
+        '--async-exports <exports...>',
+        'EXPERIMENTAL: async component exports (examples: "wasi:cli/run@#run", "handle")'
+    )
+    .option('--tracing', 'emit `tracing` calls on function entry/exit')
+    .option(
+        '-b, --base64-cutoff <bytes>',
+        'set the byte size under which core Wasm binaries will be inlined as base64',
+        myParseInt
+    )
+    .option(
+        '--tla-compat',
+        'enables compatibility for JS environments without top-level await support via an async $init promise export'
+    )
+    .option(
+        '--no-nodejs-compat',
+        'disables compatibility in Node.js without a fetch global'
+    )
+    .option(
+        '-M, --map <mappings...>',
+        'specifier=./output custom mappings for the component imports'
+    )
+    .option(
+        '--no-wasi-shim',
+        'disable automatic rewriting of WASI imports to use @bytecodealliance/preview2-shim'
+    )
+    .option('--stub', 'generate a stub implementation from a WIT file directly')
+    .option('--js', 'output JS instead of core WebAssembly')
+    .addOption(
+        new Option(
+            '-I, --instantiation [mode]',
+            'output for custom module instantiation'
+        )
+            .choices(['async', 'sync'])
+            .preset('async')
+    )
+    .option('-q, --quiet', 'disable output summary')
+    .option(
+        '--no-namespaced-exports',
+        'disable namespaced exports for typescript compatibility'
+    )
+    .option('--multi-memory', 'optimized output for Wasm multi-memory')
+    .option(
+        '--',
+        'for --optimize, custom wasm-opt arguments (defaults to best size optimization)'
+    )
+    .action(asyncAction(transpile));
 
-program.command('types')
-  .description('Generate types for the given WIT')
-  .usage('<wit-path> -o <out-dir>')
-  .argument('<wit-path>', 'path to a WIT file or directory')
-  .option('--name <name>', 'custom output name')
-  .option('-n, --world-name <world>', 'WIT world to generate types for')
-  .requiredOption('-o, --out-dir <out-dir>', 'output directory')
-  .option('--tla-compat', 'generates types for the TLA compat output with an async $init promise export')
-  .addOption(new Option('-I, --instantiation [mode]', 'type output for custom module instantiation').choices(['async', 'sync']).preset('async'))
-  .addOption(new Option('--async-mode [mode]', 'EXPERIMENTAL: use async imports and exports').choices(['sync', 'jspi']).preset('sync'))
-  .option('--async-wasi-imports', 'EXPERIMENTAL: async component imports from WASI interfaces')
-  .option('--async-wasi-exports', 'EXPERIMENTAL: async component exports from WASI interfaces')
-  .option('--async-imports <imports...>', 'EXPERIMENTAL: async component imports (examples: "wasi:io/poll@0.2.0#poll", "wasi:io/poll#[method]pollable.block")')
-  .option('--async-exports <exports...>', 'EXPERIMENTAL: async component exports (examples: "wasi:cli/run@#run", "handle")')
-  .option('-q, --quiet', 'disable output summary')
-  .option('--feature <feature>', 'enable one specific WIT feature (repeatable)', collectOptions, [])
-  .option('--all-features', 'enable all features')
-  .action(asyncAction(types));
+program
+    .command('types')
+    .description('Generate types for the given WIT')
+    .usage('<wit-path> -o <out-dir>')
+    .argument('<wit-path>', 'path to a WIT file or directory')
+    .option('--name <name>', 'custom output name')
+    .option('-n, --world-name <world>', 'WIT world to generate types for')
+    .requiredOption('-o, --out-dir <out-dir>', 'output directory')
+    .option(
+        '--tla-compat',
+        'generates types for the TLA compat output with an async $init promise export'
+    )
+    .addOption(
+        new Option(
+            '-I, --instantiation [mode]',
+            'type output for custom module instantiation'
+        )
+            .choices(['async', 'sync'])
+            .preset('async')
+    )
+    .addOption(
+        new Option(
+            '--async-mode [mode]',
+            'EXPERIMENTAL: use async imports and exports'
+        )
+            .choices(['sync', 'jspi'])
+            .preset('sync')
+    )
+    .option(
+        '--async-wasi-imports',
+        'EXPERIMENTAL: async component imports from WASI interfaces'
+    )
+    .option(
+        '--async-wasi-exports',
+        'EXPERIMENTAL: async component exports from WASI interfaces'
+    )
+    .option(
+        '--async-imports <imports...>',
+        'EXPERIMENTAL: async component imports (examples: "wasi:io/poll@0.2.0#poll", "wasi:io/poll#[method]pollable.block")'
+    )
+    .option(
+        '--async-exports <exports...>',
+        'EXPERIMENTAL: async component exports (examples: "wasi:cli/run@#run", "handle")'
+    )
+    .option('-q, --quiet', 'disable output summary')
+    .option(
+        '--feature <feature>',
+        'enable one specific WIT feature (repeatable)',
+        collectOptions,
+        []
+    )
+    .option('--all-features', 'enable all features')
+    .action(asyncAction(types));
 
-program.command('guest-types')
-  .description('(experimental) Generate guest types for the given WIT')
-  .usage('<wit-path> -o <out-dir>')
-  .argument('<wit-path>', 'path to a WIT file or directory')
-  .option('--name <name>', 'custom output name')
-  .option('-n, --world-name <world>', 'WIT world to generate types for')
-  .requiredOption('-o, --out-dir <out-dir>', 'output directory')
-  .option('-q, --quiet', 'disable output summary')
-  .option('--feature <feature>', 'enable one specific WIT feature (repeatable)', collectOptions, [])
-  .option('--all-features', 'enable all features')
-  .action(asyncAction(guestTypes));
+program
+    .command('guest-types')
+    .description('(experimental) Generate guest types for the given WIT')
+    .usage('<wit-path> -o <out-dir>')
+    .argument('<wit-path>', 'path to a WIT file or directory')
+    .option('--name <name>', 'custom output name')
+    .option('-n, --world-name <world>', 'WIT world to generate types for')
+    .requiredOption('-o, --out-dir <out-dir>', 'output directory')
+    .option('-q, --quiet', 'disable output summary')
+    .option(
+        '--feature <feature>',
+        'enable one specific WIT feature (repeatable)',
+        collectOptions,
+        []
+    )
+    .option('--all-features', 'enable all features')
+    .action(asyncAction(guestTypes));
 
-program.command('run')
-  .description('Run a WASI Command component')
-  .usage('<command.wasm> <args...>')
-  .helpOption(false)
-  .allowUnknownOption(true)
-  .allowExcessArguments(true)
-  .argument('<command>', 'WASI command binary to run')
-  .option('--jco-dir <dir>', 'Instead of using a temporary dir, set the output directory for the run command')
-  .option('--jco-trace', 'Enable call tracing')
-  .option('--jco-import <module>', 'Custom module to import before the run executes to support custom environment setup')
-  .option('--jco-map <mappings...>', 'specifier=./output custom mappings for the component imports')
-  .addOption(new Option('--jco-import-bindings [mode]', 'bindings mode for imports').choices(['js', 'optimized', 'hybrid', 'direct-optimized']).preset('js'))
-  .argument('[args...]', 'Any CLI arguments for the component')
-  .action(asyncAction(async function run (cmd, args, opts, command) {
-    // specially only allow help option in first position
-    if (cmd === '--help' || cmd === '-h') {
-      command.help();
-    } else {
-      return runCmd(cmd, args, opts);
-    }
-  }));
+program
+    .command('run')
+    .description('Run a WASI Command component')
+    .usage('<command.wasm> <args...>')
+    .helpOption(false)
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
+    .argument('<command>', 'WASI command binary to run')
+    .option(
+        '--jco-dir <dir>',
+        'Instead of using a temporary dir, set the output directory for the run command'
+    )
+    .option('--jco-trace', 'Enable call tracing')
+    .option(
+        '--jco-import <module>',
+        'Custom module to import before the run executes to support custom environment setup'
+    )
+    .option(
+        '--jco-map <mappings...>',
+        'specifier=./output custom mappings for the component imports'
+    )
+    .addOption(
+        new Option('--jco-import-bindings [mode]', 'bindings mode for imports')
+            .choices(['js', 'optimized', 'hybrid', 'direct-optimized'])
+            .preset('js')
+    )
+    .argument('[args...]', 'Any CLI arguments for the component')
+    .action(
+        asyncAction(async function run(cmd, args, opts, command) {
+            // specially only allow help option in first position
+            if (cmd === '--help' || cmd === '-h') {
+                command.help();
+            } else {
+                return runCmd(cmd, args, opts);
+            }
+        })
+    );
 
-program.command('serve')
-  .description('Serve a WASI HTTP component')
-  .usage('<server.wasm> <args...>')
-  .helpOption(false)
-  .allowUnknownOption(true)
-  .allowExcessArguments(true)
-  .argument('<server>', 'WASI server binary to run')
-  .option('--port <number>')
-  .option('--host <host>')
-  .option('--jco-dir <dir>', 'Instead of using a temporary dir, set the output directory for the transpiled code')
-  .option('--jco-trace', 'Enable call tracing')
-  .option('--jco-import <module>', 'Custom module to import before the server executes to support custom environment setup')
-  .addOption(new Option('--jco-import-bindings [mode]', 'bindings mode for imports').choices(['js', 'optimized', 'hybrid', 'direct-optimized']).preset('js'))
-  .option('--jco-map <mappings...>', 'specifier=./output custom mappings for the component imports')
-  .argument('[args...]', 'Any CLI arguments for the component')
-  .action(asyncAction(async function serve (cmd, args, opts, command) {
-    // specially only allow help option in first position
-    if (cmd === '--help' || cmd === '-h') {
-      command.help();
-    } else {
-      return serveCmd(cmd, args, opts);
-    }
-  }));
+program
+    .command('serve')
+    .description('Serve a WASI HTTP component')
+    .usage('<server.wasm> <args...>')
+    .helpOption(false)
+    .allowUnknownOption(true)
+    .allowExcessArguments(true)
+    .argument('<server>', 'WASI server binary to run')
+    .option('--port <number>')
+    .option('--host <host>')
+    .option(
+        '--jco-dir <dir>',
+        'Instead of using a temporary dir, set the output directory for the transpiled code'
+    )
+    .option('--jco-trace', 'Enable call tracing')
+    .option(
+        '--jco-import <module>',
+        'Custom module to import before the server executes to support custom environment setup'
+    )
+    .addOption(
+        new Option('--jco-import-bindings [mode]', 'bindings mode for imports')
+            .choices(['js', 'optimized', 'hybrid', 'direct-optimized'])
+            .preset('js')
+    )
+    .option(
+        '--jco-map <mappings...>',
+        'specifier=./output custom mappings for the component imports'
+    )
+    .argument('[args...]', 'Any CLI arguments for the component')
+    .action(
+        asyncAction(async function serve(cmd, args, opts, command) {
+            // specially only allow help option in first position
+            if (cmd === '--help' || cmd === '-h') {
+                command.help();
+            } else {
+                return serveCmd(cmd, args, opts);
+            }
+        })
+    );
 
-program.command('opt')
-  .description('optimizes a Wasm component, including running wasm-opt Binaryen optimizations')
-  .usage('<component-file> -o <output-file>')
-  .argument('<component-file>', 'Wasm component binary filepath')
-  .requiredOption('-o, --output <output-file>', 'optimized component output filepath')
-  .option('--asyncify', 'runs Asyncify pass in wasm-opt')
-  .option('-q, --quiet')
-  .option('--', 'custom wasm-opt arguments (defaults to best size optimization)')
-  .action(asyncAction(opt));
+program
+    .command('opt')
+    .description(
+        'optimizes a Wasm component, including running wasm-opt Binaryen optimizations'
+    )
+    .usage('<component-file> -o <output-file>')
+    .argument('<component-file>', 'Wasm component binary filepath')
+    .requiredOption(
+        '-o, --output <output-file>',
+        'optimized component output filepath'
+    )
+    .option('--asyncify', 'runs Asyncify pass in wasm-opt')
+    .option('-q, --quiet')
+    .option(
+        '--',
+        'custom wasm-opt arguments (defaults to best size optimization)'
+    )
+    .action(asyncAction(opt));
 
-program.command('wit')
-  .description('extract the WIT from a WebAssembly Component [wasm-tools component wit]')
-  .argument('<component-path>', 'Wasm component binary filepath')
-  .option('-d, --document <name>', 'WIT document of a package to print')
-  .option('-o, --output <output-file>', 'WIT output file path')
-  .action(asyncAction(componentWit));
+program
+    .command('wit')
+    .description(
+        'extract the WIT from a WebAssembly Component [wasm-tools component wit]'
+    )
+    .argument('<component-path>', 'Wasm component binary filepath')
+    .option('-d, --document <name>', 'WIT document of a package to print')
+    .option('-o, --output <output-file>', 'WIT output file path')
+    .action(asyncAction(componentWit));
 
-program.command('print')
-  .description('print the WebAssembly WAT text for a binary file [wasm-tools print]')
-  .argument('<input>', 'input file to process')
-  .option('-o, --output <output-file>', 'output file path')
-  .action(asyncAction(print));
+program
+    .command('print')
+    .description(
+        'print the WebAssembly WAT text for a binary file [wasm-tools print]'
+    )
+    .argument('<input>', 'input file to process')
+    .option('-o, --output <output-file>', 'output file path')
+    .action(asyncAction(print));
 
-program.command('metadata-show')
-  .description('extract the producer metadata for a Wasm binary [wasm-tools metadata show]')
-  .argument('[module]', 'Wasm component or core module filepath')
-  .option('--json', 'output component metadata as JSON')
-  .action(asyncAction(metadataShow));
+program
+    .command('metadata-show')
+    .description(
+        'extract the producer metadata for a Wasm binary [wasm-tools metadata show]'
+    )
+    .argument('[module]', 'Wasm component or core module filepath')
+    .option('--json', 'output component metadata as JSON')
+    .action(asyncAction(metadataShow));
 
-program.command('metadata-add')
-  .description('add producer metadata for a Wasm binary [wasm-tools metadata add]')
-  .argument('[module]', 'Wasm component or core module filepath')
-  .requiredOption('-m, --metadata <metadata...>', 'field=name[@version] producer metadata to add with the embedding')
-  .requiredOption('-o, --output <output-file>', 'output binary path')
-  .action(asyncAction(metadataAdd));
+program
+    .command('metadata-add')
+    .description(
+        'add producer metadata for a Wasm binary [wasm-tools metadata add]'
+    )
+    .argument('[module]', 'Wasm component or core module filepath')
+    .requiredOption(
+        '-m, --metadata <metadata...>',
+        'field=name[@version] producer metadata to add with the embedding'
+    )
+    .requiredOption('-o, --output <output-file>', 'output binary path')
+    .action(asyncAction(metadataAdd));
 
-program.command('parse')
-  .description('parses the Wasm text format into a binary file [wasm-tools parse]')
-  .argument('<input>', 'input file to process')
-  .requiredOption('-o, --output <output-file>', 'output binary file path')
-  .action(asyncAction(parse));
+program
+    .command('parse')
+    .description(
+        'parses the Wasm text format into a binary file [wasm-tools parse]'
+    )
+    .argument('<input>', 'input file to process')
+    .requiredOption('-o, --output <output-file>', 'output binary file path')
+    .action(asyncAction(parse));
 
-program.command('new')
-  .description('create a WebAssembly component adapted from a component core Wasm [wasm-tools component new]')
-  .argument('<core-module>', 'Wasm core module filepath')
-  .requiredOption('-o, --output <output-file>', 'Wasm component output filepath')
-  .option('--name <name>', 'custom output name')
-  .option('--adapt <[NAME=]adapter...>', 'component adapters to apply')
-  .option('--wasi-reactor', 'build with the WASI Reactor adapter')
-  .option('--wasi-command', 'build with the WASI Command adapter')
-  .action(asyncAction(componentNew));
+program
+    .command('new')
+    .description(
+        'create a WebAssembly component adapted from a component core Wasm [wasm-tools component new]'
+    )
+    .argument('<core-module>', 'Wasm core module filepath')
+    .requiredOption(
+        '-o, --output <output-file>',
+        'Wasm component output filepath'
+    )
+    .option('--name <name>', 'custom output name')
+    .option('--adapt <[NAME=]adapter...>', 'component adapters to apply')
+    .option('--wasi-reactor', 'build with the WASI Reactor adapter')
+    .option('--wasi-command', 'build with the WASI Command adapter')
+    .action(asyncAction(componentNew));
 
-program.command('embed')
-  .description('embed the component typing section into a core Wasm module [wasm-tools component embed]')
-  .argument('[core-module]', 'Wasm core module filepath')
-  .requiredOption('-o, --output <output-file>', 'Wasm component output filepath')
-  .requiredOption('--wit <wit-world>', 'WIT world path')
-  .option('--dummy', 'generate a dummy component')
-  .option('--string-encoding <utf8|utf16|compact-utf16>', 'set the component string encoding')
-  .option('-n, --world-name <world-name>', 'world name to embed')
-  .option('-m, --metadata <metadata...>', 'field=name[@version] producer metadata to add with the embedding')
-  .action(asyncAction(componentEmbed));
+program
+    .command('embed')
+    .description(
+        'embed the component typing section into a core Wasm module [wasm-tools component embed]'
+    )
+    .argument('[core-module]', 'Wasm core module filepath')
+    .requiredOption(
+        '-o, --output <output-file>',
+        'Wasm component output filepath'
+    )
+    .requiredOption('--wit <wit-world>', 'WIT world path')
+    .option('--dummy', 'generate a dummy component')
+    .option(
+        '--string-encoding <utf8|utf16|compact-utf16>',
+        'set the component string encoding'
+    )
+    .option('-n, --world-name <world-name>', 'world name to embed')
+    .option(
+        '-m, --metadata <metadata...>',
+        'field=name[@version] producer metadata to add with the embedding'
+    )
+    .action(asyncAction(componentEmbed));
 
 program.showHelpAfterError();
 
 program.parse();
 
-function asyncAction (cmd) {
-  return function () {
-    const args = [...arguments];
-    (async () => {
-      try {
-        await cmd.apply(null, args);
-      }
-      catch (e) {
-        process.stdout.write(`(jco ${cmd.name}) `);
-        if (typeof e === 'string') {
-          console.error(c`{red.bold Error}: ${e}\n`);
-        } else {
-          console.error(e);
-        }
-        process.exit(1);
-      }
-    })();
-  };
+function asyncAction(cmd) {
+    return function () {
+        const args = [...arguments];
+        (async () => {
+            try {
+                await cmd.apply(null, args);
+            } catch (e) {
+                process.stdout.write(`(jco ${cmd.name}) `);
+                if (typeof e === 'string') {
+                    console.error(c`{red.bold Error}: ${e}\n`);
+                } else {
+                    console.error(e);
+                }
+                process.exit(1);
+            }
+        })();
+    };
 }

--- a/packages/jco/src/ora-shim.js
+++ b/packages/jco/src/ora-shim.js
@@ -1,9 +1,9 @@
 // browser shim for ora
-export default function ora () {
-  return new Ora();
+export default function ora() {
+    return new Ora();
 }
 
 class Ora {
-  start () {}
-  stop () {}
+    start() {}
+    stop() {}
 }

--- a/packages/jco/test/api.js
+++ b/packages/jco/test/api.js
@@ -1,271 +1,290 @@
-import { fileURLToPath } from "node:url";
-import { platform } from "node:process";
-import { readFile } from "node:fs/promises";
+import { fileURLToPath } from 'node:url';
+import { platform } from 'node:process';
+import { readFile } from 'node:fs/promises';
 
-import { suite, test, assert, beforeAll } from "vitest";
-
-import {
-  transpile,
-  types,
-  opt,
-  print,
-  parse,
-  componentNew,
-  componentEmbed,
-  metadataShow,
-  preview1AdapterReactorPath,
-} from "../src/api.js";
+import { suite, test, assert, beforeAll } from 'vitest';
 
 import {
-  readComponentBytes,
-  getCurrentWitComponentVersion,
-} from "./helpers.js";
+    transpile,
+    types,
+    opt,
+    print,
+    parse,
+    componentNew,
+    componentEmbed,
+    metadataShow,
+    preview1AdapterReactorPath,
+} from '../src/api.js';
 
-const isWindows = platform === "win32";
+import {
+    readComponentBytes,
+    getCurrentWitComponentVersion,
+} from './helpers.js';
+
+const isWindows = platform === 'win32';
 
 // - (2025/02/04) incrased due to incoming implementations of async and new flush impl
 const FLAVORFUL_WASM_TRANSPILED_CODE_CHAR_LIMIT = 28_500;
 
-suite("API", () => {
-  let flavorfulWasmBytes;
-  let exitCodeWasmBytes;
+suite('API', () => {
+    let flavorfulWasmBytes;
+    let exitCodeWasmBytes;
 
-  beforeAll(async () => {
-    const bytes = await Promise.all([
-      readComponentBytes(`test/fixtures/components/flavorful.component.wasm`),
-      readComponentBytes(`test/fixtures/modules/exitcode.wasm`),
-    ]);
-    flavorfulWasmBytes = bytes[0];
-    exitCodeWasmBytes = bytes[1];
-  });
-
-  test("Transpile", async () => {
-    const name = "flavorful";
-    const { files, imports, exports } = await transpile(flavorfulWasmBytes, {
-      name,
+    beforeAll(async () => {
+        const bytes = await Promise.all([
+            readComponentBytes(
+                `test/fixtures/components/flavorful.component.wasm`
+            ),
+            readComponentBytes(`test/fixtures/modules/exitcode.wasm`),
+        ]);
+        flavorfulWasmBytes = bytes[0];
+        exitCodeWasmBytes = bytes[1];
     });
-    assert.strictEqual(imports.length, 4);
-    assert.strictEqual(exports.length, 3);
-    assert.deepStrictEqual(exports[0], ["test", "instance"]);
-    assert.ok(files[name + ".js"]);
-  });
 
-  test("Transpile to JS", async () => {
-    const name = "flavorful";
-    const { files, imports, exports } = await transpile(flavorfulWasmBytes, {
-      map: {
-        "test:flavorful/*": "./*.js",
-      },
-      name,
-      validLiftingOptimization: true,
-      tlaCompat: true,
-      base64Cutoff: 0,
-      js: true,
+    test('Transpile', async () => {
+        const name = 'flavorful';
+        const { files, imports, exports } = await transpile(
+            flavorfulWasmBytes,
+            {
+                name,
+            }
+        );
+        assert.strictEqual(imports.length, 4);
+        assert.strictEqual(exports.length, 3);
+        assert.deepStrictEqual(exports[0], ['test', 'instance']);
+        assert.ok(files[name + '.js']);
     });
-    assert.strictEqual(imports.length, 4);
-    assert.strictEqual(exports.length, 3);
-    assert.deepStrictEqual(exports[0], ["test", "instance"]);
-    assert.deepStrictEqual(exports[1], ["test:flavorful/test", "instance"]);
-    assert.deepStrictEqual(exports[2], ["testImports", "function"]);
-    const source = Buffer.from(files[name + ".js"]).toString();
-    assert.ok(source.includes("./test.js"));
-    assert.ok(source.includes("FUNCTION_TABLE"));
-    for (let i = 0; i < 2; i++) assert.ok(source.includes(exports[i][0]));
-  });
 
-  test("Transpile map into package imports", async () => {
-    const name = "flavorful";
-    const { files, imports } = await transpile(flavorfulWasmBytes, {
-      name,
-      map: {
-        "test:flavorful/*": "#*import",
-      },
+    test('Transpile to JS', async () => {
+        const name = 'flavorful';
+        const { files, imports, exports } = await transpile(
+            flavorfulWasmBytes,
+            {
+                map: {
+                    'test:flavorful/*': './*.js',
+                },
+                name,
+                validLiftingOptimization: true,
+                tlaCompat: true,
+                base64Cutoff: 0,
+                js: true,
+            }
+        );
+        assert.strictEqual(imports.length, 4);
+        assert.strictEqual(exports.length, 3);
+        assert.deepStrictEqual(exports[0], ['test', 'instance']);
+        assert.deepStrictEqual(exports[1], ['test:flavorful/test', 'instance']);
+        assert.deepStrictEqual(exports[2], ['testImports', 'function']);
+        const source = Buffer.from(files[name + '.js']).toString();
+        assert.ok(source.includes('./test.js'));
+        assert.ok(source.includes('FUNCTION_TABLE'));
+        for (let i = 0; i < 2; i++) {
+            assert.ok(source.includes(exports[i][0]));
+        }
     });
-    assert.strictEqual(imports.length, 4);
-    assert.strictEqual(imports[0], "#testimport");
-    const source = Buffer.from(files[name + ".js"]).toString();
-    assert.ok(source.includes("'#testimport'"));
-  });
 
-  test("Type generation", async () => {
-    const files = await types("test/fixtures/wit", {
-      worldName: "test:flavorful/flavorful",
+    test('Transpile map into package imports', async () => {
+        const name = 'flavorful';
+        const { files, imports } = await transpile(flavorfulWasmBytes, {
+            name,
+            map: {
+                'test:flavorful/*': '#*import',
+            },
+        });
+        assert.strictEqual(imports.length, 4);
+        assert.strictEqual(imports[0], '#testimport');
+        const source = Buffer.from(files[name + '.js']).toString();
+        assert.ok(source.includes("'#testimport'"));
     });
-    assert.strictEqual(Object.keys(files).length, 2);
-    assert.strictEqual(Object.keys(files)[0], "flavorful.d.ts");
-    assert.strictEqual(
-      Object.keys(files)[1],
-      "interfaces/test-flavorful-test.d.ts"
-    );
-    assert.ok(
-      Buffer.from(files[Object.keys(files)[0]]).includes(
-        "export * as test from './interfaces/test-flavorful-test.js'"
-      )
-    );
-    assert.ok(
-      Buffer.from(files[Object.keys(files)[1]]).includes(
-        "export type ListInAlias = "
-      )
-    );
-  });
 
-  test("Type generation (guest)", async () => {
-    const files = await types("test/fixtures/wit", {
-      worldName: "test:flavorful/flavorful",
-      guest: true,
+    test('Type generation', async () => {
+        const files = await types('test/fixtures/wit', {
+            worldName: 'test:flavorful/flavorful',
+        });
+        assert.strictEqual(Object.keys(files).length, 2);
+        assert.strictEqual(Object.keys(files)[0], 'flavorful.d.ts');
+        assert.strictEqual(
+            Object.keys(files)[1],
+            'interfaces/test-flavorful-test.d.ts'
+        );
+        assert.ok(
+            Buffer.from(files[Object.keys(files)[0]]).includes(
+                "export * as test from './interfaces/test-flavorful-test.js'"
+            )
+        );
+        assert.ok(
+            Buffer.from(files[Object.keys(files)[1]]).includes(
+                'export type ListInAlias = '
+            )
+        );
     });
-    assert.strictEqual(Object.keys(files).length, 2);
-    assert.strictEqual(
-      Object.keys(files)[1],
-      "interfaces/test-flavorful-test.d.ts"
-    );
-    assert.ok(
-      Buffer.from(files[Object.keys(files)[0]]).includes(
-        "declare module 'test:flavorful/flavorful' {"
-      )
-    );
-    assert.ok(
-      Buffer.from(files[Object.keys(files)[1]]).includes(
-        "declare module 'test:flavorful/test' {"
-      )
-    );
-  });
 
-  test("Print & Parse", async () => {
-    const output = await print(flavorfulWasmBytes);
-    assert.strictEqual(output.slice(0, 10), "(component");
-
-    const componentParsed = await parse(output);
-    assert.ok(componentParsed);
-  });
-
-  test("Wit & New", async () => {
-    const wit = await readFile(
-      `test/fixtures/wit/deps/flavorful/flavorful.wit`,
-      "utf8"
-    );
-
-    const generatedComponent = await componentEmbed({
-      witSource: wit,
-      dummy: true,
-      metadata: [
-        ["language", [["javascript", ""]]],
-        ["processed-by", [["dummy-gen", "test"]]],
-      ],
+    test('Type generation (guest)', async () => {
+        const files = await types('test/fixtures/wit', {
+            worldName: 'test:flavorful/flavorful',
+            guest: true,
+        });
+        assert.strictEqual(Object.keys(files).length, 2);
+        assert.strictEqual(
+            Object.keys(files)[1],
+            'interfaces/test-flavorful-test.d.ts'
+        );
+        assert.ok(
+            Buffer.from(files[Object.keys(files)[0]]).includes(
+                "declare module 'test:flavorful/flavorful' {"
+            )
+        );
+        assert.ok(
+            Buffer.from(files[Object.keys(files)[1]]).includes(
+                "declare module 'test:flavorful/test' {"
+            )
+        );
     });
-    {
-      const output = await print(generatedComponent);
-      assert.strictEqual(output.slice(0, 7), "(module");
-    }
 
-    const newComponent = await componentNew(generatedComponent);
-    {
-      const output = await print(newComponent);
-      assert.strictEqual(output.slice(0, 10), "(component");
-    }
+    test('Print & Parse', async () => {
+        const output = await print(flavorfulWasmBytes);
+        assert.strictEqual(output.slice(0, 10), '(component');
 
-    const meta = await metadataShow(newComponent);
-    assert.deepStrictEqual(meta[0].metaType, {
-      tag: "component",
-      val: 5,
+        const componentParsed = await parse(output);
+        assert.ok(componentParsed);
     });
-    assert.deepStrictEqual(meta[1].producers, [
-      [
-        "processed-by",
-        [
-          ["wit-component", await getCurrentWitComponentVersion()],
-          ["dummy-gen", "test"],
-        ],
-      ],
-      ["language", [["javascript", ""]]],
-    ]);
-  });
 
-  test("Multi-file WIT", async () => {
-    const generatedComponent = await componentEmbed({
-      dummy: true,
-      witPath:
-        (isWindows ? "//?/" : "") +
-        fileURLToPath(
-          new URL("./fixtures/componentize/source.wit", import.meta.url)
-        ),
-      metadata: [
-        ["language", [["javascript", ""]]],
-        ["processed-by", [["dummy-gen", "test"]]],
-      ],
+    test('Wit & New', async () => {
+        const wit = await readFile(
+            `test/fixtures/wit/deps/flavorful/flavorful.wit`,
+            'utf8'
+        );
+
+        const generatedComponent = await componentEmbed({
+            witSource: wit,
+            dummy: true,
+            metadata: [
+                ['language', [['javascript', '']]],
+                ['processed-by', [['dummy-gen', 'test']]],
+            ],
+        });
+        {
+            const output = await print(generatedComponent);
+            assert.strictEqual(output.slice(0, 7), '(module');
+        }
+
+        const newComponent = await componentNew(generatedComponent);
+        {
+            const output = await print(newComponent);
+            assert.strictEqual(output.slice(0, 10), '(component');
+        }
+
+        const meta = await metadataShow(newComponent);
+        assert.deepStrictEqual(meta[0].metaType, {
+            tag: 'component',
+            val: 5,
+        });
+        assert.deepStrictEqual(meta[1].producers, [
+            [
+                'processed-by',
+                [
+                    ['wit-component', await getCurrentWitComponentVersion()],
+                    ['dummy-gen', 'test'],
+                ],
+            ],
+            ['language', [['javascript', '']]],
+        ]);
     });
-    {
-      const output = await print(generatedComponent);
-      assert.strictEqual(output.slice(0, 7), "(module");
-    }
 
-    const newComponent = await componentNew(generatedComponent);
-    {
-      const output = await print(newComponent);
-      assert.strictEqual(output.slice(0, 10), "(component");
-    }
+    test('Multi-file WIT', async () => {
+        const generatedComponent = await componentEmbed({
+            dummy: true,
+            witPath:
+                (isWindows ? '//?/' : '') +
+                fileURLToPath(
+                    new URL(
+                        './fixtures/componentize/source.wit',
+                        import.meta.url
+                    )
+                ),
+            metadata: [
+                ['language', [['javascript', '']]],
+                ['processed-by', [['dummy-gen', 'test']]],
+            ],
+        });
+        {
+            const output = await print(generatedComponent);
+            assert.strictEqual(output.slice(0, 7), '(module');
+        }
 
-    const meta = await metadataShow(newComponent);
-    assert.deepStrictEqual(meta[0].metaType, {
-      tag: "component",
-      val: 2,
+        const newComponent = await componentNew(generatedComponent);
+        {
+            const output = await print(newComponent);
+            assert.strictEqual(output.slice(0, 10), '(component');
+        }
+
+        const meta = await metadataShow(newComponent);
+        assert.deepStrictEqual(meta[0].metaType, {
+            tag: 'component',
+            val: 2,
+        });
+        assert.deepStrictEqual(meta[1].producers, [
+            [
+                'processed-by',
+                [
+                    ['wit-component', await getCurrentWitComponentVersion()],
+                    ['dummy-gen', 'test'],
+                ],
+            ],
+            ['language', [['javascript', '']]],
+        ]);
     });
-    assert.deepStrictEqual(meta[1].producers, [
-      [
-        "processed-by",
-        [
-          ["wit-component", await getCurrentWitComponentVersion()],
-          ["dummy-gen", "test"],
-        ],
-      ],
-      ["language", [["javascript", ""]]],
-    ]);
-  });
 
-  test("Component new adapt", async () => {
-    const generatedComponent = await componentNew(exitCodeWasmBytes, [
-      [
-        "wasi_snapshot_preview1",
-        await readComponentBytes(preview1AdapterReactorPath()),
-      ],
-    ]);
+    test('Component new adapt', async () => {
+        const generatedComponent = await componentNew(exitCodeWasmBytes, [
+            [
+                'wasi_snapshot_preview1',
+                await readComponentBytes(preview1AdapterReactorPath()),
+            ],
+        ]);
 
-    await print(generatedComponent);
-  });
-
-  test("Extract metadata", async () => {
-    const meta = await metadataShow(exitCodeWasmBytes);
-    assert.deepStrictEqual(meta, [
-      {
-        metaType: { tag: "module" },
-        producers: [],
-        name: undefined,
-        parentIndex: undefined,
-        range: [0, 262],
-      },
-    ]);
-  });
-
-  test("Optimize", async () => {
-    const { component: optimizedComponent } = await opt(flavorfulWasmBytes);
-    assert.ok(optimizedComponent.byteLength < flavorfulWasmBytes.byteLength);
-  });
-
-  test("Transpile & Optimize & Minify", async () => {
-    const name = "flavorful";
-    const { files, imports, exports } = await transpile(flavorfulWasmBytes, {
-      name,
-      minify: true,
-      validLiftingOptimization: true,
-      tlaCompat: true,
-      optimize: true,
-      base64Cutoff: 0,
+        await print(generatedComponent);
     });
-    assert.strictEqual(imports.length, 4);
-    assert.strictEqual(exports.length, 3);
-    assert.deepStrictEqual(exports[0], ["test", "instance"]);
-    assert.ok(
-      files[name + ".js"].length < FLAVORFUL_WASM_TRANSPILED_CODE_CHAR_LIMIT
-    );
-  });
+
+    test('Extract metadata', async () => {
+        const meta = await metadataShow(exitCodeWasmBytes);
+        assert.deepStrictEqual(meta, [
+            {
+                metaType: { tag: 'module' },
+                producers: [],
+                name: undefined,
+                parentIndex: undefined,
+                range: [0, 262],
+            },
+        ]);
+    });
+
+    test('Optimize', async () => {
+        const { component: optimizedComponent } = await opt(flavorfulWasmBytes);
+        assert.ok(
+            optimizedComponent.byteLength < flavorfulWasmBytes.byteLength
+        );
+    });
+
+    test('Transpile & Optimize & Minify', async () => {
+        const name = 'flavorful';
+        const { files, imports, exports } = await transpile(
+            flavorfulWasmBytes,
+            {
+                name,
+                minify: true,
+                validLiftingOptimization: true,
+                tlaCompat: true,
+                optimize: true,
+                base64Cutoff: 0,
+            }
+        );
+        assert.strictEqual(imports.length, 4);
+        assert.strictEqual(exports.length, 3);
+        assert.deepStrictEqual(exports[0], ['test', 'instance']);
+        assert.ok(
+            files[name + '.js'].length <
+                FLAVORFUL_WASM_TRANSPILED_CODE_CHAR_LIMIT
+        );
+    });
 });

--- a/packages/jco/test/async.browser.js
+++ b/packages/jco/test/async.browser.js
@@ -1,149 +1,147 @@
-import { resolve } from "node:path";
-import { mkdir, rm, symlink } from "node:fs/promises";
+import { resolve } from 'node:path';
+import { mkdir, rm, symlink } from 'node:fs/promises';
 
-import { fileURLToPath, pathToFileURL } from "url";
-import puppeteer from "puppeteer";
+import { fileURLToPath, pathToFileURL } from 'url';
+import puppeteer from 'puppeteer';
 
-import { suite, test, beforeAll, afterAll, afterEach, assert } from "vitest";
+import { suite, test, beforeAll, afterAll, afterEach, assert } from 'vitest';
 
 import {
-  getTmpDir,
-  setupAsyncTest,
-  startTestWebServer,
-  loadTestPage,
-} from "./helpers.js";
-import { AsyncFunction } from "./common.js";
+    getTmpDir,
+    setupAsyncTest,
+    startTestWebServer,
+    loadTestPage,
+} from './helpers.js';
+import { AsyncFunction } from './common.js';
 
 suite(`Async`, async () => {
-  var tmpDir;
-  var outDir;
-  var outFile;
+    var tmpDir;
+    var outDir;
+    var outFile;
 
-  beforeAll(async function () {
-    tmpDir = await getTmpDir();
-    outDir = resolve(tmpDir, "out-component-dir");
-    outFile = resolve(tmpDir, "out-component-file");
+    beforeAll(async function () {
+        tmpDir = await getTmpDir();
+        outDir = resolve(tmpDir, 'out-component-dir');
+        outFile = resolve(tmpDir, 'out-component-file');
 
-    const modulesDir = resolve(tmpDir, "node_modules", "@bytecodealliance");
-    await mkdir(modulesDir, { recursive: true });
-    await symlink(
-      fileURLToPath(new URL("../packages/preview2-shim", import.meta.url)),
-      resolve(modulesDir, "preview2-shim"),
-      "dir"
-    );
-  });
+        const modulesDir = resolve(tmpDir, 'node_modules', '@bytecodealliance');
+        await mkdir(modulesDir, { recursive: true });
+        await symlink(
+            fileURLToPath(
+                new URL('../packages/preview2-shim', import.meta.url)
+            ),
+            resolve(modulesDir, 'preview2-shim'),
+            'dir'
+        );
+    });
 
-  afterAll(async function () {
-    try {
-      await rm(tmpDir, { recursive: true });
-    } catch {}
-  });
+    afterAll(async function () {
+        try {
+            await rm(tmpDir, { recursive: true });
+        } catch {}
+    });
 
-  afterEach(async function () {
-    try {
-      await rm(outDir, { recursive: true });
-      await rm(outFile);
-    } catch {}
-  });
+    afterEach(async function () {
+        try {
+            await rm(outDir, { recursive: true });
+            await rm(outFile);
+        } catch {}
+    });
 
-  test(
-    "Transpile async (browser, JSPI)",
-    { retry: 3 },
-    async () => {
-      if (typeof WebAssembly?.Suspending !== "function") {
-        return;
-      }
-      const componentName = "async-call";
-      const {
-        instance,
-        cleanup: componentCleanup,
-        outputDir,
-      } = await setupAsyncTest({
-        asyncMode: "jspi",
-        component: {
-          name: "async_call",
-          path: resolve("test/fixtures/components/async_call.component.wasm"),
-          imports: {
-            "something:test/test-interface": {
-              callAsync: async () => "called async",
-              callSync: () => "called sync",
+    test('Transpile async (browser, JSPI)', { retry: 3 }, async () => {
+        if (typeof WebAssembly?.Suspending !== 'function') {
+            return;
+        }
+        const componentName = 'async-call';
+        const {
+            instance,
+            cleanup: componentCleanup,
+            outputDir,
+        } = await setupAsyncTest({
+            asyncMode: 'jspi',
+            component: {
+                name: 'async_call',
+                path: resolve(
+                    'test/fixtures/components/async_call.component.wasm'
+                ),
+                imports: {
+                    'something:test/test-interface': {
+                        callAsync: async () => 'called async',
+                        callSync: () => 'called sync',
+                    },
+                },
             },
-          },
-        },
-        jco: {
-          transpile: {
-            extraArgs: {
-              asyncImports: ["something:test/test-interface#call-async"],
-              asyncExports: ["run-async"],
+            jco: {
+                transpile: {
+                    extraArgs: {
+                        asyncImports: [
+                            'something:test/test-interface#call-async',
+                        ],
+                        asyncExports: ['run-async'],
+                    },
+                },
             },
-          },
-        },
-      });
-      const moduleName = componentName.toLowerCase().replaceAll("-", "_");
-      const moduleRelPath = `${moduleName}/${moduleName}.js`;
+        });
+        const moduleName = componentName.toLowerCase().replaceAll('-', '_');
+        const moduleRelPath = `${moduleName}/${moduleName}.js`;
 
-      assert.strictEqual(
-        instance.runSync instanceof AsyncFunction,
-        false,
-        "runSync() should be a sync function"
-      );
-      assert.strictEqual(
-        instance.runAsync instanceof AsyncFunction,
-        true,
-        "runAsync() should be an async function"
-      );
+        assert.strictEqual(
+            instance.runSync instanceof AsyncFunction,
+            false,
+            'runSync() should be a sync function'
+        );
+        assert.strictEqual(
+            instance.runAsync instanceof AsyncFunction,
+            true,
+            'runAsync() should be an async function'
+        );
 
-      // Start a test web server
-      const {
-        server,
-        serverPort,
-        cleanup: webServerCleanup,
-      } = await startTestWebServer({
-        routes: [
-          // NOTE: the goal here is to serve relative paths via the browser hash
-          //
-          // (1) browser visits test page (served by test web server)
-          // (2) browser requests component itself by looking at URL hash fragment
-          //     (i.e. "#transpiled:async_call/async_call.js" -> , "/transpiled/async_call/async_call.js")
-          //     (i.e. "/transpiled/async_call/async_call.js" -> file read of /tmp/xxxxxx/async_call/async_call.js)
-          {
-            urlPrefix: "/transpiled/",
-            basePathURL: pathToFileURL(`${outputDir}/`),
-          },
-          // Serve all other files (ex. the initial HTML for the page)
-          { basePathURL: import.meta.url },
-        ],
-      });
+        // Start a test web server
+        const { serverPort, cleanup: webServerCleanup } =
+            await startTestWebServer({
+                routes: [
+                    // NOTE: the goal here is to serve relative paths via the browser hash
+                    //
+                    // (1) browser visits test page (served by test web server)
+                    // (2) browser requests component itself by looking at URL hash fragment
+                    //     (i.e. "#transpiled:async_call/async_call.js" -> , "/transpiled/async_call/async_call.js")
+                    //     (i.e. "/transpiled/async_call/async_call.js" -> file read of /tmp/xxxxxx/async_call/async_call.js)
+                    {
+                        urlPrefix: '/transpiled/',
+                        basePathURL: pathToFileURL(`${outputDir}/`),
+                    },
+                    // Serve all other files (ex. the initial HTML for the page)
+                    { basePathURL: import.meta.url },
+                ],
+            });
 
-      // Start a browser to visit the test server
-      const browser = await puppeteer.launch({
-        args: [
-          "--enable-experimental-webassembly-jspi",
-          "--flag-switches-begin",
-          "--enable-features=WebAssemblyExperimentalJSPI",
-          "--flag-switches-end",
-        ],
-      });
+        // Start a browser to visit the test server
+        const browser = await puppeteer.launch({
+            args: [
+                '--enable-experimental-webassembly-jspi',
+                '--flag-switches-begin',
+                '--enable-features=WebAssemblyExperimentalJSPI',
+                '--flag-switches-end',
+            ],
+        });
 
-      // Load the test page in the browser, which will trigger tests against
-      // the component and/or related browser polyfills
-      const {
-        page,
-        output: { json },
-      } = await loadTestPage({
-        browser,
-        serverPort,
-        path: "fixtures/browser/test-pages/something__test.async.html",
-        hash: `transpiled:${moduleRelPath}`,
-      });
+        // Load the test page in the browser, which will trigger tests against
+        // the component and/or related browser polyfills
+        const {
+            output: { json },
+        } = await loadTestPage({
+            browser,
+            serverPort,
+            path: 'fixtures/browser/test-pages/something__test.async.html',
+            hash: `transpiled:${moduleRelPath}`,
+        });
 
-      // Check the output expected to be returned from handle of the
-      // guest export (this depends on the component)
-      assert.deepStrictEqual(json, { responseText: "callAsync" });
+        // Check the output expected to be returned from handle of the
+        // guest export (this depends on the component)
+        assert.deepStrictEqual(json, { responseText: 'callAsync' });
 
-      await browser.close();
-      await webServerCleanup();
-      await componentCleanup();
-    },
-  );
+        await browser.close();
+        await webServerCleanup();
+        await componentCleanup();
+    });
 });

--- a/packages/jco/test/async.js
+++ b/packages/jco/test/async.js
@@ -6,13 +6,7 @@ import { fileURLToPath } from 'url';
 
 import { suite, test, assert, expect } from 'vitest';
 
-import {
-    exec,
-    jcoPath,
-    getTmpDir,
-    setupAsyncTest,
-    skipWithoutJSPI,
-} from './helpers.js';
+import { exec, jcoPath, getTmpDir, setupAsyncTest } from './helpers.js';
 import { AsyncFunction } from './common.js';
 
 const P3_COMPONENT_FIXTURES_DIR = fileURLToPath(
@@ -79,7 +73,7 @@ suite('Async', () => {
             'dir'
         );
 
-        const { instance, cleanup, component } = await setupAsyncTest({
+        const { instance, cleanup } = await setupAsyncTest({
             asyncMode: 'jspi',
             component: {
                 name: 'async_call',
@@ -152,7 +146,7 @@ suite('Async', () => {
                 'dir'
             );
             const testMessage = 'Hello from Async Function!';
-            const { instance, cleanup, component } = await setupAsyncTest({
+            const { instance, cleanup } = await setupAsyncTest({
                 asyncMode: 'jspi',
                 component: {
                     name: 'async_call',
@@ -201,7 +195,7 @@ suite('Async', () => {
             t.skip();
         }
 
-        const { esModule, cleanup, esModuleOutputDir } = await setupAsyncTest({
+        const { esModule, cleanup } = await setupAsyncTest({
             asyncMode: 'jspi',
             component: {
                 name: 'async-error-context',
@@ -245,7 +239,7 @@ suite('Async', () => {
         await cleanup();
     });
 
-    test('context.get/set (sync export, sync call)', async (t) => {
+    test('context.get/set (sync export, sync call)', async () => {
         const componentName = 'context-sync';
         const componentPath = join(
             P3_COMPONENT_FIXTURES_DIR,
@@ -316,7 +310,7 @@ suite('Async', () => {
         await cleanup();
     });
 
-    test('backpressure.get (sync export, sync call)', async (t) => {
+    test('backpressure.get (sync export, sync call)', async () => {
         const componentName = 'backpressure-sync';
         const componentPath = join(
             P3_COMPONENT_FIXTURES_DIR,

--- a/packages/jco/test/browser.js
+++ b/packages/jco/test/browser.js
@@ -1,193 +1,196 @@
-import { mkdir, readFile, writeFile, rm, symlink } from "node:fs/promises";
-import { createServer } from "node:http";
-import { resolve, extname, dirname } from "node:path";
+import { mkdir, readFile, writeFile, rm, symlink } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { resolve, extname, dirname } from 'node:path';
 
-import puppeteer from "puppeteer";
-import { fileURLToPath, pathToFileURL } from "url";
-import mime from "mime";
+import puppeteer from 'puppeteer';
+import { fileURLToPath, pathToFileURL } from 'url';
+import mime from 'mime';
 
 import {
-  suite,
-  test,
-  beforeAll,
-  afterAll,
-  afterEach,
-  assert,
-  vi,
-} from "vitest";
+    suite,
+    test,
+    beforeAll,
+    afterAll,
+    afterEach,
+    assert,
+    vi,
+} from 'vitest';
 
-import { transpile } from "../src/api.js";
-import { getRandomPort, exec, getTmpDir } from "./helpers.js";
+import { transpile } from '../src/api.js';
+import { getRandomPort, exec, getTmpDir } from './helpers.js';
 
-suite("Browser", () => {
-  let tmpDir, outDir, outFile, outDirUrl;
-  let server, port, browser;
+suite('Browser', () => {
+    let tmpDir, outDir, outFile, outDirUrl;
+    let server, port, browser;
 
-  beforeAll(async function () {
-    tmpDir = await getTmpDir();
-    outDir = resolve(tmpDir, "out-component-dir");
-    outDirUrl = pathToFileURL(outDir + "/");
-    outFile = resolve(tmpDir, "out-component-file");
-    port = await getRandomPort();
+    beforeAll(async function () {
+        tmpDir = await getTmpDir();
+        outDir = resolve(tmpDir, 'out-component-dir');
+        outDirUrl = pathToFileURL(outDir + '/');
+        outFile = resolve(tmpDir, 'out-component-file');
+        port = await getRandomPort();
 
-    const modulesDir = resolve(tmpDir, "node_modules", "@bytecodealliance");
-    await mkdir(modulesDir, { recursive: true });
-    await symlink(
-      fileURLToPath(new URL("../../preview2-shim", import.meta.url)),
-      resolve(modulesDir, "preview2-shim"),
-      "dir",
-    );
+        const modulesDir = resolve(tmpDir, 'node_modules', '@bytecodealliance');
+        await mkdir(modulesDir, { recursive: true });
+        await symlink(
+            fileURLToPath(new URL('../../preview2-shim', import.meta.url)),
+            resolve(modulesDir, 'preview2-shim'),
+            'dir'
+        );
 
-    // run a local server on some port
-    server = createServer(async (req, res) => {
-      let fileUrl;
-      if (req.url.startsWith("/tmpdir/")) {
-        fileUrl = new URL(`.${req.url.slice(7)}`, outDirUrl);
-      } else {
-        fileUrl = new URL(`../../${req.url}`, import.meta.url);
-      }
-      try {
-        const html = await readFile(fileUrl);
-        res.writeHead(200, { "content-type": mime.getType(extname(req.url)) });
-        res.end(html);
-      } catch (e) {
-        if (e.code === "ENOENT") {
-          res.writeHead(404);
-          res.end(e.message);
-        } else {
-          res.writeHead(500);
-          res.end(e.message);
-        }
-      }
-    }).listen(port);
+        // run a local server on some port
+        server = createServer(async (req, res) => {
+            let fileUrl;
+            if (req.url.startsWith('/tmpdir/')) {
+                fileUrl = new URL(`.${req.url.slice(7)}`, outDirUrl);
+            } else {
+                fileUrl = new URL(`../../${req.url}`, import.meta.url);
+            }
+            try {
+                const html = await readFile(fileUrl);
+                res.writeHead(200, {
+                    'content-type': mime.getType(extname(req.url)),
+                });
+                res.end(html);
+            } catch (e) {
+                if (e.code === 'ENOENT') {
+                    res.writeHead(404);
+                    res.end(e.message);
+                } else {
+                    res.writeHead(500);
+                    res.end(e.message);
+                }
+            }
+        }).listen(port);
 
-    // Wait until the server is ready
-    await vi.waitUntil(
-      async () => {
-        let res;
-        try {
-          // NOTE: we only need the request to succeed to know the server is running
-          // requesting the root will actually return a 500 due to attempt to open a dir
-          res = await fetch(`http://localhost:${port}`);
-          return true;
-        } catch (err) {
-          console.log("ERROR:", err);
-          return false;
-        }
-      },
-      {
-        timeout: 30_000,
-        interval: 500,
-      },
-    );
+        // Wait until the server is ready
+        await vi.waitUntil(
+            async () => {
+                try {
+                    // NOTE: we only need the request to succeed to know the server is running
+                    // requesting the root will actually return a 500 due to attempt to open a dir
+                    await fetch(`http://localhost:${port}`);
+                    return true;
+                } catch (err) {
+                    console.log('ERROR:', err);
+                    return false;
+                }
+            },
+            {
+                timeout: 30_000,
+                interval: 500,
+            }
+        );
 
-    browser = await puppeteer.launch();
-  });
-
-  afterAll(async function () {
-    try {
-      await rm(tmpDir, { recursive: true });
-    } catch {}
-    await browser.close();
-    await new Promise((resolve) => server.close(resolve));
-  });
-
-  afterEach(async function () {
-    try {
-      await rm(outDir, { recursive: true });
-      await rm(outFile);
-    } catch {}
-  });
-
-  test("Transpilation", async () => {
-    await testPage(browser, port, "transpile");
-  });
-
-    test("IDL window", async () => {
-      // Componentize the webidl DOM window test
-      const { stdout: _, stderr } = await exec(
-        "src/jco.js",
-        "componentize",
-        "test/fixtures/idl/dom.test.js",
-        "-d",
-        "clocks",
-        "-d",
-        "random",
-        "-d",
-        "stdio",
-        "-w",
-        "test/fixtures/idl/dom.wit",
-        "-n",
-        "window-test",
-        "-o",
-        outFile,
-      );
-      assert.strictEqual(stderr, "");
-
-      // Transpile the test component
-      const component = await readFile(outFile);
-      const { files } = await transpile(component, { name: "dom" });
-
-      for (const [file, source] of Object.entries(files)) {
-        const outPath = resolve(outDir, file);
-        await mkdir(dirname(outPath), { recursive: true });
-        await writeFile(outPath, source);
-      }
-
-      // Run the test function in the browser from the generated tmpdir
-      await testPage(browser, port, "test:dom.js");
+        browser = await puppeteer.launch();
     });
 
-    test("IDL console", async () => {
-      // Componentize the webidl DOM window test
-      const { stdout: _, stderr } = await exec(
-        "src/jco.js",
-        "componentize",
-        "test/fixtures/idl/console.test.js",
-        "-d",
-        "clocks",
-        "-d",
-        "random",
-        "-d",
-        "stdio",
-        "-w",
-        "test/fixtures/idl/console.wit",
-        "-n",
-        "console-test",
-        "-o",
-        outFile,
-      );
-      assert.strictEqual(stderr, "");
+    afterAll(async function () {
+        try {
+            await rm(tmpDir, { recursive: true });
+        } catch {}
+        await browser.close();
+        await new Promise((resolve) => server.close(resolve));
+    });
 
-      // Transpile the test component
-      const component = await readFile(outFile);
-      const { files } = await transpile(component, { name: "console" });
+    afterEach(async function () {
+        try {
+            await rm(outDir, { recursive: true });
+            await rm(outFile);
+        } catch {}
+    });
 
-      for (const [file, source] of Object.entries(files)) {
-        const outPath = resolve(outDir, file);
-        await mkdir(dirname(outPath), { recursive: true });
-        await writeFile(outPath, source);
-      }
+    test('Transpilation', async () => {
+        await testPage(browser, port, 'transpile');
+    });
 
-      await testPage(browser, port, "test:console.js");
+    test('IDL window', async () => {
+        // Componentize the webidl DOM window test
+        const { stderr } = await exec(
+            'src/jco.js',
+            'componentize',
+            'test/fixtures/idl/dom.test.js',
+            '-d',
+            'clocks',
+            '-d',
+            'random',
+            '-d',
+            'stdio',
+            '-w',
+            'test/fixtures/idl/dom.wit',
+            '-n',
+            'window-test',
+            '-o',
+            outFile
+        );
+        assert.strictEqual(stderr, '');
+
+        // Transpile the test component
+        const component = await readFile(outFile);
+        const { files } = await transpile(component, { name: 'dom' });
+
+        for (const [file, source] of Object.entries(files)) {
+            const outPath = resolve(outDir, file);
+            await mkdir(dirname(outPath), { recursive: true });
+            await writeFile(outPath, source);
+        }
+
+        // Run the test function in the browser from the generated tmpdir
+        await testPage(browser, port, 'test:dom.js');
+    });
+
+    test('IDL console', async () => {
+        // Componentize the webidl DOM window test
+        const { stderr } = await exec(
+            'src/jco.js',
+            'componentize',
+            'test/fixtures/idl/console.test.js',
+            '-d',
+            'clocks',
+            '-d',
+            'random',
+            '-d',
+            'stdio',
+            '-w',
+            'test/fixtures/idl/console.wit',
+            '-n',
+            'console-test',
+            '-o',
+            outFile
+        );
+        assert.strictEqual(stderr, '');
+
+        // Transpile the test component
+        const component = await readFile(outFile);
+        const { files } = await transpile(component, { name: 'console' });
+
+        for (const [file, source] of Object.entries(files)) {
+            const outPath = resolve(outDir, file);
+            await mkdir(dirname(outPath), { recursive: true });
+            await writeFile(outPath, source);
+        }
+
+        await testPage(browser, port, 'test:console.js');
     });
 });
 
 export async function testPage(browser, port, hash) {
-  const page = await browser.newPage();
+    const page = await browser.newPage();
 
-  assert.ok(
-    (
-      await page.goto(`http://localhost:${port}/jco/test/browser.html#${hash}`)
-    ).ok(),
-  );
+    assert.ok(
+        (
+            await page.goto(
+                `http://localhost:${port}/jco/test/browser.html#${hash}`
+            )
+        ).ok()
+    );
 
-  const body = await page.locator("body").waitHandle();
+    const body = await page.locator('body').waitHandle();
 
-  let bodyHtml = await body.evaluate((el) => el.innerHTML);
-  while (bodyHtml === "<h1>Running</h1>") {
-    bodyHtml = await body.evaluate((el) => el.innerHTML);
-  }
-  assert.strictEqual(bodyHtml, "<h1>OK</h1>");
-  await page.close();
+    let bodyHtml = await body.evaluate((el) => el.innerHTML);
+    while (bodyHtml === '<h1>Running</h1>') {
+        bodyHtml = await body.evaluate((el) => el.innerHTML);
+    }
+    assert.strictEqual(bodyHtml, '<h1>OK</h1>');
+    await page.close();
 }

--- a/packages/jco/test/cli.js
+++ b/packages/jco/test/cli.js
@@ -1,687 +1,708 @@
-import { resolve } from "node:path";
-import { execArgv } from "node:process";
-import { mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
+import { resolve } from 'node:path';
+import { execArgv } from 'node:process';
+import { mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises';
 
-import { fileURLToPath, pathToFileURL } from "url";
+import { fileURLToPath, pathToFileURL } from 'url';
 
 import {
-  exec,
-  jcoPath,
-  getTmpDir,
-  readComponentBytes,
-  getCurrentWitComponentVersion,
-} from "./helpers.js";
-import { AsyncFunction } from "./common.js";
+    exec,
+    jcoPath,
+    getTmpDir,
+    readComponentBytes,
+    getCurrentWitComponentVersion,
+} from './helpers.js';
+import { AsyncFunction } from './common.js';
 
-import { suite, test, beforeAll, afterAll, afterEach, assert } from "vitest";
+import { suite, test, beforeAll, afterAll, afterEach, assert } from 'vitest';
 
-const multiMemory = execArgv.includes("--experimental-wasm-multi-memory")
-  ? ["--multi-memory"]
-  : [];
+const multiMemory = execArgv.includes('--experimental-wasm-multi-memory')
+    ? ['--multi-memory']
+    : [];
 
-suite("CLI", () => {
-  var tmpDir;
-  var outDir;
-  var outFile;
+suite('CLI', () => {
+    var tmpDir;
+    var outDir;
+    var outFile;
 
-  beforeAll(async function () {
-    tmpDir = await getTmpDir();
-    outDir = resolve(tmpDir, "out-component-dir");
-    outFile = resolve(tmpDir, "out-component-file");
+    beforeAll(async function () {
+        tmpDir = await getTmpDir();
+        outDir = resolve(tmpDir, 'out-component-dir');
+        outFile = resolve(tmpDir, 'out-component-file');
 
-    const modulesDir = resolve(tmpDir, "node_modules", "@bytecodealliance");
-    await mkdir(modulesDir, { recursive: true });
-    await symlink(
-      fileURLToPath(new URL("../packages/preview2-shim", import.meta.url)),
-      resolve(modulesDir, "preview2-shim"),
-      "dir"
-    );
-  });
-
-  afterAll(async function () {
-    try {
-      await rm(tmpDir, { recursive: true });
-    } catch {}
-  });
-
-  afterEach(async function () {
-    try {
-      await rm(outDir, { recursive: true });
-      await rm(outFile);
-    } catch {}
-  });
-
-  test("Transcoding", async () => {
-    const { stderr } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/env-allow.composed.wasm`,
-      ...multiMemory,
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    await writeFile(
-      `${outDir}/package.json`,
-      JSON.stringify({ type: "module" })
-    );
-    const m = await import(`${pathToFileURL(outDir)}/env-allow.composed.js`);
-    assert.deepStrictEqual(m.testGetEnv(), [["CUSTOM", "VAL"]]);
-  });
-
-  test("Transcoding UTF8 <-> UTF16", async () => {
-    const { stdout, stderr } = await exec(
-      jcoPath,
-      "run",
-      `test/fixtures/utf8-utf16.composed.wasm`,
-      ...multiMemory,
-      "--",
-      "asdf中文🀄️⏰"
-    );
-    assert.strictEqual(stdout, "ret: asdf中文🀄️⏰asdf中文🀄️⏰\n");
-    assert.strictEqual(stderr, "");
-  });
-
-  test("Resource transfer", async () => {
-    const { stderr } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/stdio.composed.wasm`,
-      ...multiMemory,
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    await writeFile(
-      `${outDir}/package.json`,
-      JSON.stringify({ type: "module" })
-    );
-    const m = await import(`${pathToFileURL(outDir)}/stdio.composed.js`);
-    m.testStdio();
-  });
-
-  test("Resource transfer valid lifting", async () => {
-    const { stderr } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/stdio.composed.wasm`,
-      ...multiMemory,
-      "--valid-lifting-optimization",
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    await writeFile(
-      `${outDir}/package.json`,
-      JSON.stringify({ type: "module" })
-    );
-    const m = await import(`${pathToFileURL(outDir)}/stdio.composed.js`);
-    m.testStdio();
-  });
-
-  test("Transpile", async () => {
-    const name = "flavorful";
-    const { stderr } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/components/${name}.component.wasm`,
-      "--no-wasi-shim",
-      "--name",
-      name,
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(`${outDir}/${name}.js`);
-    assert.ok(source.toString().includes("export { test"));
-  });
-
-  test("Transpile with Async Mode for JSPI", async () => {
-    if (typeof WebAssembly.Suspending !== "function") {
-      return;
-    }
-
-    const name = "async_call";
-    const { stderr } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/components/${name}.component.wasm`,
-      `--name=${name}`,
-      "--valid-lifting-optimization",
-      "--tla-compat",
-      "--instantiation=async",
-      "--base64-cutoff=0",
-      "--async-mode=jspi",
-      "--async-imports=something:test/test-interface#call-async",
-      "--async-exports=run-async",
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    await writeFile(
-      `${outDir}/package.json`,
-      JSON.stringify({ type: "module" })
-    );
-    const m = await import(`${pathToFileURL(outDir)}/${name}.js`);
-    const inst = await m.instantiate(undefined, {
-      "something:test/test-interface": {
-        callAsync: async () => "called async",
-        callSync: () => "called sync",
-      },
+        const modulesDir = resolve(tmpDir, 'node_modules', '@bytecodealliance');
+        await mkdir(modulesDir, { recursive: true });
+        await symlink(
+            fileURLToPath(
+                new URL('../packages/preview2-shim', import.meta.url)
+            ),
+            resolve(modulesDir, 'preview2-shim'),
+            'dir'
+        );
     });
-    assert.strictEqual(inst.runSync instanceof AsyncFunction, false);
-    assert.strictEqual(inst.runAsync instanceof AsyncFunction, true);
 
-    assert.strictEqual(inst.runSync(), "called sync");
-    assert.strictEqual(await inst.runAsync(), "called async");
-  });
+    afterAll(async function () {
+        try {
+            await rm(tmpDir, { recursive: true });
+        } catch {}
+    });
 
-  test("Transpile & Optimize & Minify", async () => {
-    const name = "flavorful";
-    const { stderr } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/components/${name}.component.wasm`,
-      "--name",
-      name,
-      "--valid-lifting-optimization",
-      "--tla-compat",
-      "--optimize",
-      "--minify",
-      "--base64-cutoff=0",
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(`${outDir}/${name}.js`);
-    assert.ok(source.toString().includes("as test,"));
-  });
+    afterEach(async function () {
+        try {
+            await rm(outDir, { recursive: true });
+            await rm(outFile);
+        } catch {}
+    });
 
-  test("Transpile with tracing", async () => {
-    const name = "flavorful";
-    const { stderr } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/components/${name}.component.wasm`,
-      "--name",
-      name,
-      "--map",
-      "testwasi=./wasi.js",
-      "--tracing",
-      "--base64-cutoff=0",
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(`${outDir}/${name}.js`, "utf8");
-    assert.ok(source.includes("function toResultString("));
-    assert.ok(
-      source.includes(
-        'console.error(`[module="test:flavorful/test", function="f-list-in-record1"] call a'
-      )
-    );
-    assert.ok(
-      source.includes(
-        'console.error(`[module="test:flavorful/test", function="list-of-variants"] return result=${toResultString(ret)}`);'
-      )
-    );
-  });
+    test('Transcoding', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/env-allow.composed.wasm`,
+            ...multiMemory,
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        await writeFile(
+            `${outDir}/package.json`,
+            JSON.stringify({ type: 'module' })
+        );
+        const m = await import(
+            `${pathToFileURL(outDir)}/env-allow.composed.js`
+        );
+        assert.deepStrictEqual(m.testGetEnv(), [['CUSTOM', 'VAL']]);
+    });
 
-  test("Type generation", async () => {
-    const { stderr } = await exec(
-      jcoPath,
-      "types",
-      "test/fixtures/wit",
-      "--world-name",
-      "test:flavorful/flavorful",
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(`${outDir}/flavorful.d.ts`, "utf8");
-    assert.ok(
-      source.includes(
-        "export * as test from './interfaces/test-flavorful-test.js';"
-      )
-    ); // exported interface
-    const iface = await readFile(
-      `${outDir}/interfaces/test-flavorful-test.d.ts`,
-      "utf8"
-    );
-    assert.ok(!iface.includes("declare module 'test:flavorful/test' {")); // should *not* be an ambient module (guest types)
-    assert.ok(iface.includes("export function listOfVariants(")); // function
-    assert.ok(iface.includes("export type MyErrno =")); // enum
-    assert.ok(iface.includes("export type ListInAlias =")); // type alias
-  });
+    test('Transcoding UTF8 <-> UTF16', async () => {
+        const { stdout, stderr } = await exec(
+            jcoPath,
+            'run',
+            `test/fixtures/utf8-utf16.composed.wasm`,
+            ...multiMemory,
+            '--',
+            'asdf中文🀄️⏰'
+        );
+        assert.strictEqual(stdout, 'ret: asdf中文🀄️⏰asdf中文🀄️⏰\n');
+        assert.strictEqual(stderr, '');
+    });
 
-  test("Type generation (specific features)", async () => {
-    const { stderr, stdout } = await exec(
-      jcoPath,
-      "types",
-      "test/fixtures/wits/feature-gates-unstable.wit",
-      "--world-name",
-      "test:feature-gates-unstable/gated",
-      "--feature",
-      "enable-c",
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(
-      `${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`,
-      "utf8"
-    );
-    assert.ok(source.includes("export function a(): void;"));
-    assert.ok(!source.includes("export function b(): void;"));
-    assert.ok(source.includes("export function c(): void;"));
-  });
+    test('Resource transfer', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/stdio.composed.wasm`,
+            ...multiMemory,
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        await writeFile(
+            `${outDir}/package.json`,
+            JSON.stringify({ type: 'module' })
+        );
+        const m = await import(`${pathToFileURL(outDir)}/stdio.composed.js`);
+        m.testStdio();
+    });
 
-  test("Type generation (all features)", async () => {
-    const { stderr, stdout } = await exec(
-      jcoPath,
-      "types",
-      "test/fixtures/wits/feature-gates-unstable.wit",
-      "--world-name",
-      "test:feature-gates-unstable/gated",
-      "--all-features",
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(
-      `${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`,
-      "utf8"
-    );
-    assert.ok(source.includes("export function a(): void;"));
-    assert.ok(source.includes("export function b(): void;"));
-    assert.ok(source.includes("export function c(): void;"));
-  });
+    test('Resource transfer valid lifting', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/stdio.composed.wasm`,
+            ...multiMemory,
+            '--valid-lifting-optimization',
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        await writeFile(
+            `${outDir}/package.json`,
+            JSON.stringify({ type: 'module' })
+        );
+        const m = await import(`${pathToFileURL(outDir)}/stdio.composed.js`);
+        m.testStdio();
+    });
 
-  // NOTE: enabling all features and a specific feature means --all-features takes precedence
-  test("Type generation (all features + feature)", async () => {
-    const { stderr, stdout } = await exec(
-      jcoPath,
-      "types",
-      "test/fixtures/wits/feature-gates-unstable.wit",
-      "--world-name",
-      "test:feature-gates-unstable/gated",
-      "--all-features",
-      "--feature",
-      "enable-c",
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(
-      `${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`,
-      "utf8"
-    );
-    assert.ok(source.includes("export function a(): void;"));
-    assert.ok(source.includes("export function b(): void;"));
-    assert.ok(source.includes("export function c(): void;"));
-  });
+    test('Transpile', async () => {
+        const name = 'flavorful';
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/components/${name}.component.wasm`,
+            '--no-wasi-shim',
+            '--name',
+            name,
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(`${outDir}/${name}.js`);
+        assert.ok(source.toString().includes('export { test'));
+    });
 
-  test("Type generation (declare imports)", async () => {
-    const { stderr } = await exec(
-      jcoPath,
-      "guest-types",
-      "test/fixtures/wit",
-      "--world-name",
-      "test:flavorful/flavorful",
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(
-      `${outDir}/interfaces/test-flavorful-test.d.ts`,
-      "utf8"
-    );
-    // NOTE: generation of guest types *no longer* produces an explicitly exported module
-    // but rather contains an typescript ambient module (w/ opt-in for producing explicit
-    // module declarations if necessary)
-    //
-    // see: https://github.com/bytecodealliance/jco/pull/528
-    assert.ok(source.includes("declare module 'test:flavorful/test' {"));
-  });
+    test('Transpile with Async Mode for JSPI', async () => {
+        if (typeof WebAssembly.Suspending !== 'function') {
+            return;
+        }
 
-  test("TypeScript naming checks", async () => {
-    const { stderr } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/wit/deps/ts-check/ts-check.wit`,
-      "--stub",
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    {
-      const source = await readFile(`${outDir}/ts-check.d.ts`);
-      assert.ok(source.toString().includes("declare function _class(): void"));
-      assert.ok(source.toString().includes("export { _class as class }"));
-    }
-    {
-      const source = await readFile(`${outDir}/interfaces/ts-naming-blah.d.ts`);
-      assert.ok(source.toString().includes("declare function _class(): void"));
-      assert.ok(source.toString().includes("export { _class as class }"));
-    }
-  });
+        const name = 'async_call';
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/components/${name}.component.wasm`,
+            `--name=${name}`,
+            '--valid-lifting-optimization',
+            '--tla-compat',
+            '--instantiation=async',
+            '--base64-cutoff=0',
+            '--async-mode=jspi',
+            '--async-imports=something:test/test-interface#call-async',
+            '--async-exports=run-async',
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        await writeFile(
+            `${outDir}/package.json`,
+            JSON.stringify({ type: 'module' })
+        );
+        const m = await import(`${pathToFileURL(outDir)}/${name}.js`);
+        const inst = await m.instantiate(undefined, {
+            'something:test/test-interface': {
+                callAsync: async () => 'called async',
+                callSync: () => 'called sync',
+            },
+        });
+        assert.strictEqual(inst.runSync instanceof AsyncFunction, false);
+        assert.strictEqual(inst.runAsync instanceof AsyncFunction, true);
 
-  test("Transpile to JS", async () => {
-    const name = "flavorful";
-    const { stderr } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/components/${name}.component.wasm`,
-      "--name",
-      name,
-      "--map",
-      "test:flavorful/test=./flavorful.js",
-      "--valid-lifting-optimization",
-      "--tla-compat",
-      "--js",
-      "--base64-cutoff=0",
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(`${outDir}/${name}.js`, "utf8");
-    assert.ok(source.includes("./flavorful.js"));
-    assert.ok(source.includes("FUNCTION_TABLE"));
-    assert.ok(source.includes("export {\n  $init"));
-  });
+        assert.strictEqual(inst.runSync(), 'called sync');
+        assert.strictEqual(await inst.runAsync(), 'called async');
+    });
 
-  test("Transpile without namespaced exports", async () => {
-    const name = "flavorful";
-    const { stderr } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/components/${name}.component.wasm`,
-      "--no-namespaced-exports",
-      "--no-wasi-shim",
-      "--name",
-      name,
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(`${outDir}/${name}.js`);
-    const finalLine = source.toString().split("\n").at(-1);
-    //Check final line is the export statement
-    assert.ok(finalLine.toString().includes("export {"));
-    //Check that it does not contain the namespaced export
-    assert.ok(!finalLine.toString().includes("test:flavorful/test"));
-  });
+    test('Transpile & Optimize & Minify', async () => {
+        const name = 'flavorful';
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/components/${name}.component.wasm`,
+            '--name',
+            name,
+            '--valid-lifting-optimization',
+            '--tla-compat',
+            '--optimize',
+            '--minify',
+            '--base64-cutoff=0',
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(`${outDir}/${name}.js`);
+        assert.ok(source.toString().includes('as test,'));
+    });
 
-  test("Transpile with namespaced exports", async () => {
-    const name = "flavorful";
-    const { stderr } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/components/${name}.component.wasm`,
-      "--no-wasi-shim",
-      "--name",
-      name,
-      "-o",
-      outDir
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(`${outDir}/${name}.js`);
-    const finalLine = source.toString().split("\n").at(-1);
-    //Check final line is the export statement
-    assert.ok(finalLine.toString().includes("export {"));
-    //Check that it does contain the namespaced export
-    assert.ok(finalLine.toString().includes("test as 'test:flavorful/test'"));
-  });
+    test('Transpile with tracing', async () => {
+        const name = 'flavorful';
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/components/${name}.component.wasm`,
+            '--name',
+            name,
+            '--map',
+            'testwasi=./wasi.js',
+            '--tracing',
+            '--base64-cutoff=0',
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(`${outDir}/${name}.js`, 'utf8');
+        assert.ok(source.includes('function toResultString('));
+        assert.ok(
+            source.includes(
+                'console.error(`[module="test:flavorful/test", function="f-list-in-record1"] call a'
+            )
+        );
+        assert.ok(
+            source.includes(
+                'console.error(`[module="test:flavorful/test", function="list-of-variants"] return result=${toResultString(ret)}`);'
+            )
+        );
+    });
 
-  test("Optimize", async () => {
-    const wasmPath = fileURLToPath(
-      new URL(`./fixtures/components/flavorful.component.wasm`, import.meta.url)
-    );
-    const component = await readComponentBytes(wasmPath);
-    const { stderr, stdout } = await exec(
-      jcoPath,
-      "opt",
-      wasmPath,
-      "-o",
-      outFile
-    );
-    assert.strictEqual(stderr, "");
-    assert.ok(stdout.includes("Core Module 1:"));
-    const optimizedComponent = await readFile(outFile);
-    assert.ok(optimizedComponent.byteLength < component.byteLength);
-  });
+    test('Type generation', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'types',
+            'test/fixtures/wit',
+            '--world-name',
+            'test:flavorful/flavorful',
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(`${outDir}/flavorful.d.ts`, 'utf8');
+        assert.ok(
+            source.includes(
+                "export * as test from './interfaces/test-flavorful-test.js';"
+            )
+        ); // exported interface
+        const iface = await readFile(
+            `${outDir}/interfaces/test-flavorful-test.d.ts`,
+            'utf8'
+        );
+        assert.ok(!iface.includes("declare module 'test:flavorful/test' {")); // should *not* be an ambient module (guest types)
+        assert.ok(iface.includes('export function listOfVariants(')); // function
+        assert.ok(iface.includes('export type MyErrno =')); // enum
+        assert.ok(iface.includes('export type ListInAlias =')); // type alias
+    });
 
-  test("Optimize nested component", async () => {
-    const component = await readFile(
-      `test/fixtures/components/simple-nested.component.wasm`
-    );
-    const { stderr, stdout } = await exec(
-      jcoPath,
-      "opt",
-      `test/fixtures/components/simple-nested.component.wasm`,
-      "-o",
-      outFile
-    );
-    assert.strictEqual(stderr, "");
-    assert.ok(stdout.includes("Core Module 1:"));
-    const optimizedComponent = await readFile(outFile);
-    assert.ok(optimizedComponent.byteLength < component.byteLength);
-  });
+    test('Type generation (specific features)', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'types',
+            'test/fixtures/wits/feature-gates-unstable.wit',
+            '--world-name',
+            'test:feature-gates-unstable/gated',
+            '--feature',
+            'enable-c',
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(
+            `${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`,
+            'utf8'
+        );
+        assert.ok(source.includes('export function a(): void;'));
+        assert.ok(!source.includes('export function b(): void;'));
+        assert.ok(source.includes('export function c(): void;'));
+    });
 
-  test("Optimize component with Asyncify pass", async () => {
-    const component = await readFile(
-      `test/fixtures/components/simple-nested-optimized.component.wasm`
-    );
-    const { stderr, stdout } = await exec(
-      jcoPath,
-      "opt",
-      `test/fixtures/components/simple-nested-optimized.component.wasm`,
-      "--asyncify",
-      "-o",
-      outFile
-    );
-    assert.strictEqual(stderr, "");
-    assert.ok(stdout.includes("Core Module 1:"));
-    const asyncifiedComponent = await readFile(outFile);
-    assert.ok(asyncifiedComponent.byteLength > component.byteLength); // should be larger
-  });
+    test('Type generation (all features)', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'types',
+            'test/fixtures/wits/feature-gates-unstable.wit',
+            '--world-name',
+            'test:feature-gates-unstable/gated',
+            '--all-features',
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(
+            `${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`,
+            'utf8'
+        );
+        assert.ok(source.includes('export function a(): void;'));
+        assert.ok(source.includes('export function b(): void;'));
+        assert.ok(source.includes('export function c(): void;'));
+    });
 
-  test("Print & Parse", async () => {
-    const { stderr, stdout } = await exec(
-      jcoPath,
-      "print",
-      `test/fixtures/components/flavorful.component.wasm`
-    );
-    assert.strictEqual(stderr, "");
-    assert.strictEqual(stdout.slice(0, 10), "(component");
-    {
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "print",
-        `test/fixtures/components/flavorful.component.wasm`,
-        "-o",
-        outFile
-      );
-      assert.strictEqual(stderr, "");
-      assert.strictEqual(stdout, "");
-    }
-    {
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "parse",
-        outFile,
-        "-o",
-        outFile
-      );
-      assert.strictEqual(stderr, "");
-      assert.strictEqual(stdout, "");
-      assert.ok(await readFile(outFile));
-    }
-  });
+    // NOTE: enabling all features and a specific feature means --all-features takes precedence
+    test('Type generation (all features + feature)', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'types',
+            'test/fixtures/wits/feature-gates-unstable.wit',
+            '--world-name',
+            'test:feature-gates-unstable/gated',
+            '--all-features',
+            '--feature',
+            'enable-c',
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(
+            `${outDir}/interfaces/test-feature-gates-unstable-foo.d.ts`,
+            'utf8'
+        );
+        assert.ok(source.includes('export function a(): void;'));
+        assert.ok(source.includes('export function b(): void;'));
+        assert.ok(source.includes('export function c(): void;'));
+    });
 
-  test("Wit shadowing stub test", async () => {
-    const { stderr, stdout } = await exec(
-      jcoPath,
-      "transpile",
-      `test/fixtures/wit/deps/app/app.wit`,
-      "-o",
-      outDir,
-      "--stub"
-    );
-    assert.strictEqual(stderr, "");
-    const source = await readFile(`${outDir}/app.js`);
-    assert.ok(source.includes("class PString$1{"));
-  });
+    test('Type generation (declare imports)', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'guest-types',
+            'test/fixtures/wit',
+            '--world-name',
+            'test:flavorful/flavorful',
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(
+            `${outDir}/interfaces/test-flavorful-test.d.ts`,
+            'utf8'
+        );
+        // NOTE: generation of guest types *no longer* produces an explicitly exported module
+        // but rather contains an typescript ambient module (w/ opt-in for producing explicit
+        // module declarations if necessary)
+        //
+        // see: https://github.com/bytecodealliance/jco/pull/528
+        assert.ok(source.includes("declare module 'test:flavorful/test' {"));
+    });
 
-  test("Wit & New", async () => {
-    const { stderr, stdout } = await exec(
-      jcoPath,
-      "wit",
-      `test/fixtures/components/flavorful.component.wasm`
-    );
-    assert.strictEqual(stderr, "");
-    assert.ok(stdout.includes("world root {"));
+    test('TypeScript naming checks', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/wit/deps/ts-check/ts-check.wit`,
+            '--stub',
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        {
+            const source = await readFile(`${outDir}/ts-check.d.ts`);
+            assert.ok(
+                source.toString().includes('declare function _class(): void')
+            );
+            assert.ok(source.toString().includes('export { _class as class }'));
+        }
+        {
+            const source = await readFile(
+                `${outDir}/interfaces/ts-naming-blah.d.ts`
+            );
+            assert.ok(
+                source.toString().includes('declare function _class(): void')
+            );
+            assert.ok(source.toString().includes('export { _class as class }'));
+        }
+    });
 
-    {
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "embed",
-        "--dummy",
-        "--wit",
-        "test/fixtures/wit/deps/flavorful/flavorful.wit",
-        "-m",
-        "language=javascript",
-        "-m",
-        "processed-by=dummy-gen@test",
-        "-o",
-        outFile
-      );
-      assert.strictEqual(stderr, "");
-      assert.strictEqual(stdout, "");
-    }
+    test('Transpile to JS', async () => {
+        const name = 'flavorful';
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/components/${name}.component.wasm`,
+            '--name',
+            name,
+            '--map',
+            'test:flavorful/test=./flavorful.js',
+            '--valid-lifting-optimization',
+            '--tla-compat',
+            '--js',
+            '--base64-cutoff=0',
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(`${outDir}/${name}.js`, 'utf8');
+        assert.ok(source.includes('./flavorful.js'));
+        assert.ok(source.includes('FUNCTION_TABLE'));
+        assert.ok(source.includes('export {\n  $init'));
+    });
 
-    {
-      const { stderr, stdout } = await exec(jcoPath, "print", outFile);
-      assert.strictEqual(stderr, "");
-      assert.strictEqual(stdout.slice(0, 7), "(module");
-    }
-    {
-      const { stderr, stdout } = await exec(
-        jcoPath,
-        "new",
-        outFile,
-        "-o",
-        outFile
-      );
-      assert.strictEqual(stderr, "");
-      assert.strictEqual(stdout, "");
-    }
-    {
-      const { stderr, stdout } = await exec(jcoPath, "print", outFile);
-      assert.strictEqual(stderr, "");
-      assert.strictEqual(stdout.slice(0, 10), "(component");
-    }
-    {
-      const { stdout, stderr } = await exec(
-        jcoPath,
-        "metadata-show",
-        outFile,
-        "--json"
-      );
-      assert.strictEqual(stderr, "");
-      const meta = JSON.parse(stdout);
-      // NOTE: the check below is depends on *how many* modules *and* components are
-      // generated by wit-component (as used by the wasm-tools rust dep in this project)
-      // and componentize-js.
-      //
-      // As such, this is subject to optimizations or changes in operation of
-      // upstream functionality and may change with upstream releases -- for example
-      // the addition of a "glue" or redirection-heavy module/component
-      assert.deepStrictEqual(meta[0].metaType, { tag: "component", val: 5 });
-      assert.deepStrictEqual(meta[1].producers, [
-        [
-          "processed-by",
-          [
-            ["wit-component", await getCurrentWitComponentVersion()],
-            ["dummy-gen", "test"],
-          ],
-        ],
-        ["language", [["javascript", ""]]],
-      ]);
-    }
-  });
+    test('Transpile without namespaced exports', async () => {
+        const name = 'flavorful';
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/components/${name}.component.wasm`,
+            '--no-namespaced-exports',
+            '--no-wasi-shim',
+            '--name',
+            name,
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(`${outDir}/${name}.js`);
+        const finalLine = source.toString().split('\n').at(-1);
+        //Check final line is the export statement
+        assert.ok(finalLine.toString().includes('export {'));
+        //Check that it does not contain the namespaced export
+        assert.ok(!finalLine.toString().includes('test:flavorful/test'));
+    });
 
-  test("Component new adapt", async () => {
-    const { stderr } = await exec(
-      jcoPath,
-      "new",
-      "test/fixtures/modules/exitcode.wasm",
-      "--wasi-reactor",
-      "-o",
-      outFile
-    );
-    assert.strictEqual(stderr, "");
-    {
-      const { stderr, stdout } = await exec(jcoPath, "print", outFile);
-      assert.strictEqual(stderr, "");
-      assert.strictEqual(stdout.slice(0, 10), "(component");
-    }
-  });
+    test('Transpile with namespaced exports', async () => {
+        const name = 'flavorful';
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/components/${name}.component.wasm`,
+            '--no-wasi-shim',
+            '--name',
+            name,
+            '-o',
+            outDir
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(`${outDir}/${name}.js`);
+        const finalLine = source.toString().split('\n').at(-1);
+        //Check final line is the export statement
+        assert.ok(finalLine.toString().includes('export {'));
+        //Check that it does contain the namespaced export
+        assert.ok(
+            finalLine.toString().includes("test as 'test:flavorful/test'")
+        );
+    });
 
-  test("Extract metadata", async () => {
-    const { stdout, stderr } = await exec(
-      jcoPath,
-      "metadata-show",
-      "test/fixtures/modules/exitcode.wasm",
-      "--json"
-    );
-    assert.strictEqual(stderr, "");
-    assert.deepStrictEqual(JSON.parse(stdout), [
-      {
-        metaType: { tag: "module" },
-        producers: [],
-        range: [0, 262],
-      },
-    ]);
-  });
+    test('Optimize', async () => {
+        const wasmPath = fileURLToPath(
+            new URL(
+                `./fixtures/components/flavorful.component.wasm`,
+                import.meta.url
+            )
+        );
+        const component = await readComponentBytes(wasmPath);
+        const { stderr, stdout } = await exec(
+            jcoPath,
+            'opt',
+            wasmPath,
+            '-o',
+            outFile
+        );
+        assert.strictEqual(stderr, '');
+        assert.ok(stdout.includes('Core Module 1:'));
+        const optimizedComponent = await readFile(outFile);
+        assert.ok(optimizedComponent.byteLength < component.byteLength);
+    });
 
-  test("Componentize", async () => {
-    const { stdout, stderr } = await exec(
-      jcoPath,
-      "componentize",
-      "test/fixtures/componentize/source.js",
-      "-d",
-      "all",
-      "--aot",
-      "-w",
-      "test/fixtures/componentize/source.wit",
-      "-o",
-      outFile
-    );
-    assert.strictEqual(stderr, "");
-    {
-      const { stderr } = await exec(
-        jcoPath,
-        "transpile",
-        outFile,
-        "--name",
-        "componentize",
-        "--map",
-        "local:test/foo=./foo.js",
-        "-o",
-        outDir
-      );
-      assert.strictEqual(stderr, "");
-    }
-    await writeFile(
-      `${outDir}/package.json`,
-      JSON.stringify({ type: "module" })
-    );
-    await writeFile(`${outDir}/foo.js`, `export class Bar {}`);
-    const m = await import(`${pathToFileURL(outDir)}/componentize.js`);
-    assert.strictEqual(m.hello(), "world");
-    // assert.strictEqual(m.consumeBar(m.createBar()), 'bar1');
-  });
+    test('Optimize nested component', async () => {
+        const component = await readFile(
+            `test/fixtures/components/simple-nested.component.wasm`
+        );
+        const { stderr, stdout } = await exec(
+            jcoPath,
+            'opt',
+            `test/fixtures/components/simple-nested.component.wasm`,
+            '-o',
+            outFile
+        );
+        assert.strictEqual(stderr, '');
+        assert.ok(stdout.includes('Core Module 1:'));
+        const optimizedComponent = await readFile(outFile);
+        assert.ok(optimizedComponent.byteLength < component.byteLength);
+    });
+
+    test('Optimize component with Asyncify pass', async () => {
+        const component = await readFile(
+            `test/fixtures/components/simple-nested-optimized.component.wasm`
+        );
+        const { stderr, stdout } = await exec(
+            jcoPath,
+            'opt',
+            `test/fixtures/components/simple-nested-optimized.component.wasm`,
+            '--asyncify',
+            '-o',
+            outFile
+        );
+        assert.strictEqual(stderr, '');
+        assert.ok(stdout.includes('Core Module 1:'));
+        const asyncifiedComponent = await readFile(outFile);
+        assert.ok(asyncifiedComponent.byteLength > component.byteLength); // should be larger
+    });
+
+    test('Print & Parse', async () => {
+        const { stderr, stdout } = await exec(
+            jcoPath,
+            'print',
+            `test/fixtures/components/flavorful.component.wasm`
+        );
+        assert.strictEqual(stderr, '');
+        assert.strictEqual(stdout.slice(0, 10), '(component');
+        {
+            const { stderr, stdout } = await exec(
+                jcoPath,
+                'print',
+                `test/fixtures/components/flavorful.component.wasm`,
+                '-o',
+                outFile
+            );
+            assert.strictEqual(stderr, '');
+            assert.strictEqual(stdout, '');
+        }
+        {
+            const { stderr, stdout } = await exec(
+                jcoPath,
+                'parse',
+                outFile,
+                '-o',
+                outFile
+            );
+            assert.strictEqual(stderr, '');
+            assert.strictEqual(stdout, '');
+            assert.ok(await readFile(outFile));
+        }
+    });
+
+    test('Wit shadowing stub test', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'transpile',
+            `test/fixtures/wit/deps/app/app.wit`,
+            '-o',
+            outDir,
+            '--stub'
+        );
+        assert.strictEqual(stderr, '');
+        const source = await readFile(`${outDir}/app.js`);
+        assert.ok(source.includes('class PString$1{'));
+    });
+
+    test('Wit & New', async () => {
+        const { stderr, stdout } = await exec(
+            jcoPath,
+            'wit',
+            `test/fixtures/components/flavorful.component.wasm`
+        );
+        assert.strictEqual(stderr, '');
+        assert.ok(stdout.includes('world root {'));
+
+        {
+            const { stderr, stdout } = await exec(
+                jcoPath,
+                'embed',
+                '--dummy',
+                '--wit',
+                'test/fixtures/wit/deps/flavorful/flavorful.wit',
+                '-m',
+                'language=javascript',
+                '-m',
+                'processed-by=dummy-gen@test',
+                '-o',
+                outFile
+            );
+            assert.strictEqual(stderr, '');
+            assert.strictEqual(stdout, '');
+        }
+
+        {
+            const { stderr, stdout } = await exec(jcoPath, 'print', outFile);
+            assert.strictEqual(stderr, '');
+            assert.strictEqual(stdout.slice(0, 7), '(module');
+        }
+        {
+            const { stderr, stdout } = await exec(
+                jcoPath,
+                'new',
+                outFile,
+                '-o',
+                outFile
+            );
+            assert.strictEqual(stderr, '');
+            assert.strictEqual(stdout, '');
+        }
+        {
+            const { stderr, stdout } = await exec(jcoPath, 'print', outFile);
+            assert.strictEqual(stderr, '');
+            assert.strictEqual(stdout.slice(0, 10), '(component');
+        }
+        {
+            const { stdout, stderr } = await exec(
+                jcoPath,
+                'metadata-show',
+                outFile,
+                '--json'
+            );
+            assert.strictEqual(stderr, '');
+            const meta = JSON.parse(stdout);
+            // NOTE: the check below is depends on *how many* modules *and* components are
+            // generated by wit-component (as used by the wasm-tools rust dep in this project)
+            // and componentize-js.
+            //
+            // As such, this is subject to optimizations or changes in operation of
+            // upstream functionality and may change with upstream releases -- for example
+            // the addition of a "glue" or redirection-heavy module/component
+            assert.deepStrictEqual(meta[0].metaType, {
+                tag: 'component',
+                val: 5,
+            });
+            assert.deepStrictEqual(meta[1].producers, [
+                [
+                    'processed-by',
+                    [
+                        [
+                            'wit-component',
+                            await getCurrentWitComponentVersion(),
+                        ],
+                        ['dummy-gen', 'test'],
+                    ],
+                ],
+                ['language', [['javascript', '']]],
+            ]);
+        }
+    });
+
+    test('Component new adapt', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'new',
+            'test/fixtures/modules/exitcode.wasm',
+            '--wasi-reactor',
+            '-o',
+            outFile
+        );
+        assert.strictEqual(stderr, '');
+        {
+            const { stderr, stdout } = await exec(jcoPath, 'print', outFile);
+            assert.strictEqual(stderr, '');
+            assert.strictEqual(stdout.slice(0, 10), '(component');
+        }
+    });
+
+    test('Extract metadata', async () => {
+        const { stdout, stderr } = await exec(
+            jcoPath,
+            'metadata-show',
+            'test/fixtures/modules/exitcode.wasm',
+            '--json'
+        );
+        assert.strictEqual(stderr, '');
+        assert.deepStrictEqual(JSON.parse(stdout), [
+            {
+                metaType: { tag: 'module' },
+                producers: [],
+                range: [0, 262],
+            },
+        ]);
+    });
+
+    test('Componentize', async () => {
+        const { stderr } = await exec(
+            jcoPath,
+            'componentize',
+            'test/fixtures/componentize/source.js',
+            '-d',
+            'all',
+            '--aot',
+            '-w',
+            'test/fixtures/componentize/source.wit',
+            '-o',
+            outFile
+        );
+        assert.strictEqual(stderr, '');
+        {
+            const { stderr } = await exec(
+                jcoPath,
+                'transpile',
+                outFile,
+                '--name',
+                'componentize',
+                '--map',
+                'local:test/foo=./foo.js',
+                '-o',
+                outDir
+            );
+            assert.strictEqual(stderr, '');
+        }
+        await writeFile(
+            `${outDir}/package.json`,
+            JSON.stringify({ type: 'module' })
+        );
+        await writeFile(`${outDir}/foo.js`, `export class Bar {}`);
+        const m = await import(`${pathToFileURL(outDir)}/componentize.js`);
+        assert.strictEqual(m.hello(), 'world');
+        // assert.strictEqual(m.consumeBar(m.createBar()), 'bar1');
+    });
 });
 
 // Cache of componentize byte outputs
@@ -694,21 +715,21 @@ const CACHE_COMPONENTIZE_OUTPUT = {};
  * @param {string} outputPath - path to where to write the component
  * @param {string[]} args - arguments to be fed to `jco componentize` (*without* "compnentize" or "-o/--output")
  */
-async function cachedComponentize(outputPath, args) {
-  const cacheKey = args.join("+");
-  if (cacheKey in CACHE_COMPONENTIZE_OUTPUT) {
-    await writeFile(outputPath, CACHE_COMPONENTIZE_OUTPUT[cacheKey]);
-    return;
-  }
+export async function cachedComponentize(outputPath, args) {
+    const cacheKey = args.join('+');
+    if (cacheKey in CACHE_COMPONENTIZE_OUTPUT) {
+        await writeFile(outputPath, CACHE_COMPONENTIZE_OUTPUT[cacheKey]);
+        return;
+    }
 
-  const { stdout, stderr } = await exec(
-    jcoPath,
-    "componentize",
-    ...args,
-    "-o",
-    outputPath
-  );
-  assert.strictEqual(stderr, "");
+    const { stderr } = await exec(
+        jcoPath,
+        'componentize',
+        ...args,
+        '-o',
+        outputPath
+    );
+    assert.strictEqual(stderr, '');
 
-  CACHE_COMPONENTIZE_OUTPUT[cacheKey] = await readFile(outputPath);
+    CACHE_COMPONENTIZE_OUTPUT[cacheKey] = await readFile(outputPath);
 }

--- a/packages/jco/test/codegen.js
+++ b/packages/jco/test/codegen.js
@@ -1,248 +1,273 @@
-import { readFile, writeFile } from "node:fs/promises";
-import { createServer } from "node:http";
-import { resolve } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { readFile, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import {
-  componentNew,
-  componentEmbed,
-  transpile,
-  preview1AdapterCommandPath,
-} from "@bytecodealliance/jco";
-import { HTTPServer } from "@bytecodealliance/preview2-shim/http";
+    componentNew,
+    componentEmbed,
+    transpile,
+    preview1AdapterCommandPath,
+} from '@bytecodealliance/jco';
+import { HTTPServer } from '@bytecodealliance/preview2-shim/http';
 
-import { suite, test, assert, describe } from "vitest";
+import { suite, test, assert, describe } from 'vitest';
 
 import {
-  exec,
-  jcoPath,
-  readFixtureFlags,
-  getTmpDir,
-  getRandomPort,
-  readComponentBytes,
-} from "./helpers.js";
-import { tsGenerationPromise } from "./typescript.js";
-import { getDefaultComponentFixtures, ESLINT_PATH } from "./common.js";
+    exec,
+    jcoPath,
+    readFixtureFlags,
+    getTmpDir,
+    getRandomPort,
+    readComponentBytes,
+} from './helpers.js';
+import { tsGenerationPromise } from './typescript.js';
+import { getDefaultComponentFixtures, ESLINT_PATH } from './common.js';
 
 suite(`Transpiler codegen`, async () => {
-  // NOTE: the codegen tests *must* run first and generate outputs for other tests to use
-  describe("codegen", async () => {
-    const fixtures = await getDefaultComponentFixtures();
-    for (const fixture of fixtures) {
-      const testName = fixture.replace(/(\.component)?\.(wasm|wat)$/, "");
-      test.concurrent(`${testName} transpile & lint`, async () => {
-        const flags = await readFixtureFlags(
-          fileURLToPath(new URL(`./runtime/${testName}.ts`, import.meta.url))
-        );
-        var { stderr } = await exec(
-          jcoPath,
-          "transpile",
-          fileURLToPath(
-            new URL(`./fixtures/components/${fixture}`, import.meta.url)
-          ),
-          "--name",
-          testName,
-          ...flags,
-          "-o",
-          fileURLToPath(new URL(`./output/${testName}`, import.meta.url))
-        );
-        assert.strictEqual(stderr, "");
+    // NOTE: the codegen tests *must* run first and generate outputs for other tests to use
+    describe('codegen', async () => {
+        const fixtures = await getDefaultComponentFixtures();
+        for (const fixture of fixtures) {
+            const testName = fixture.replace(/(\.component)?\.(wasm|wat)$/, '');
+            test.concurrent(`${testName} transpile & lint`, async () => {
+                const flags = await readFixtureFlags(
+                    fileURLToPath(
+                        new URL(`./runtime/${testName}.ts`, import.meta.url)
+                    )
+                );
+                var { stderr } = await exec(
+                    jcoPath,
+                    'transpile',
+                    fileURLToPath(
+                        new URL(
+                            `./fixtures/components/${fixture}`,
+                            import.meta.url
+                        )
+                    ),
+                    '--name',
+                    testName,
+                    ...flags,
+                    '-o',
+                    fileURLToPath(
+                        new URL(`./output/${testName}`, import.meta.url)
+                    )
+                );
+                assert.strictEqual(stderr, '');
 
-        if (flags.includes("--js")) return;
+                if (flags.includes('--js')) {
+                    return;
+                }
 
-        const eslintOutput = await exec(
-          ESLINT_PATH,
-          fileURLToPath(
-            new URL(`./output/${testName}/${testName}.js`, import.meta.url)
-          ),
-          "-c",
-          fileURLToPath(new URL(`./eslint.config.mjs`, import.meta.url))
-        );
-        assert.strictEqual(eslintOutput.stderr, "");
-      });
-    }
-  });
-
-  describe("preview2", async () => {
-    test("hello_stdout", async () => {
-      const component = await readComponentBytes(
-        fileURLToPath(
-          new URL("./fixtures/modules/hello_stdout.wasm", import.meta.url)
-        )
-      );
-      const generatedComponent = await componentNew(component, [
-        [
-          "wasi_snapshot_preview1",
-          await readComponentBytes(preview1AdapterCommandPath()),
-        ],
-      ]);
-
-      const outputPath = fileURLToPath(
-        new URL(
-          "./fixtures/modules/hello_stdout.component.wasm",
-          import.meta.url
-        )
-      );
-
-      await writeFile(outputPath, generatedComponent);
-
-      const { stdout, stderr } = await exec(jcoPath, "run", outputPath);
-      assert.strictEqual(stdout, "writing to stdout: hello, world\n");
-      assert.strictEqual(stderr, "writing to stderr: hello, world\n");
-    });
-
-    test("wasi-http-proxy", async () => {
-      const tmpDir = await getTmpDir();
-      const outFile = resolve(tmpDir, "out-component-file");
-
-      const port = await getRandomPort();
-      const server = createServer(async (req, res) => {
-        if (req.url == "/api/examples") {
-          res.writeHead(200, {
-            "Content-Type": "text/plain",
-            "X-Wasi": "mock-server",
-            Date: null,
-          });
-          if (req.method === "GET") {
-            res.write("hello world");
-          } else {
-            req.pipe(res);
-            return;
-          }
-        } else {
-          res.statusCode(500);
+                const eslintOutput = await exec(
+                    ESLINT_PATH,
+                    fileURLToPath(
+                        new URL(
+                            `./output/${testName}/${testName}.js`,
+                            import.meta.url
+                        )
+                    ),
+                    '-c',
+                    fileURLToPath(
+                        new URL(`./eslint.config.mjs`, import.meta.url)
+                    )
+                );
+                assert.strictEqual(eslintOutput.stderr, '');
+            });
         }
-        res.end();
-      }).listen(port); // transpile component expects this port
-
-      // Ignore errors from compilation (usually TS warnings)
-      await tsGenerationPromise();
-
-      const runtimeName = "wasi-http-proxy";
-      try {
-        const { stderr } = await exec(
-          jcoPath,
-          "componentize",
-          fileURLToPath(
-            new URL(
-              "./fixtures/componentize/wasi-http-proxy/source.js",
-              import.meta.url
-            )
-          ),
-          "-w",
-          fileURLToPath(new URL("./fixtures/wit", import.meta.url)),
-          "--world-name",
-          "test:jco/command-extended",
-          "-o",
-          outFile
-        );
-        assert.strictEqual(stderr, "");
-        const outDir = fileURLToPath(
-          new URL(`./output/${runtimeName}`, import.meta.url)
-        );
-        {
-          const { stderr } = await exec(
-            jcoPath,
-            "transpile",
-            outFile,
-            "--name",
-            runtimeName,
-            "-o",
-            outDir
-          );
-          assert.strictEqual(stderr, "");
-        }
-        await exec(`test/output/${runtimeName}.js`, `--test-port=${port}`);
-      } finally {
-        server.close();
-      }
-
-      try {
-        await rm(outFile);
-      } catch {}
     });
 
-    test.concurrent("incoming composed", async () => {
-      const tmpDir = await getTmpDir();
-      const outFile = resolve(tmpDir, "out-component-file");
+    describe('preview2', async () => {
+        test('hello_stdout', async () => {
+            const component = await readComponentBytes(
+                fileURLToPath(
+                    new URL(
+                        './fixtures/modules/hello_stdout.wasm',
+                        import.meta.url
+                    )
+                )
+            );
+            const generatedComponent = await componentNew(component, [
+                [
+                    'wasi_snapshot_preview1',
+                    await readComponentBytes(preview1AdapterCommandPath()),
+                ],
+            ]);
 
-      const outDir = fileURLToPath(
-        new URL(`./output/composed`, import.meta.url)
-      );
-      {
-        const { stderr } = await exec(
-          jcoPath,
-          "transpile",
-          fileURLToPath(
-            new URL("./fixtures/components/composed.wasm", import.meta.url)
-          ),
-          "-o",
-          outDir
-        );
-        assert.strictEqual(stderr, "");
-      }
+            const outputPath = fileURLToPath(
+                new URL(
+                    './fixtures/modules/hello_stdout.component.wasm',
+                    import.meta.url
+                )
+            );
 
-      const { incomingHandler } = await import(
-        `${pathToFileURL(outDir)}/composed.js`
-      );
-      const server = new HTTPServer(incomingHandler);
-      const port = await getRandomPort();
-      server.listen(port);
+            await writeFile(outputPath, generatedComponent);
 
-      const res = await (await fetch(`http://localhost:${port}`)).text();
-      assert.strictEqual(res, "Hello from Typescript!\n");
+            const { stdout, stderr } = await exec(jcoPath, 'run', outputPath);
+            assert.strictEqual(stdout, 'writing to stdout: hello, world\n');
+            assert.strictEqual(stderr, 'writing to stderr: hello, world\n');
+        });
 
-      server.stop();
+        test('wasi-http-proxy', async () => {
+            const tmpDir = await getTmpDir();
+            const outFile = resolve(tmpDir, 'out-component-file');
 
-      try {
-        await rm(outFile);
-      } catch {}
+            const port = await getRandomPort();
+            const server = createServer(async (req, res) => {
+                if (req.url == '/api/examples') {
+                    res.writeHead(200, {
+                        'Content-Type': 'text/plain',
+                        'X-Wasi': 'mock-server',
+                        Date: null,
+                    });
+                    if (req.method === 'GET') {
+                        res.write('hello world');
+                    } else {
+                        req.pipe(res);
+                        return;
+                    }
+                } else {
+                    res.statusCode(500);
+                }
+                res.end();
+            }).listen(port); // transpile component expects this port
+
+            // Ignore errors from compilation (usually TS warnings)
+            await tsGenerationPromise();
+
+            const runtimeName = 'wasi-http-proxy';
+            try {
+                const { stderr } = await exec(
+                    jcoPath,
+                    'componentize',
+                    fileURLToPath(
+                        new URL(
+                            './fixtures/componentize/wasi-http-proxy/source.js',
+                            import.meta.url
+                        )
+                    ),
+                    '-w',
+                    fileURLToPath(new URL('./fixtures/wit', import.meta.url)),
+                    '--world-name',
+                    'test:jco/command-extended',
+                    '-o',
+                    outFile
+                );
+                assert.strictEqual(stderr, '');
+                const outDir = fileURLToPath(
+                    new URL(`./output/${runtimeName}`, import.meta.url)
+                );
+                {
+                    const { stderr } = await exec(
+                        jcoPath,
+                        'transpile',
+                        outFile,
+                        '--name',
+                        runtimeName,
+                        '-o',
+                        outDir
+                    );
+                    assert.strictEqual(stderr, '');
+                }
+                await exec(
+                    `test/output/${runtimeName}.js`,
+                    `--test-port=${port}`
+                );
+            } finally {
+                server.close();
+            }
+
+            try {
+                await rm(outFile);
+            } catch {}
+        });
+
+        test.concurrent('incoming composed', async () => {
+            const tmpDir = await getTmpDir();
+            const outFile = resolve(tmpDir, 'out-component-file');
+
+            const outDir = fileURLToPath(
+                new URL(`./output/composed`, import.meta.url)
+            );
+            {
+                const { stderr } = await exec(
+                    jcoPath,
+                    'transpile',
+                    fileURLToPath(
+                        new URL(
+                            './fixtures/components/composed.wasm',
+                            import.meta.url
+                        )
+                    ),
+                    '-o',
+                    outDir
+                );
+                assert.strictEqual(stderr, '');
+            }
+
+            const { incomingHandler } = await import(
+                `${pathToFileURL(outDir)}/composed.js`
+            );
+            const server = new HTTPServer(incomingHandler);
+            const port = await getRandomPort();
+            server.listen(port);
+
+            const res = await (await fetch(`http://localhost:${port}`)).text();
+            assert.strictEqual(res, 'Hello from Typescript!\n');
+
+            server.stop();
+
+            try {
+                await rm(outFile);
+            } catch {}
+        });
+
+        // https://github.com/bytecodealliance/jco/issues/550
+        test.concurrent('pollable hang', async () => {
+            await exec(
+                jcoPath,
+                'run',
+                fileURLToPath(
+                    new URL(
+                        './../test/fixtures/components/stdout-pollable-hang.component.wasm',
+                        import.meta.url
+                    )
+                )
+            );
+        });
     });
-
-    // https://github.com/bytecodealliance/jco/issues/550
-    test.concurrent("pollable hang", async () => {
-      await exec(
-        jcoPath,
-        "run",
-        fileURLToPath(
-          new URL(
-            "./../test/fixtures/components/stdout-pollable-hang.component.wasm",
-            import.meta.url
-          )
-        )
-      );
-    });
-  });
 });
 
 suite(`Naming`, () => {
-  test(`Resource deduping`, async () => {
-    const component = await componentNew(
-      await componentEmbed({
-        witSource: await readFile(
-          fileURLToPath(
-            new URL(
-              `./fixtures/wits/resource-naming/resource-naming.wit`,
-              import.meta.url
-            )
-          ),
-          "utf8"
-        ),
-        dummy: true,
-        metadata: [
-          ["language", [["javascript", ""]]],
-          ["processed-by", [["dummy-gen", "test"]]],
-        ],
-      })
-    );
+    test(`Resource deduping`, async () => {
+        const component = await componentNew(
+            await componentEmbed({
+                witSource: await readFile(
+                    fileURLToPath(
+                        new URL(
+                            `./fixtures/wits/resource-naming/resource-naming.wit`,
+                            import.meta.url
+                        )
+                    ),
+                    'utf8'
+                ),
+                dummy: true,
+                metadata: [
+                    ['language', [['javascript', '']]],
+                    ['processed-by', [['dummy-gen', 'test']]],
+                ],
+            })
+        );
 
-    const { files } = await transpile(component, { name: "resource-naming" });
+        const { files } = await transpile(component, {
+            name: 'resource-naming',
+        });
 
-    const bindingsSource = new TextDecoder().decode(
-      files["resource-naming.js"]
-    );
+        const bindingsSource = new TextDecoder().decode(
+            files['resource-naming.js']
+        );
 
-    assert.isOk(bindingsSource.includes("class Thing$1{"));
-    assert.isOk(bindingsSource.includes("Thing: Thing$1"));
-  });
+        assert.isOk(bindingsSource.includes('class Thing$1{'));
+        assert.isOk(bindingsSource.includes('Thing: Thing$1'));
+    });
 });

--- a/packages/jco/test/commands.js
+++ b/packages/jco/test/commands.js
@@ -1,32 +1,34 @@
-import { readdir, readFile } from "node:fs/promises";
-import { resolve } from "node:path";
+import { readdir, readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 
-import { suite, test, assert } from "vitest";
+import { suite, test, assert } from 'vitest';
 
-import { exec, jcoPath } from "./helpers.js";
+import { exec, jcoPath } from './helpers.js';
 
 const DEBUG = false;
 
-suite("Commands", async () => {
-  const [tests, rawCommands] = await Promise.all([
-    readFile("test/fixtures/commands/tests.json", "utf8").then(JSON.parse),
-    readdir("test/fixtures/commands"),
-  ]);
-  const commands = rawCommands
-    .filter((f) => f !== "tests.json")
-    .map((f) => [f, f.replace(/\.(wat|wasm)$/, "")]);
+suite('Commands', async () => {
+    const [tests, rawCommands] = await Promise.all([
+        readFile('test/fixtures/commands/tests.json', 'utf8').then(JSON.parse),
+        readdir('test/fixtures/commands'),
+    ]);
+    const commands = rawCommands
+        .filter((f) => f !== 'tests.json')
+        .map((f) => [f, f.replace(/\.(wat|wasm)$/, '')]);
 
-  for (const [fixture, runName] of commands) {
-    test.concurrent(runName, async () => {
-      const { stdout, stderr } = await exec(
-        jcoPath,
-        "run",
-        ...(DEBUG ? ["--jco-dir", `test/output/commands/${fixture}`] : []),
-        resolve("test/fixtures/commands", fixture),
-        ...(tests[runName]?.args || [])
-      );
-      assert.strictEqual(stderr, tests[runName]?.stderr || "");
-      assert.strictEqual(stdout, tests[runName]?.stdout || "");
-    });
-  }
+    for (const [fixture, runName] of commands) {
+        test.concurrent(runName, async () => {
+            const { stdout, stderr } = await exec(
+                jcoPath,
+                'run',
+                ...(DEBUG
+                    ? ['--jco-dir', `test/output/commands/${fixture}`]
+                    : []),
+                resolve('test/fixtures/commands', fixture),
+                ...(tests[runName]?.args || [])
+            );
+            assert.strictEqual(stderr, tests[runName]?.stderr || '');
+            assert.strictEqual(stdout, tests[runName]?.stdout || '');
+        });
+    }
 });

--- a/packages/jco/test/common.js
+++ b/packages/jco/test/common.js
@@ -1,6 +1,6 @@
-import { env } from "node:process";
-import { readdir } from "node:fs/promises";
-import { fileURLToPath } from "node:url";
+import { env } from 'node:process';
+import { readdir } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 
 /**
  * Retrieve a list of all component fixtures
@@ -19,26 +19,28 @@ import { fileURLToPath } from "node:url";
  * as the flags of the code generation step.
  */
 export async function getDefaultComponentFixtures() {
-  return env.COMPONENT_FIXTURES
-    ? env.COMPONENT_FIXTURES.split(",")
-    : (await readdir("test/fixtures/components", { withFileTypes: true }))
-        .filter((f) => f.isFile() && f.name !== "dummy_reactor.component.wasm")
-        .map((f) => f.name);
+    return env.COMPONENT_FIXTURES
+        ? env.COMPONENT_FIXTURES.split(',')
+        : (await readdir('test/fixtures/components', { withFileTypes: true }))
+              .filter(
+                  (f) => f.isFile() && f.name !== 'dummy_reactor.component.wasm'
+              )
+              .map((f) => f.name);
 }
 
 /** Path to ESLint as installed by npm-compatible tooling */
 export const ESLINT_PATH = fileURLToPath(
-  new URL("../../../node_modules/eslint/bin/eslint.js", import.meta.url)
+    new URL('../../../node_modules/eslint/bin/eslint.js', import.meta.url)
 );
 
 export const AsyncFunction = (async () => {}).constructor;
 
 /** Path to `tsc` binary as installed by npm-compatible tooling */
 export const NODE_MODULES_TSC_BIN_PATH = fileURLToPath(
-  new URL("../../../node_modules/typescript/bin/tsc", import.meta.url)
+    new URL('../../../node_modules/typescript/bin/tsc', import.meta.url)
 );
 
 /** Path to Jco JS script */
 export const JCO_JS_PATH = fileURLToPath(
-  new URL("../src/jco.js", import.meta.url)
+    new URL('../src/jco.js', import.meta.url)
 );

--- a/packages/jco/test/fixtures/component-gen/import-fn.js
+++ b/packages/jco/test/fixtures/component-gen/import-fn.js
@@ -1,11 +1,9 @@
 import print from 'print';
 import importPoint from 'import-point';
 
-export function run () {
-  
-}
+export function run() {}
 
-export function movePoint (pnt) {
-  const mapPoint = importPoint(pnt);
-  print(`x: ${mapPoint.x}, y: ${mapPoint.y}`);
+export function movePoint(pnt) {
+    const mapPoint = importPoint(pnt);
+    print(`x: ${mapPoint.x}, y: ${mapPoint.y}`);
 }

--- a/packages/jco/test/fixtures/componentize/source.js
+++ b/packages/jco/test/fixtures/componentize/source.js
@@ -1,23 +1,23 @@
 class Bar {
-  constructor (name) {
-    this.name = name;
-  }
+    constructor(name) {
+        this.name = name;
+    }
 }
 
 export const foo = {
-  Bar
+    Bar,
 };
 
 let idx = 1;
 
-export function createBar () {
-  return new Bar('bar' + idx++);
+export function createBar() {
+    return new Bar('bar' + idx++);
 }
 
-export function consumeBar (bar) {
-  return bar.name;
+export function consumeBar(bar) {
+    return bar.name;
 }
 
-export function hello () {
-  return 'world';
+export function hello() {
+    return 'world';
 }

--- a/packages/jco/test/fixtures/componentize/wasi-http-proxy/source.js
+++ b/packages/jco/test/fixtures/componentize/wasi-http-proxy/source.js
@@ -1,108 +1,109 @@
-import { handle } from "wasi:http/outgoing-handler@0.2.3";
-import { Fields, OutgoingRequest, OutgoingBody } from "wasi:http/types@0.2.3";
-import { getArguments } from "wasi:cli/environment@0.2.3";
+import { handle } from 'wasi:http/outgoing-handler@0.2.3';
+import { Fields, OutgoingRequest, OutgoingBody } from 'wasi:http/types@0.2.3';
+import { getArguments } from 'wasi:cli/environment@0.2.3';
 
 const sendRequest = (method, scheme, authority, pathWithQuery, body) => {
-  try {
-    let incomingResponse;
-    {
-      let encoder = new TextEncoder();
-
-      const req = new OutgoingRequest(
-        new Fields([
-          ["User-agent", encoder.encode("WASI-HTTP/0.0.1")],
-          ["Content-type", encoder.encode("application/json")],
-        ])
-      );
-      req.setScheme(scheme);
-      req.setMethod(method);
-      req.setPathWithQuery(pathWithQuery);
-      req.setAuthority(authority);
-
-      if (body) {
-        const outgoingBody = req.body();
+    try {
+        let incomingResponse;
         {
-          const bodyStream = outgoingBody.write();
-          bodyStream.blockingWriteAndFlush(encoder.encode(body));
+            let encoder = new TextEncoder();
+
+            const req = new OutgoingRequest(
+                new Fields([
+                    ['User-agent', encoder.encode('WASI-HTTP/0.0.1')],
+                    ['Content-type', encoder.encode('application/json')],
+                ])
+            );
+            req.setScheme(scheme);
+            req.setMethod(method);
+            req.setPathWithQuery(pathWithQuery);
+            req.setAuthority(authority);
+
+            if (body) {
+                const outgoingBody = req.body();
+                {
+                    const bodyStream = outgoingBody.write();
+                    bodyStream.blockingWriteAndFlush(encoder.encode(body));
+                }
+                // TODO: we should explicitly drop the bodyStream here
+                //       when we have support for Symbol.dispose
+                OutgoingBody.finish(outgoingBody);
+            }
+
+            const futureIncomingResponse = handle(req);
+            futureIncomingResponse.subscribe().block();
+            incomingResponse = futureIncomingResponse.get().val.val;
         }
-        // TODO: we should explicitly drop the bodyStream here
-        //       when we have support for Symbol.dispose
-        OutgoingBody.finish(outgoingBody);
-      }
 
-      const futureIncomingResponse = handle(req);
-      futureIncomingResponse.subscribe().block();
-      incomingResponse = futureIncomingResponse.get().val.val;
+        const status = incomingResponse.status();
+        const responseHeaders = incomingResponse.headers().entries();
+
+        const decoder = new TextDecoder();
+        const headers = responseHeaders.map(([k, v]) => [k, decoder.decode(v)]);
+
+        let responseBody;
+        const incomingBody = incomingResponse.consume();
+        {
+            const bodyStream = incomingBody.stream();
+            bodyStream.subscribe().block();
+            const buf = bodyStream.read(50n);
+            responseBody =
+                buf.length > 0 ? new TextDecoder().decode(buf) : undefined;
+        }
+
+        return JSON.stringify({
+            status,
+            headers,
+            body: responseBody,
+        });
+    } catch (err) {
+        throw new Error(err);
     }
-
-    const status = incomingResponse.status();
-    const responseHeaders = incomingResponse.headers().entries();
-
-    const decoder = new TextDecoder();
-    const headers = responseHeaders.map(([k, v]) => [k, decoder.decode(v)]);
-
-    let responseBody;
-    const incomingBody = incomingResponse.consume();
-    {
-      const bodyStream = incomingBody.stream();
-      bodyStream.subscribe().block();
-      const buf = bodyStream.read(50n);
-      responseBody = buf.length > 0 ? new TextDecoder().decode(buf) : undefined;
-    }
-
-    return JSON.stringify({
-      status,
-      headers,
-      body: responseBody,
-    });
-  } catch (err) {
-    throw new Error(err);
-  }
 };
 
 export const commands = {
-  Error,
-  getExample: () => {
-    // Pull in a dynamic host port via the command line arguments
-    const port = parseInt(
-      getArguments()
-        .filter((s) => s.startsWith("--test-port="))
-        .map((s) => s.slice(12))[0]
-    );
-    return sendRequest(
-      {
-        tag: "get",
-      },
-      {
-        tag: "HTTP",
-      },
-      `localhost:${port}`,
-      "/api/examples"
-    );
-  },
-  postExample: () => {
-    // Pull in a dynamic host port via the command line arguments
-    const port = parseInt(
-      getArguments()
-        .filter((s) => s.startsWith("--test-port="))
-        .map((s) => s.slice(12))[0]
-    );
-    return sendRequest(
-      {
-        tag: "post",
-      },
-      {
-        tag: "HTTP",
-      },
-      `localhost:${port}`,
-      "/api/examples",
-      JSON.stringify({ key: "value" })
-    );
-  },
+    Error,
+    getExample: () => {
+        // Pull in a dynamic host port via the command line arguments
+        const port = parseInt(
+            getArguments()
+                .filter((s) => s.startsWith('--test-port='))
+                .map((s) => s.slice(12))[0]
+        );
+        return sendRequest(
+            {
+                tag: 'get',
+            },
+            {
+                tag: 'HTTP',
+            },
+            `localhost:${port}`,
+            '/api/examples'
+        );
+    },
+    postExample: () => {
+        // Pull in a dynamic host port via the command line arguments
+        const port = parseInt(
+            getArguments()
+                .filter((s) => s.startsWith('--test-port='))
+                .map((s) => s.slice(12))[0]
+        );
+        return sendRequest(
+            {
+                tag: 'post',
+            },
+            {
+                tag: 'HTTP',
+            },
+            `localhost:${port}`,
+            '/api/examples',
+            JSON.stringify({ key: 'value' })
+        );
+    },
 };
 
 export const incomingHandler = {
-  handle(_request, _response) {
-    throw new Error("not implemented");
-  },
+    handle(_request, _response) {
+        throw new Error('not implemented');
+    },
 };

--- a/packages/jco/test/fixtures/idl/console.test.js
+++ b/packages/jco/test/fixtures/idl/console.test.js
@@ -1,5 +1,5 @@
 import { log } from 'webidl:console/global-console@0.0.1';
 
 export function test() {
-  log(['HI']);
+    log(['HI']);
 }

--- a/packages/jco/test/fixtures/idl/dom.test.js
+++ b/packages/jco/test/fixtures/idl/dom.test.js
@@ -1,7 +1,7 @@
 import { getWindow } from 'webidl:dom/dom@0.0.1';
 
 export function test() {
-  const window = getWindow();
-  window.document().body().setInnerHtml('<h1>hello world</h1>');
-  window.console().log(["HI"]);
+    const window = getWindow();
+    window.document().body().setInnerHtml('<h1>hello world</h1>');
+    window.console().log(['HI']);
 }

--- a/packages/jco/test/runtime.js
+++ b/packages/jco/test/runtime.js
@@ -1,12 +1,12 @@
-import { stat } from "node:fs/promises";
-import { join } from "node:path";
-import { URL, fileURLToPath } from "node:url";
+import { stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { URL, fileURLToPath } from 'node:url';
 
-import { suite, test, assert } from "vitest";
+import { suite, test, assert } from 'vitest';
 
-import { getDefaultComponentFixtures } from "./common.js";
-import { jcoPath, exec, readFixtureFlags } from "./helpers.js";
-import { tsGenerationPromise } from "./typescript.js";
+import { getDefaultComponentFixtures } from './common.js';
+import { jcoPath, exec, readFixtureFlags } from './helpers.js';
+import { tsGenerationPromise } from './typescript.js';
 
 /**
  * To run the runtime tests specified below, transpilation must be performed
@@ -16,104 +16,108 @@ import { tsGenerationPromise } from "./typescript.js";
  * which tests run first.
  */
 const CODEGEN_TRANSPILE_DEPS = {
-  dummy_proxy: ["dummy_proxy/dummy_proxy.js"],
-  example_guest_export: ["example_guest_export/example_guest_export.js"],
-  example_guest_import: ["example_guest_import/example_guest_import.js"],
-  flavorful: ["flavorful/flavorful.js"],
-  "list-adapter-fusion": ["list-adapter-fusion/list-adapter-fusion.js"],
-  lists: ["lists/lists.js"],
-  "many-arguments": ["many-arguments/many-arguments.js"],
-  "multi-version": ["multi-version/multi-version.js"],
-  numbers: ["numbers/numbers.js"],
-  records: ["records/records.js"],
-  "strings.async+js": ["strings.async+js/strings.async+js.js"],
-  "strings.sync+js": ["strings.sync+js/strings.sync+js.js"],
-  "strings.sync": ["strings.sync/strings.sync.js"],
-  smoke: ["smoke/smoke.js"],
-  strings: ["strings/strings.js"],
-  variants: ["variants/variants.js", "helpers.js"],
-  resource_borrow_simple: ["resource_borrow_simple/resource_borrow_simple.js"],
+    dummy_proxy: ['dummy_proxy/dummy_proxy.js'],
+    example_guest_export: ['example_guest_export/example_guest_export.js'],
+    example_guest_import: ['example_guest_import/example_guest_import.js'],
+    flavorful: ['flavorful/flavorful.js'],
+    'list-adapter-fusion': ['list-adapter-fusion/list-adapter-fusion.js'],
+    lists: ['lists/lists.js'],
+    'many-arguments': ['many-arguments/many-arguments.js'],
+    'multi-version': ['multi-version/multi-version.js'],
+    numbers: ['numbers/numbers.js'],
+    records: ['records/records.js'],
+    'strings.async+js': ['strings.async+js/strings.async+js.js'],
+    'strings.sync+js': ['strings.sync+js/strings.sync+js.js'],
+    'strings.sync': ['strings.sync/strings.sync.js'],
+    smoke: ['smoke/smoke.js'],
+    strings: ['strings/strings.js'],
+    variants: ['variants/variants.js', 'helpers.js'],
+    resource_borrow_simple: [
+        'resource_borrow_simple/resource_borrow_simple.js',
+    ],
 };
 
-suite("Runtime", async () => {
-  await tsGenerationPromise();
+suite('Runtime', async () => {
+    await tsGenerationPromise();
 
-  const runtimeFolderPath = fileURLToPath(
-    new URL("./runtime", import.meta.url)
-  );
+    const runtimeFolderPath = fileURLToPath(
+        new URL('./runtime', import.meta.url)
+    );
 
-  // Pre-process the list of fixtures to get the runtime specific tests
-  const rawFixtures = await getDefaultComponentFixtures();
-  const runtimes = (
-    await Promise.all(
-      rawFixtures
-        .filter((f) => !f.startsWith("dummy_"))
-        .filter((f) => !f.startsWith("wasi-http-proxy"))
-        // Get the fixture, along with a runtime test name
-        .map((f) => [f, f.replace(/(\.component)?\.(wat|wasm)$/, "")])
-        .map(([f, r]) =>
-          stat(join(runtimeFolderPath, `${r}.ts`))
-            .then(() => [f, r])
-            .catch(() => null)
+    // Pre-process the list of fixtures to get the runtime specific tests
+    const rawFixtures = await getDefaultComponentFixtures();
+    const runtimes = (
+        await Promise.all(
+            rawFixtures
+                .filter((f) => !f.startsWith('dummy_'))
+                .filter((f) => !f.startsWith('wasi-http-proxy'))
+                // Get the fixture, along with a runtime test name
+                .map((f) => [f, f.replace(/(\.component)?\.(wat|wasm)$/, '')])
+                .map(([f, r]) =>
+                    stat(join(runtimeFolderPath, `${r}.ts`))
+                        .then(() => [f, r])
+                        .catch(() => null)
+                )
         )
-    )
-  ).filter((v) => v !== null);
+    ).filter((v) => v !== null);
 
-  // Create all runtime tests
-  const outputFolderPath = fileURLToPath(new URL("./output", import.meta.url));
-  const componentFixturesFolderPath = fileURLToPath(
-    new URL("./fixtures/components", import.meta.url)
-  );
-  for (const [fixtureName, testName] of runtimes) {
-    test.concurrent(testName, async () => {
-      // Perform transpilation on deps where necessary
+    // Create all runtime tests
+    const outputFolderPath = fileURLToPath(
+        new URL('./output', import.meta.url)
+    );
+    const componentFixturesFolderPath = fileURLToPath(
+        new URL('./fixtures/components', import.meta.url)
+    );
+    for (const [fixtureName, testName] of runtimes) {
+        test.concurrent(testName, async () => {
+            // Perform transpilation on deps where necessary
 
-      if (CODEGEN_TRANSPILE_DEPS[testName]) {
-        for (const filename of CODEGEN_TRANSPILE_DEPS[testName]) {
-          // Skip files that have already been generated
-          const requiredOutputPath = join(outputFolderPath, filename);
-          let exists;
-          try {
-            exists = (await stat(requiredOutputPath)).isFile();
-          } catch {
-            exists = false;
-          }
-          if (exists) {
-            continue;
-          }
+            if (CODEGEN_TRANSPILE_DEPS[testName]) {
+                for (const filename of CODEGEN_TRANSPILE_DEPS[testName]) {
+                    // Skip files that have already been generated
+                    const requiredOutputPath = join(outputFolderPath, filename);
+                    let exists;
+                    try {
+                        exists = (await stat(requiredOutputPath)).isFile();
+                    } catch {
+                        exists = false;
+                    }
+                    if (exists) {
+                        continue;
+                    }
 
-          const tsFileName = `${testName}.ts`;
+                    const tsFileName = `${testName}.ts`;
 
-          // Read flags
-          const runtimeTestPath = join(runtimeFolderPath, tsFileName);
-          const flags = await readFixtureFlags(runtimeTestPath);
+                    // Read flags
+                    const runtimeTestPath = join(runtimeFolderPath, tsFileName);
+                    const flags = await readFixtureFlags(runtimeTestPath);
 
-          // Perform transpilation
-          let componentFixturePath = join(
-            componentFixturesFolderPath,
-            fixtureName
-          );
-          const outputDirPath = join(outputFolderPath, testName);
-          const transpileOutput = await exec(
-            jcoPath,
-            "transpile",
-            componentFixturePath,
-            "--name",
-            testName,
-            ...flags,
-            "-o",
-            outputDirPath
-          );
+                    // Perform transpilation
+                    let componentFixturePath = join(
+                        componentFixturesFolderPath,
+                        fixtureName
+                    );
+                    const outputDirPath = join(outputFolderPath, testName);
+                    const transpileOutput = await exec(
+                        jcoPath,
+                        'transpile',
+                        componentFixturePath,
+                        '--name',
+                        testName,
+                        ...flags,
+                        '-o',
+                        outputDirPath
+                    );
 
-          assert.strictEqual(transpileOutput.stderr, "");
-          assert.ok((await stat(requiredOutputPath)).isFile());
-        }
-      }
+                    assert.strictEqual(transpileOutput.stderr, '');
+                    assert.ok((await stat(requiredOutputPath)).isFile());
+                }
+            }
 
-      // Run the post-TS compilation test file (now that deps have been resolved)
-      const testFilePath = join(outputFolderPath, `${testName}.js`);
-      const { stderr } = await exec(testFilePath);
-      assert.strictEqual(stderr, "");
-    });
-  }
+            // Run the post-TS compilation test file (now that deps have been resolved)
+            const testFilePath = join(outputFolderPath, `${testName}.js`);
+            const { stderr } = await exec(testFilePath);
+            assert.strictEqual(stderr, '');
+        });
+    }
 });

--- a/packages/jco/test/typescript.js
+++ b/packages/jco/test/typescript.js
@@ -1,84 +1,92 @@
-import { readFile } from "node:fs/promises";
+import { readFile } from 'node:fs/promises';
 
-import { fileURLToPath } from "url";
+import { fileURLToPath } from 'url';
 
-import { transpile, componentNew, componentEmbed } from "../src/api.js";
+import { transpile, componentNew, componentEmbed } from '../src/api.js';
 
-import { suite, test, beforeAll, assert } from "vitest";
+import { suite, test, beforeAll, assert } from 'vitest';
 
-import { exec } from "./helpers.js";
-import { NODE_MODULES_TSC_BIN_PATH } from "./common.js";
+import { exec } from './helpers.js';
+import { NODE_MODULES_TSC_BIN_PATH } from './common.js';
 
 let TS_GEN_PROMISE;
 export function tsGenerationPromise() {
-  if (TS_GEN_PROMISE) return TS_GEN_PROMISE;
-  return (TS_GEN_PROMISE = (async () => {
-    const tsConfigPath = fileURLToPath(
-      new URL("./tsconfig.json", import.meta.url)
-    );
-    var { stdout, stderr } = await exec(
-      NODE_MODULES_TSC_BIN_PATH,
-      "-p",
-      tsConfigPath
-    );
-    assert.strictEqual(stderr, "");
-  })());
+    if (TS_GEN_PROMISE) {
+        return TS_GEN_PROMISE;
+    }
+    return (TS_GEN_PROMISE = (async () => {
+        const tsConfigPath = fileURLToPath(
+            new URL('./tsconfig.json', import.meta.url)
+        );
+        var { stderr } = await exec(
+            NODE_MODULES_TSC_BIN_PATH,
+            '-p',
+            tsConfigPath
+        );
+        assert.strictEqual(stderr, '');
+    })());
 }
 
 suite(`TypeScript`, async () => {
-  beforeAll(async () => {
-    await tsGenerationPromise();
-  });
+    beforeAll(async () => {
+        await tsGenerationPromise();
+    });
 
-  test(`TS aliasing`, async () => {
-    const witSource = await readFile(
-      fileURLToPath(
-        new URL(`./fixtures/wits/issue-365/issue-365.wit`, import.meta.url)
-      ),
-      "utf8"
-    );
-    const component = await componentNew(
-      await componentEmbed({
-        witSource,
-        dummy: true,
-      })
-    );
+    test(`TS aliasing`, async () => {
+        const witSource = await readFile(
+            fileURLToPath(
+                new URL(
+                    `./fixtures/wits/issue-365/issue-365.wit`,
+                    import.meta.url
+                )
+            ),
+            'utf8'
+        );
+        const component = await componentNew(
+            await componentEmbed({
+                witSource,
+                dummy: true,
+            })
+        );
 
-    const { files } = await transpile(component, { name: "issue" });
+        const { files } = await transpile(component, { name: 'issue' });
 
-    const dtsSource = new TextDecoder().decode(files["issue.d.ts"]);
+        const dtsSource = new TextDecoder().decode(files['issue.d.ts']);
 
-    assert.ok(
-      dtsSource.includes(
-        `export type Bar = import('./interfaces/test-issue-types.js').Bar;`
-      )
-    );
-  });
+        assert.ok(
+            dtsSource.includes(
+                `export type Bar = import('./interfaces/test-issue-types.js').Bar;`
+            )
+        );
+    });
 
-  test(`TS types`, async () => {
-    const witSource = await readFile(
-      fileURLToPath(
-        new URL(`./fixtures/wits/issue-480/issue-480.wit`, import.meta.url)
-      ),
-      "utf8"
-    );
-    const component = await componentNew(
-      await componentEmbed({
-        witSource,
-        dummy: true,
-      })
-    );
+    test(`TS types`, async () => {
+        const witSource = await readFile(
+            fileURLToPath(
+                new URL(
+                    `./fixtures/wits/issue-480/issue-480.wit`,
+                    import.meta.url
+                )
+            ),
+            'utf8'
+        );
+        const component = await componentNew(
+            await componentEmbed({
+                witSource,
+                dummy: true,
+            })
+        );
 
-    const { files } = await transpile(component, { name: "issue" });
+        const { files } = await transpile(component, { name: 'issue' });
 
-    const dtsSource = new TextDecoder().decode(
-      files["interfaces/test-issue-types.d.ts"]
-    );
+        const dtsSource = new TextDecoder().decode(
+            files['interfaces/test-issue-types.d.ts']
+        );
 
-    assert.ok(
-      dtsSource.includes(
-        `export function foobarbaz(): Array<Value | undefined>;`
-      )
-    );
-  });
+        assert.ok(
+            dtsSource.includes(
+                `export function foobarbaz(): Array<Value | undefined>;`
+            )
+        );
+    });
 });

--- a/packages/jco/test/wit.js
+++ b/packages/jco/test/wit.js
@@ -1,407 +1,412 @@
-import { readFile, rm } from "node:fs/promises";
-import { resolve, join } from "node:path";
+import { readFile, rm } from 'node:fs/promises';
+import { resolve, join } from 'node:path';
 
-import { componentNew, componentEmbed, transpile, types } from "../src/api.js";
-import { getTmpDir } from "./helpers.js";
+import { componentNew, componentEmbed, transpile, types } from '../src/api.js';
+import { getTmpDir } from './helpers.js';
 
-import { suite, test, beforeAll, afterAll, afterEach, assert } from "vitest";
+import { suite, test, beforeAll, afterAll, afterEach, assert } from 'vitest';
 
-suite("WIT", () => {
-  var tmpDir;
-  var outFile;
+suite('WIT', () => {
+    var tmpDir;
+    var outFile;
 
-  // Content of test/fixtures/wits/feature-gates.wit
-  var featureGatesWitContent;
-  var featureGatesWitPath;
+    // Content of test/fixtures/wits/feature-gates.wit
+    var featureGatesWitContent;
+    var featureGatesWitPath;
 
-  var witFixturesPath;
+    var witFixturesPath;
 
-  beforeAll(async function () {
-    tmpDir = await getTmpDir();
-    outFile = resolve(tmpDir, "out-component-file");
-    featureGatesWitPath = resolve("test/fixtures/wits/feature-gates.wit");
-    featureGatesWitContent = await readFile(featureGatesWitPath, "utf8");
+    beforeAll(async function () {
+        tmpDir = await getTmpDir();
+        outFile = resolve(tmpDir, 'out-component-file');
+        featureGatesWitPath = resolve('test/fixtures/wits/feature-gates.wit');
+        featureGatesWitContent = await readFile(featureGatesWitPath, 'utf8');
 
-    witFixturesPath = resolve("test/fixtures/wits");
-  });
-
-  afterAll(async function () {
-    try {
-      await rm(tmpDir, { recursive: true });
-    } catch {}
-  });
-
-  afterEach(async function () {
-    try {
-      await rm(outFile);
-    } catch {}
-  });
-
-  // (transpile): features marked @unstable should *not* be present when no features are enabled
-  //
-  // NOTE: this works primarily the features are fed through to the `wit_parser::Resolve` that is used,
-  // not due to active filtering on the jco side.
-  test("Feature gates (no features)", async () => {
-    // Build a dummy WIT component
-    const generatedComponent = await componentEmbed({
-      witSource: featureGatesWitContent,
-      dummy: true,
-      metadata: [
-        ["language", [["javascript", ""]]],
-        ["processed-by", [["dummy-gen", "test"]]],
-      ],
+        witFixturesPath = resolve('test/fixtures/wits');
     });
-    const component = await componentNew(generatedComponent);
 
-    // Transpile the component
-    const { files, imports, exports } = await transpile(component);
-    assert.deepStrictEqual(imports, ["test:feature-gates/foo"]);
-    assert.deepStrictEqual(exports, [
-      ["foo", "instance"],
-      ["test:feature-gates/foo@0.2.1", "instance"],
-    ]);
-    assert.ok(files["component.js"], "component js was generated");
-    assert.ok(files["component.d.ts"], "component typings were generated");
-    assert.ok(
-      files["interfaces/test-feature-gates-foo.d.ts"],
-      "interface typings were generated"
-    );
-
-    // Check the interfaces file for the right exports
-    const interfaces = Buffer.from(
-      files["interfaces/test-feature-gates-foo.d.ts"]
-    ).toString("utf8");
-    assert.ok(
-      interfaces.includes("export function a(): void;"),
-      "unconstrained export foo/a is present"
-    );
-    assert.ok(
-      interfaces.includes("export function b(): void;"),
-      "@since(0.2.1) export foo/b is present (version matches)"
-    );
-    assert.ok(
-      interfaces.includes("export function c(): void;"),
-      "@since(0.2.1) export foo/c is present (feature is ignored)"
-    );
-    assert.ok(
-      !interfaces.includes("export function d(): void;"),
-      "@unstable(...) export is missing, without the feature specified"
-    );
-  });
-
-  // (transpile): features marked @unstable should *not* be present when an unrelated feature is enabled
-  //
-  // NOTE: this works primarily the features are fed through to the `wit_parser::Resolve` that is used,
-  // not due to active filtering on the jco side.
-  test("Feature gates (unrelated feature)", async () => {
-    // Build a dummy WIT component
-    const generatedComponent = await componentEmbed({
-      witSource: featureGatesWitContent,
-      dummy: true,
-      metadata: [
-        ["language", [["javascript", ""]]],
-        ["processed-by", [["dummy-gen", "test"]]],
-      ],
-      features: {
-        tag: "list",
-        val: ["some-feature"],
-      },
+    afterAll(async function () {
+        try {
+            await rm(tmpDir, { recursive: true });
+        } catch {}
     });
-    const component = await componentNew(generatedComponent);
 
-    // Transpile the component
-    const { files, imports, exports } = await transpile(component);
-    assert.deepStrictEqual(imports, ["test:feature-gates/foo"]);
-    assert.deepStrictEqual(exports, [
-      ["foo", "instance"],
-      ["test:feature-gates/foo@0.2.1", "instance"],
-    ]);
-    assert.ok(files["component.js"], "component js was generated");
-    assert.ok(files["component.d.ts"], "component typings were generated");
-    assert.ok(
-      files["interfaces/test-feature-gates-foo.d.ts"],
-      "interface typings were generated"
-    );
-
-    // Check the interfaces file for the right exports
-    const interfaces = Buffer.from(
-      files["interfaces/test-feature-gates-foo.d.ts"]
-    ).toString("utf8");
-    assert.ok(
-      interfaces.includes("export function a(): void;"),
-      "unconstrained export foo/a is present"
-    );
-    assert.ok(
-      interfaces.includes("export function b(): void;"),
-      "@since(0.2.1) export foo/b is present (version matches)"
-    );
-    assert.ok(
-      interfaces.includes("export function c(): void;"),
-      "@since(0.2.1) export foo/c is present (feature is ignored)"
-    );
-    assert.ok(
-      !interfaces.includes("export function d(): void;"),
-      "@unstable(...) export is missing, without the feature specified"
-    );
-  });
-
-  // (transpile): features marked @unstable shoudl be present in exports when only the specific feature is enabled
-  //
-  // NOTE: this works primarily the features are fed through to the `wit_parser::Resolve` that is used,
-  // not due to active filtering on the jco side.
-  test("Feature gates (single feature enabled)", async () => {
-    // Build a dummy WIT component
-    const generatedComponent = await componentEmbed({
-      witSource: featureGatesWitContent,
-      dummy: true,
-      metadata: [
-        ["language", [["javascript", ""]]],
-        ["processed-by", [["dummy-gen", "test"]]],
-      ],
-      features: {
-        tag: "list",
-        val: ["fancier-foo"],
-      },
+    afterEach(async function () {
+        try {
+            await rm(outFile);
+        } catch {}
     });
-    const component = await componentNew(generatedComponent);
 
-    // Transpile the component
-    const { files, imports, exports } = await transpile(component);
-    assert.deepStrictEqual(imports, ["test:feature-gates/foo"]);
-    assert.deepStrictEqual(exports, [
-      ["foo", "instance"],
-      ["test:feature-gates/foo@0.2.1", "instance"],
-    ]);
-    assert.ok(files["component.js"], "component js was generated");
-    assert.ok(files["component.d.ts"], "component typings were generated");
-    assert.ok(
-      files["interfaces/test-feature-gates-foo.d.ts"],
-      "interface typings were generated"
-    );
+    // (transpile): features marked @unstable should *not* be present when no features are enabled
+    //
+    // NOTE: this works primarily the features are fed through to the `wit_parser::Resolve` that is used,
+    // not due to active filtering on the jco side.
+    test('Feature gates (no features)', async () => {
+        // Build a dummy WIT component
+        const generatedComponent = await componentEmbed({
+            witSource: featureGatesWitContent,
+            dummy: true,
+            metadata: [
+                ['language', [['javascript', '']]],
+                ['processed-by', [['dummy-gen', 'test']]],
+            ],
+        });
+        const component = await componentNew(generatedComponent);
 
-    // Check the interfaces file for the right exports
-    const interfaces = Buffer.from(
-      files["interfaces/test-feature-gates-foo.d.ts"]
-    ).toString("utf8");
-    assert.ok(
-      interfaces.includes("export function a(): void;"),
-      "unconstrained export foo/a is present"
-    );
-    assert.ok(
-      interfaces.includes("export function b(): void;"),
-      "@since(0.2.1) export foo/b is present (version matches)"
-    );
-    assert.ok(
-      interfaces.includes("export function c(): void;"),
-      "@since(0.2.1) export foo/c is present (feature is ignored)"
-    );
-    assert.ok(
-      interfaces.includes("export function d(): void;"),
-      "@unstable(...) export is present, with all features enabled"
-    );
-  });
+        // Transpile the component
+        const { files, imports, exports } = await transpile(component);
+        assert.deepStrictEqual(imports, ['test:feature-gates/foo']);
+        assert.deepStrictEqual(exports, [
+            ['foo', 'instance'],
+            ['test:feature-gates/foo@0.2.1', 'instance'],
+        ]);
+        assert.ok(files['component.js'], 'component js was generated');
+        assert.ok(files['component.d.ts'], 'component typings were generated');
+        assert.ok(
+            files['interfaces/test-feature-gates-foo.d.ts'],
+            'interface typings were generated'
+        );
 
-  // (transpile): features marked @unstable shoudl be present in exports when all features are enabled
-  //
-  // NOTE: this works primarily the features are fed through to the `wit_parser::Resolve` that is used,
-  // not due to active filtering on the jco side.
-  test("Feature gates (all features enabled)", async () => {
-    // Build a dummy WIT component
-    const generatedComponent = await componentEmbed({
-      witSource: featureGatesWitContent,
-      dummy: true,
-      metadata: [
-        ["language", [["javascript", ""]]],
-        ["processed-by", [["dummy-gen", "test"]]],
-      ],
-      features: { tag: "all" },
+        // Check the interfaces file for the right exports
+        const interfaces = Buffer.from(
+            files['interfaces/test-feature-gates-foo.d.ts']
+        ).toString('utf8');
+        assert.ok(
+            interfaces.includes('export function a(): void;'),
+            'unconstrained export foo/a is present'
+        );
+        assert.ok(
+            interfaces.includes('export function b(): void;'),
+            '@since(0.2.1) export foo/b is present (version matches)'
+        );
+        assert.ok(
+            interfaces.includes('export function c(): void;'),
+            '@since(0.2.1) export foo/c is present (feature is ignored)'
+        );
+        assert.ok(
+            !interfaces.includes('export function d(): void;'),
+            '@unstable(...) export is missing, without the feature specified'
+        );
     });
-    const component = await componentNew(generatedComponent);
 
-    // Transpile the component
-    const { files, imports, exports } = await transpile(component);
-    assert.deepStrictEqual(imports, ["test:feature-gates/foo"]);
-    assert.deepStrictEqual(exports, [
-      ["foo", "instance"],
-      ["test:feature-gates/foo@0.2.1", "instance"],
-    ]);
-    assert.ok(files["component.js"], "component js was generated");
-    assert.ok(files["component.d.ts"], "component typings were generated");
-    assert.ok(
-      files["interfaces/test-feature-gates-foo.d.ts"],
-      "interface typings were generated"
-    );
+    // (transpile): features marked @unstable should *not* be present when an unrelated feature is enabled
+    //
+    // NOTE: this works primarily the features are fed through to the `wit_parser::Resolve` that is used,
+    // not due to active filtering on the jco side.
+    test('Feature gates (unrelated feature)', async () => {
+        // Build a dummy WIT component
+        const generatedComponent = await componentEmbed({
+            witSource: featureGatesWitContent,
+            dummy: true,
+            metadata: [
+                ['language', [['javascript', '']]],
+                ['processed-by', [['dummy-gen', 'test']]],
+            ],
+            features: {
+                tag: 'list',
+                val: ['some-feature'],
+            },
+        });
+        const component = await componentNew(generatedComponent);
 
-    // Check the interfaces file for the right exports
-    const interfaces = Buffer.from(
-      files["interfaces/test-feature-gates-foo.d.ts"]
-    ).toString("utf8");
-    assert.ok(
-      interfaces.includes("export function a(): void;"),
-      "unconstrained export foo/a is present"
-    );
-    assert.ok(
-      interfaces.includes("export function b(): void;"),
-      "@since(0.2.1) export foo/b is present (version matches)"
-    );
-    assert.ok(
-      interfaces.includes("export function c(): void;"),
-      "@since(0.2.1) export foo/c is present (feature is ignored)"
-    );
-    assert.ok(
-      interfaces.includes("export function d(): void;"),
-      "@unstable(...) export is present, with all features enabled"
-    );
-  });
+        // Transpile the component
+        const { files, imports, exports } = await transpile(component);
+        assert.deepStrictEqual(imports, ['test:feature-gates/foo']);
+        assert.deepStrictEqual(exports, [
+            ['foo', 'instance'],
+            ['test:feature-gates/foo@0.2.1', 'instance'],
+        ]);
+        assert.ok(files['component.js'], 'component js was generated');
+        assert.ok(files['component.d.ts'], 'component typings were generated');
+        assert.ok(
+            files['interfaces/test-feature-gates-foo.d.ts'],
+            'interface typings were generated'
+        );
 
-  // (`jco types`) features marked @unstable() are missing as imports *and* exports
-  test("Feature gates - (types, no features enabled)", async () => {
-    const files = await types(featureGatesWitPath, {
-      worldName: "import-and-export",
+        // Check the interfaces file for the right exports
+        const interfaces = Buffer.from(
+            files['interfaces/test-feature-gates-foo.d.ts']
+        ).toString('utf8');
+        assert.ok(
+            interfaces.includes('export function a(): void;'),
+            'unconstrained export foo/a is present'
+        );
+        assert.ok(
+            interfaces.includes('export function b(): void;'),
+            '@since(0.2.1) export foo/b is present (version matches)'
+        );
+        assert.ok(
+            interfaces.includes('export function c(): void;'),
+            '@since(0.2.1) export foo/c is present (feature is ignored)'
+        );
+        assert.ok(
+            !interfaces.includes('export function d(): void;'),
+            '@unstable(...) export is missing, without the feature specified'
+        );
     });
-    assert.ok(files["import-and-export.d.ts"], "component js was generated");
-    assert.ok(
-      files["interfaces/test-feature-gates-foo.d.ts"],
-      "interface typings were generated"
-    );
 
-    const imports = Buffer.from(files["import-and-export.d.ts"]).toString(
-      "utf8"
-    );
+    // (transpile): features marked @unstable shoudl be present in exports when only the specific feature is enabled
+    //
+    // NOTE: this works primarily the features are fed through to the `wit_parser::Resolve` that is used,
+    // not due to active filtering on the jco side.
+    test('Feature gates (single feature enabled)', async () => {
+        // Build a dummy WIT component
+        const generatedComponent = await componentEmbed({
+            witSource: featureGatesWitContent,
+            dummy: true,
+            metadata: [
+                ['language', [['javascript', '']]],
+                ['processed-by', [['dummy-gen', 'test']]],
+            ],
+            features: {
+                tag: 'list',
+                val: ['fancier-foo'],
+            },
+        });
+        const component = await componentNew(generatedComponent);
 
-    // Check the interfaces file for the right exports
-    const interfaces = Buffer.from(
-      files["interfaces/test-feature-gates-foo.d.ts"]
-    ).toString("utf8");
-    assert.ok(
-      interfaces.includes("export function a(): void;"),
-      "unconstrained export foo/a is present"
-    );
-    assert.ok(
-      interfaces.includes("export function b(): void;"),
-      "@since(0.2.1) export foo/b is present (version matches)"
-    );
-    assert.ok(
-      interfaces.includes("export function c(): void;"),
-      "@since(0.2.1) export foo/c is present (feature is ignored)"
-    );
-    assert.ok(
-      !interfaces.includes("export function d(): void;"),
-      "@unstable(...) export is missing (no features enabled)"
-    );
-  });
+        // Transpile the component
+        const { files, imports, exports } = await transpile(component);
+        assert.deepStrictEqual(imports, ['test:feature-gates/foo']);
+        assert.deepStrictEqual(exports, [
+            ['foo', 'instance'],
+            ['test:feature-gates/foo@0.2.1', 'instance'],
+        ]);
+        assert.ok(files['component.js'], 'component js was generated');
+        assert.ok(files['component.d.ts'], 'component typings were generated');
+        assert.ok(
+            files['interfaces/test-feature-gates-foo.d.ts'],
+            'interface typings were generated'
+        );
 
-  // (`jco types`) features marked @unstable(feature = f) should be present when the specific feature is enabled
-  test("Feature gates (types, single feature enabled)", async () => {
-    const files = await types(featureGatesWitPath, {
-      worldName: "import-and-export",
-      feature: ["fancier-foo"],
+        // Check the interfaces file for the right exports
+        const interfaces = Buffer.from(
+            files['interfaces/test-feature-gates-foo.d.ts']
+        ).toString('utf8');
+        assert.ok(
+            interfaces.includes('export function a(): void;'),
+            'unconstrained export foo/a is present'
+        );
+        assert.ok(
+            interfaces.includes('export function b(): void;'),
+            '@since(0.2.1) export foo/b is present (version matches)'
+        );
+        assert.ok(
+            interfaces.includes('export function c(): void;'),
+            '@since(0.2.1) export foo/c is present (feature is ignored)'
+        );
+        assert.ok(
+            interfaces.includes('export function d(): void;'),
+            '@unstable(...) export is present, with all features enabled'
+        );
     });
-    assert.ok(files["import-and-export.d.ts"], "component js was generated");
-    assert.ok(
-      files["interfaces/test-feature-gates-foo.d.ts"],
-      "interface typings were generated"
-    );
 
-    // Check the interfaces file for the right exports
-    const interfaces = Buffer.from(
-      files["interfaces/test-feature-gates-foo.d.ts"]
-    ).toString("utf8");
-    assert.ok(
-      interfaces.includes("export function a(): void;"),
-      "unconstrained export foo/a is present"
-    );
-    assert.ok(
-      interfaces.includes("export function b(): void;"),
-      "@since(0.2.1) export foo/b is present (version matches)"
-    );
-    assert.ok(
-      interfaces.includes("export function c(): void;"),
-      "@since(0.2.1) export foo/c is present (feature is ignored)"
-    );
-    assert.ok(
-      interfaces.includes("export function d(): void;"),
-      "@unstable(...) export is present (single feature enabled)"
-    );
-  });
+    // (transpile): features marked @unstable shoudl be present in exports when all features are enabled
+    //
+    // NOTE: this works primarily the features are fed through to the `wit_parser::Resolve` that is used,
+    // not due to active filtering on the jco side.
+    test('Feature gates (all features enabled)', async () => {
+        // Build a dummy WIT component
+        const generatedComponent = await componentEmbed({
+            witSource: featureGatesWitContent,
+            dummy: true,
+            metadata: [
+                ['language', [['javascript', '']]],
+                ['processed-by', [['dummy-gen', 'test']]],
+            ],
+            features: { tag: 'all' },
+        });
+        const component = await componentNew(generatedComponent);
 
-  // (`jco types`) features marked @unstable() should be present with all features enabled
-  test("Feature gates (types, all features enabled)", async () => {
-    const files = await types(featureGatesWitPath, {
-      worldName: "import-and-export",
-      allFeatures: true,
+        // Transpile the component
+        const { files, imports, exports } = await transpile(component);
+        assert.deepStrictEqual(imports, ['test:feature-gates/foo']);
+        assert.deepStrictEqual(exports, [
+            ['foo', 'instance'],
+            ['test:feature-gates/foo@0.2.1', 'instance'],
+        ]);
+        assert.ok(files['component.js'], 'component js was generated');
+        assert.ok(files['component.d.ts'], 'component typings were generated');
+        assert.ok(
+            files['interfaces/test-feature-gates-foo.d.ts'],
+            'interface typings were generated'
+        );
+
+        // Check the interfaces file for the right exports
+        const interfaces = Buffer.from(
+            files['interfaces/test-feature-gates-foo.d.ts']
+        ).toString('utf8');
+        assert.ok(
+            interfaces.includes('export function a(): void;'),
+            'unconstrained export foo/a is present'
+        );
+        assert.ok(
+            interfaces.includes('export function b(): void;'),
+            '@since(0.2.1) export foo/b is present (version matches)'
+        );
+        assert.ok(
+            interfaces.includes('export function c(): void;'),
+            '@since(0.2.1) export foo/c is present (feature is ignored)'
+        );
+        assert.ok(
+            interfaces.includes('export function d(): void;'),
+            '@unstable(...) export is present, with all features enabled'
+        );
     });
-    assert.ok(files["import-and-export.d.ts"], "component js was generated");
-    assert.ok(
-      files["interfaces/test-feature-gates-foo.d.ts"],
-      "interface typings were generated"
-    );
 
-    // Check the interfaces file for the right exports
-    const interfaces = Buffer.from(
-      files["interfaces/test-feature-gates-foo.d.ts"]
-    ).toString("utf8");
-    assert.ok(
-      interfaces.includes("export function a(): void;"),
-      "unconstrained export foo/a is present"
-    );
-    assert.ok(
-      interfaces.includes("export function b(): void;"),
-      "@since(0.2.1) export foo/b is present (version matches)"
-    );
-    assert.ok(
-      interfaces.includes("export function c(): void;"),
-      "@since(0.2.1) export foo/c is present (feature is ignored)"
-    );
-    assert.ok(
-      interfaces.includes("export function d(): void;"),
-      "@unstable(...) export is present (all features enabled)"
-    );
-  });
+    // (`jco types`) features marked @unstable() are missing as imports *and* exports
+    test('Feature gates - (types, no features enabled)', async () => {
+        const files = await types(featureGatesWitPath, {
+            worldName: 'import-and-export',
+        });
+        assert.ok(
+            files['import-and-export.d.ts'],
+            'component js was generated'
+        );
+        assert.ok(
+            files['interfaces/test-feature-gates-foo.d.ts'],
+            'interface typings were generated'
+        );
 
-  // (`jco types`) WIT errors are handled gracefully and print useful error messages
-  // see: https://github.com/bytecodealliance/jco/issues/442
-  test("Invalid WIT produce better error messages", async () => {
-    try {
-      await types(join(witFixturesPath, "invalid/invalid-fn.wit"), {
-        worldName: "invalid",
-        allFeatures: true,
-      });
-      assert.fail("test should have errored");
-    } catch (err) {
-      const errMsg = err.toString();
-      assert.ok(errMsg.includes("expected `type`, `resource` or `func`"));
-      assert.ok(errMsg.includes("found keyword `static`"));
-    }
-  });
-
-  // (`jco types`) Same-package sibling WIT files can be referred to
-  // see: https://github.com/bytecodealliance/jco/issues/442
-  test("same-package sibling WIT files work", async () => {
-    const witPath = join(witFixturesPath, "valid/no-deps");
-    await types(witPath, {
-      worldName: "component",
-      allFeatures: true,
+        // Check the interfaces file for the right exports
+        const interfaces = Buffer.from(
+            files['interfaces/test-feature-gates-foo.d.ts']
+        ).toString('utf8');
+        assert.ok(
+            interfaces.includes('export function a(): void;'),
+            'unconstrained export foo/a is present'
+        );
+        assert.ok(
+            interfaces.includes('export function b(): void;'),
+            '@since(0.2.1) export foo/b is present (version matches)'
+        );
+        assert.ok(
+            interfaces.includes('export function c(): void;'),
+            '@since(0.2.1) export foo/c is present (feature is ignored)'
+        );
+        assert.ok(
+            !interfaces.includes('export function d(): void;'),
+            '@unstable(...) export is missing (no features enabled)'
+        );
     });
-  });
 
-  // (`jco types`)  WIT files can be referred to
-  // see: https://github.com/bytecodealliance/jco/issues/442
-  test("different-package sibling WIT files fail w/ good error messages", async () => {
-    const witPath = join(witFixturesPath, "invalid/sibling-diff-pkg");
-    try {
-      await types(witPath, {
-        worldName: "component",
-        allFeatures: true,
-      });
-    } catch (err) {
-      const errMsg = err.toString();
-      assert.ok(
-        errMsg.includes(
-          "package identifier `tests:sibling-wit` does not match previous package"
-        )
-      );
-      assert.ok(errMsg.includes("Keep in mind the following rules"));
-    }
-  });
+    // (`jco types`) features marked @unstable(feature = f) should be present when the specific feature is enabled
+    test('Feature gates (types, single feature enabled)', async () => {
+        const files = await types(featureGatesWitPath, {
+            worldName: 'import-and-export',
+            feature: ['fancier-foo'],
+        });
+        assert.ok(
+            files['import-and-export.d.ts'],
+            'component js was generated'
+        );
+        assert.ok(
+            files['interfaces/test-feature-gates-foo.d.ts'],
+            'interface typings were generated'
+        );
+
+        // Check the interfaces file for the right exports
+        const interfaces = Buffer.from(
+            files['interfaces/test-feature-gates-foo.d.ts']
+        ).toString('utf8');
+        assert.ok(
+            interfaces.includes('export function a(): void;'),
+            'unconstrained export foo/a is present'
+        );
+        assert.ok(
+            interfaces.includes('export function b(): void;'),
+            '@since(0.2.1) export foo/b is present (version matches)'
+        );
+        assert.ok(
+            interfaces.includes('export function c(): void;'),
+            '@since(0.2.1) export foo/c is present (feature is ignored)'
+        );
+        assert.ok(
+            interfaces.includes('export function d(): void;'),
+            '@unstable(...) export is present (single feature enabled)'
+        );
+    });
+
+    // (`jco types`) features marked @unstable() should be present with all features enabled
+    test('Feature gates (types, all features enabled)', async () => {
+        const files = await types(featureGatesWitPath, {
+            worldName: 'import-and-export',
+            allFeatures: true,
+        });
+        assert.ok(
+            files['import-and-export.d.ts'],
+            'component js was generated'
+        );
+        assert.ok(
+            files['interfaces/test-feature-gates-foo.d.ts'],
+            'interface typings were generated'
+        );
+
+        // Check the interfaces file for the right exports
+        const interfaces = Buffer.from(
+            files['interfaces/test-feature-gates-foo.d.ts']
+        ).toString('utf8');
+        assert.ok(
+            interfaces.includes('export function a(): void;'),
+            'unconstrained export foo/a is present'
+        );
+        assert.ok(
+            interfaces.includes('export function b(): void;'),
+            '@since(0.2.1) export foo/b is present (version matches)'
+        );
+        assert.ok(
+            interfaces.includes('export function c(): void;'),
+            '@since(0.2.1) export foo/c is present (feature is ignored)'
+        );
+        assert.ok(
+            interfaces.includes('export function d(): void;'),
+            '@unstable(...) export is present (all features enabled)'
+        );
+    });
+
+    // (`jco types`) WIT errors are handled gracefully and print useful error messages
+    // see: https://github.com/bytecodealliance/jco/issues/442
+    test('Invalid WIT produce better error messages', async () => {
+        try {
+            await types(join(witFixturesPath, 'invalid/invalid-fn.wit'), {
+                worldName: 'invalid',
+                allFeatures: true,
+            });
+            assert.fail('test should have errored');
+        } catch (err) {
+            const errMsg = err.toString();
+            assert.ok(errMsg.includes('expected `type`, `resource` or `func`'));
+            assert.ok(errMsg.includes('found keyword `static`'));
+        }
+    });
+
+    // (`jco types`) Same-package sibling WIT files can be referred to
+    // see: https://github.com/bytecodealliance/jco/issues/442
+    test('same-package sibling WIT files work', async () => {
+        const witPath = join(witFixturesPath, 'valid/no-deps');
+        await types(witPath, {
+            worldName: 'component',
+            allFeatures: true,
+        });
+    });
+
+    // (`jco types`)  WIT files can be referred to
+    // see: https://github.com/bytecodealliance/jco/issues/442
+    test('different-package sibling WIT files fail w/ good error messages', async () => {
+        const witPath = join(witFixturesPath, 'invalid/sibling-diff-pkg');
+        try {
+            await types(witPath, {
+                worldName: 'component',
+                allFeatures: true,
+            });
+        } catch (err) {
+            const errMsg = err.toString();
+            assert.ok(
+                errMsg.includes(
+                    'package identifier `tests:sibling-wit` does not match previous package'
+                )
+            );
+            assert.ok(errMsg.includes('Keep in mind the following rules'));
+        }
+    });
 });


### PR DESCRIPTION
The glob `"lint": "eslint -c ../../eslint.config.mjs ./src/**/*.js",` seems to not pick up the files recursively. I used `"lint": "eslint -c ../../eslint.config.mjs --ext .js src test"` instead.