### PR TITLE
fix(p2-shim): nsToDateTime modulo with correct number

### DIFF
--- a/packages/preview2-shim/lib/nodejs/filesystem.js
+++ b/packages/preview2-shim/lib/nodejs/filesystem.js
@@ -42,7 +42,7 @@ const isMac = platform === 'darwin';
 const nsMagnitude = 1_000_000_000_000n;
 function nsToDateTime(ns) {
     const seconds = ns / nsMagnitude;
-    const nanoseconds = Number(ns % seconds);
+    const nanoseconds = Number(ns % nsMagnitude);
     return { seconds, nanoseconds };
 }
 


### PR DESCRIPTION
Avoids error when running in docker where timestamp is zero.