### PR TITLE
feat(jco): enable memory64

### DIFF
--- a/crates/js-component-bindgen/src/lib.rs
+++ b/crates/js-component-bindgen/src/lib.rs
@@ -132,6 +132,7 @@ pub fn transpile(component: &[u8], opts: TranspileOpts) -> Result<Transpiled> {
             | WasmFeatures::CM_ASYNC
             | WasmFeatures::CM_ASYNC_BUILTINS
             | WasmFeatures::CM_ERROR_CONTEXT
+            | WasmFeatures::MEMORY64
             | WasmFeatures::MULTI_MEMORY,
     );
 


### PR DESCRIPTION
This enables Jco to transpile components that contain modules with MEMORY64.