### PR TITLE
refactor(jco): move type generation functions to separate file

### DIFF
--- a/packages/jco/src/cmd/transpile.js
+++ b/packages/jco/src/cmd/transpile.js
@@ -1,26 +1,22 @@
 import { platform } from 'node:process';
-import { writeFile, stat } from 'node:fs/promises';
-import { mkdir } from 'node:fs/promises';
-import { dirname, extname, basename, resolve } from 'node:path';
+import { extname, basename, resolve } from 'node:path';
 
 import c from 'chalk-template';
 import { minify } from 'terser';
 import { fileURLToPath } from 'url';
 
-import {
-    $init,
-    generate,
-    generateTypes,
-} from '../../obj/js-component-bindgen-component.js';
+import { optimizeComponent } from './opt.js';
+
+import { $init, generate } from '../../obj/js-component-bindgen-component.js';
 import {
     readFile,
-    sizeStr,
-    table,
     spawnIOTmp,
     setShowSpinner,
     getShowSpinner,
+    writeFiles,
+    ASYNC_WASI_IMPORTS,
+    ASYNC_WASI_EXPORTS,
 } from '../common.js';
-import { optimizeComponent } from './opt.js';
 import { $init as wasmToolsInit, tools } from '../../obj/wasm-tools.js';
 const { componentEmbed, componentNew } = tools;
 
@@ -28,166 +24,8 @@ import ora from '#ora';
 
 const isWindows = platform === 'win32';
 
-const ASYNC_WASI_IMPORTS = [
-    'wasi:io/poll#poll',
-    'wasi:io/poll#[method]pollable.block',
-    'wasi:io/streams#[method]input-stream.blocking-read',
-    'wasi:io/streams#[method]input-stream.blocking-skip',
-    'wasi:io/streams#[method]output-stream.blocking-flush',
-    'wasi:io/streams#[method]output-stream.blocking-write-and-flush',
-    'wasi:io/streams#[method]output-stream.blocking-write-zeroes-and-flush',
-    'wasi:io/streams#[method]output-stream.blocking-splice',
-];
-
-const ASYNC_WASI_EXPORTS = [
-    'wasi:cli/run#run',
-    'wasi:http/incoming-handler#handle',
-];
-
-export async function types(witPath, opts) {
-    const files = await typesComponent(witPath, opts);
-    await writeFiles(files, opts.quiet ? false : 'Generated Type Files');
-}
-
-export async function guestTypes(witPath, opts) {
-    const files = await typesComponent(witPath, { ...opts, guest: true });
-    await writeFiles(
-        files,
-        opts.quiet
-            ? false
-            : 'Generated Guest Typescript Definition Files (.d.ts)'
-    );
-}
-
-/**
- * @param {string} witPath
- * @param {{
- *   name?: string,
- *   worldName?: string,
- *   instantiation?: 'async' | 'sync',
- *   tlaCompat?: bool,
- *   asyncMode?: string,
- *   asyncImports?: string[],
- *   asyncExports?: string[],
- *   outDir?: string,
- *   allFeatures?: bool,
- *   feature?: string[] | 'all', // backwards compat
- *   features?: string[] | 'all',
- *   asyncWasiImports?: string[],
- *   asyncWasiExports?: string[],
- *   guest?: bool,
- * }} opts
- * @returns {Promise<{ [filename: string]: Uint8Array }>}
- */
-export async function typesComponent(witPath, opts) {
-    await $init;
-    const name =
-        opts.name ||
-        (opts.worldName
-            ? opts.worldName.split(':').pop().split('/').pop()
-            : basename(witPath.slice(0, -extname(witPath).length || Infinity)));
-    let instantiation;
-    if (opts.instantiation) {
-        instantiation = { tag: opts.instantiation };
-    }
-    let outDir = (opts.outDir ?? '').replace(/\\/g, '/');
-    if (!outDir.endsWith('/') && outDir !== '') {
-        outDir += '/';
-    }
-
-    let features = null;
-    if (opts.allFeatures) {
-        features = { tag: 'all' };
-    } else if (Array.isArray(opts.feature)) {
-        features = { tag: 'list', val: opts.feature };
-    } else if (Array.isArray(opts.features)) {
-        features = { tag: 'list', val: opts.features };
-    }
-
-    if (opts.asyncWasiImports) {
-        opts.asyncImports = ASYNC_WASI_IMPORTS.concat(opts.asyncImports || []);
-    }
-    if (opts.asyncWasiExports) {
-        opts.asyncExports = ASYNC_WASI_EXPORTS.concat(opts.asyncExports || []);
-    }
-
-    const asyncMode =
-        !opts.asyncMode || opts.asyncMode === 'sync'
-            ? null
-            : {
-                  tag: opts.asyncMode,
-                  val: {
-                      imports: opts.asyncImports || [],
-                      exports: opts.asyncExports || [],
-                  },
-              };
-
-    let types;
-    const absWitPath = resolve(witPath);
-    try {
-        types = generateTypes(name, {
-            wit: { tag: 'path', val: (isWindows ? '//?/' : '') + absWitPath },
-            instantiation,
-            tlaCompat: opts.tlaCompat ?? false,
-            world: opts.worldName,
-            features,
-            guest: opts.guest ?? false,
-            asyncMode,
-        }).map(([name, file]) => [`${outDir}${name}`, file]);
-    } catch (err) {
-        if (err.toString().includes('does not match previous package name')) {
-            const hint = await printWITLayoutHint(absWitPath);
-            if (err.message) {
-                err.message += `\n${hint}`;
-            }
-            throw err;
-        }
-        throw err;
-    }
-
-    return Object.fromEntries(types);
-}
-
-/**
- * Print a hint about WIT folder layout
- *
- * @param {(string, any) => void} consoleFn
- */
-async function printWITLayoutHint(witPath) {
-    const pathMeta = await stat(witPath);
-    let output = '\n';
-    if (!pathMeta.isFile() && !pathMeta.isDirectory()) {
-        output += c`{yellow.bold warning} The supplited WIT path [${witPath}] is neither a file or directory.\n`;
-        return output;
-    }
-    const ftype = pathMeta.isDirectory() ? 'directory' : 'file';
-    output += c`{yellow.bold warning} Your WIT ${ftype} [${witPath}] may be laid out incorrectly\n`;
-    output += c`{yellow.bold warning} Keep in mind the following rules:\n`;
-    output += c`{yellow.bold warning}     - Top level WIT files are in the same package (i.e. "ns:pkg" in "wit/*.wit")\n`;
-    output += c`{yellow.bold warning}     - All package dependencies should be in "wit/deps" (i.e. "some:dep" in "wit/deps/some-dep.wit"\n`;
-    return output;
-}
-
-async function writeFiles(files, summaryTitle) {
-    await Promise.all(
-        Object.entries(files).map(async ([name, file]) => {
-            await mkdir(dirname(name), { recursive: true });
-            await writeFile(name, file);
-        })
-    );
-    if (!summaryTitle) {
-        return;
-    }
-    console.log(c`
-  {bold ${summaryTitle}:}
-
-${table(
-    Object.entries(files).map(([name, source]) => [
-        c` - {italic ${name}}  `,
-        c`{black.italic ${sizeStr(source.length)}}`,
-    ])
-)}`);
-}
+// These re-exports exist to avoid breaking backwards compatibility
+export { types, guestTypes, typesComponent } from './types.js';
 
 export async function transpile(witPath, opts, program) {
     const varIdx = program?.parent.rawArgs.indexOf('--');

--- a/packages/jco/src/cmd/types.d.ts
+++ b/packages/jco/src/cmd/types.d.ts
@@ -1,0 +1,33 @@
+export function types(witPath: any, opts: any): Promise<void>;
+export function guestTypes(witPath: any, opts: any): Promise<void>;
+/**
+ * @param {string} witPath
+ * @param {{
+ *   name?: string,
+ *   worldName?: string,
+ *   instantiation?: 'async' | 'sync',
+ *   tlaCompat?: bool,
+ *   asyncMode?: string,
+ *   asyncImports?: string[],
+ *   asyncExports?: string[],
+ *   outDir?: string,
+ *   features?: string[] | 'all',
+ *   guest?: bool,
+ * }} opts
+ * @returns {Promise<{ [filename: string]: Uint8Array }>}
+ */
+export function typesComponent(witPath: string, opts: {
+    name?: string;
+    worldName?: string;
+    instantiation?: "async" | "sync";
+    tlaCompat?: boolean;
+    asyncMode?: string;
+    asyncImports?: string[];
+    asyncExports?: string[];
+    outDir?: string;
+    features?: string[] | "all";
+    guest?: boolean;
+}): Promise<{
+    [filename: string]: Uint8Array;
+}>;
+//# sourceMappingURL=types.d.ts.map

--- a/packages/jco/src/cmd/types.js
+++ b/packages/jco/src/cmd/types.js
@@ -1,0 +1,147 @@
+import { platform } from 'node:process';
+import { stat } from 'node:fs/promises';
+import { extname, basename, resolve } from 'node:path';
+
+import c from 'chalk-template';
+
+import {
+    $init,
+    generateTypes,
+} from '../../obj/js-component-bindgen-component.js';
+import {
+    writeFiles,
+    ASYNC_WASI_IMPORTS,
+    ASYNC_WASI_EXPORTS,
+} from '../common.js';
+
+const isWindows = platform === 'win32';
+
+export async function types(witPath, opts) {
+    const files = await typesComponent(witPath, opts);
+    await writeFiles(files, opts.quiet ? false : 'Generated Type Files');
+}
+
+export async function guestTypes(witPath, opts) {
+    const files = await typesComponent(witPath, { ...opts, guest: true });
+    await writeFiles(
+        files,
+        opts.quiet
+            ? false
+            : 'Generated Guest Typescript Definition Files (.d.ts)'
+    );
+}
+
+/**
+ * @param {string} witPath
+ * @param {{
+ *   name?: string,
+ *   worldName?: string,
+ *   instantiation?: 'async' | 'sync',
+ *   tlaCompat?: bool,
+ *   asyncMode?: string,
+ *   asyncImports?: string[],
+ *   asyncExports?: string[],
+ *   outDir?: string,
+ *   allFeatures?: bool,
+ *   feature?: string[] | 'all', // backwards compat
+ *   features?: string[] | 'all',
+ *   asyncWasiImports?: string[],
+ *   asyncWasiExports?: string[],
+ *   guest?: bool,
+ * }} opts
+ * @returns {Promise<{ [filename: string]: Uint8Array }>}
+ */
+export async function typesComponent(witPath, opts) {
+    await $init;
+    const name =
+        opts.name ||
+        (opts.worldName
+            ? opts.worldName.split(':').pop().split('/').pop()
+            : basename(witPath.slice(0, -extname(witPath).length || Infinity)));
+    let instantiation;
+    if (opts.instantiation) {
+        instantiation = { tag: opts.instantiation };
+    }
+    let outDir = (opts.outDir ?? '').replace(/\\/g, '/');
+    if (!outDir.endsWith('/') && outDir !== '') {
+        outDir += '/';
+    }
+
+    let features = null;
+    if (opts.allFeatures) {
+        features = { tag: 'all' };
+    } else if (Array.isArray(opts.feature)) {
+        features = { tag: 'list', val: opts.feature };
+    } else if (Array.isArray(opts.features)) {
+        features = { tag: 'list', val: opts.features };
+    }
+
+    if (opts.asyncWasiImports) {
+        opts.asyncImports = ASYNC_WASI_IMPORTS.concat(opts.asyncImports || []);
+    }
+    if (opts.asyncWasiExports) {
+        opts.asyncExports = ASYNC_WASI_EXPORTS.concat(opts.asyncExports || []);
+    }
+
+    const asyncMode =
+        !opts.asyncMode || opts.asyncMode === 'sync'
+            ? null
+            : {
+                  tag: opts.asyncMode,
+                  val: {
+                      imports: opts.asyncImports || [],
+                      exports: opts.asyncExports || [],
+                  },
+              };
+
+    let types;
+    const absWitPath = resolve(witPath);
+    try {
+        types = generateTypes(name, {
+            wit: { tag: 'path', val: (isWindows ? '//?/' : '') + absWitPath },
+            instantiation,
+            tlaCompat: opts.tlaCompat ?? false,
+            world: opts.worldName,
+            features,
+            guest: opts.guest ?? false,
+            asyncMode,
+        }).map(([name, file]) => [`${outDir}${name}`, file]);
+    } catch (err) {
+        if (err.toString().includes('does not match previous package name')) {
+            const hint = await printWITLayoutHint(absWitPath);
+            if (err.message) {
+                err.message += `\n${hint}`;
+            }
+            throw err;
+        }
+        throw err;
+    }
+
+    return Object.fromEntries(types);
+}
+
+/**
+ * Print a hint about WIT folder layout
+ *
+ * @param {(string, any) => void} consoleFn
+ */
+async function printWITLayoutHint(witPath) {
+    const pathMeta = await stat(witPath);
+    let output = '\n';
+    if (!pathMeta.isFile() && !pathMeta.isDirectory()) {
+        output += c`{yellow.bold warning} The supplited WIT path [${witPath}] is neither a file or directory.\n`;
+        return output;
+    }
+    const ftype = pathMeta.isDirectory() ? 'directory' : 'file';
+    output += c`{yellow.bold warning} Your WIT ${ftype} [${witPath}] may be laid out incorrectly\n`;
+    output += c`{yellow.bold warning} Keep in mind the following rules:\n`;
+    output += c`{yellow.bold warning}     - Top level WIT files are in the same package (i.e. "ns:pkg" in "wit/*.wit")\n`;
+    output += c`{yellow.bold warning}     - All package dependencies should be in "wit/deps" (i.e. "some:dep" in "wit/deps/some-dep.wit"\n`;
+    return output;
+}
+
+// see: https://github.com/vitest-dev/vitest/issues/6953#issuecomment-2505310022
+if (typeof __vite_ssr_import_meta__ !== 'undefined') {
+    __vite_ssr_import_meta__.resolve = (path) =>
+        'file://' + globalCreateRequire(import.meta.url).resolve(path);
+}

--- a/packages/jco/src/common.d.ts
+++ b/packages/jco/src/common.d.ts
@@ -10,6 +10,7 @@ export function table(data: any, align?: any[]): string;
  */
 export function getTmpDir(): Promise<string>;
 export function spawnIOTmp(cmd: any, input: any, args: any): Promise<Buffer<ArrayBufferLike>>;
+export function writeFiles(files: any, summaryTitle: any): Promise<void>;
 export const isWindows: boolean;
 export { readFileCli as readFile };
 declare function readFileCli(file: any, encoding: any): Promise<Buffer<ArrayBufferLike>>;

--- a/packages/jco/src/common.d.ts.map
+++ b/packages/jco/src/common.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"common.d.ts","sourceRoot":"","sources":["common.js"],"names":[],"mappings":"AAWA,+CAEC;AACD,0CAIC;AAED,0CASC;AAED,mEAcC;AAED,wDAoBC;AAED;;;;GAIG;AACH,6CAEC;AAWD,8FAiCC;AAhHD,gCAA8C;;AAsE9C,yFAMC"}
+{"version":3,"file":"common.d.ts","sourceRoot":"","sources":["common.js"],"names":[],"mappings":"AA2BA,+CAEC;AACD,0CAIC;AAED,0CASC;AAED,mEAcC;AAED,wDAoBC;AAED;;;;GAIG;AACH,6CAEC;AAWD,8FAiCC;AAED,yEAmBC;AArJD,gCAA8C;;AAsF9C,yFAMC"}

--- a/packages/jco/src/jco.js
+++ b/packages/jco/src/jco.js
@@ -4,7 +4,8 @@ import c from 'chalk-template';
 import { program, Option } from 'commander';
 
 import { opt } from './cmd/opt.js';
-import { transpile, types, guestTypes } from './cmd/transpile.js';
+import { transpile } from './cmd/transpile.js';
+import { types, guestTypes } from './cmd/types.js';
 import { run as runCmd, serve as serveCmd } from './cmd/run.js';
 import {
     parse,


### PR DESCRIPTION
This commit separates out type generation to another file from the transpilation logic, but keeps the exports that were previously part of transpile in place to ensure backwards compatibility.