### PR TITLE
feat(jco): allow configurable wasm-opt bin path

### DIFF
--- a/packages/jco-transpile/src/opt.js
+++ b/packages/jco-transpile/src/opt.js
@@ -11,6 +11,7 @@ const { metadataShow, print } = tools;
  *  asyncify?: boolean,
  *  optArgs?: string[],
  *  noVerify?: boolean
+ *  wasmOptBin?: string
  * }} OptimizeOptions
  */
 
@@ -65,7 +66,8 @@ export async function runOptimizeComponent(componentBytes, opts) {
                         metadata.range[0],
                         metadata.range[1]
                     ),
-                    args
+                    args,
+                    opts
                 );
 
                 // compute the size change, including the change to
@@ -188,15 +190,16 @@ export async function runOptimizeComponent(componentBytes, opts) {
  *
  * @param {Uint8Array} source
  * @param {Array<string>} args
+ * @param {TranspileOpt} transpileOpts
  * @returns {Promise<Uint8Array>}
  */
-async function runWasmOptCLI(source, args) {
-    const wasmOptPath = fileURLToPath(
-        import.meta.resolve('binaryen/bin/wasm-opt')
-    );
+async function runWasmOptCLI(source, args, transpileOpts) {
+    const wasmOptBin =
+        transpileOpts?.wasmOptBin ??
+        fileURLToPath(import.meta.resolve('binaryen/bin/wasm-opt'));
 
     try {
-        return await runWASMTransformProgram(wasmOptPath, source, [
+        return await runWASMTransformProgram(wasmOptBin, source, [
             ...args,
             '-o',
         ]);

--- a/packages/jco/src/cmd/opt.js
+++ b/packages/jco/src/cmd/opt.js
@@ -136,7 +136,8 @@ export async function optimizeComponent(componentBytes, opts) {
                             metadata.range[0],
                             metadata.range[1]
                         ),
-                        args
+                        args,
+                        opts
                     );
 
                     // compute the size change, including the change to
@@ -280,13 +281,13 @@ export async function optimizeComponent(componentBytes, opts) {
  * @param {Array<string>} args
  * @returns {Promise<Uint8Array>}
  */
-async function wasmOpt(source, args) {
-    const wasmOptPath = fileURLToPath(
-        import.meta.resolve('binaryen/bin/wasm-opt')
-    );
+async function wasmOpt(source, args, transpileOpts) {
+    const wasmOptBin =
+        transpileOpts?.wasmOptBin ??
+        fileURLToPath(import.meta.resolve('binaryen/bin/wasm-opt'));
 
     try {
-        return await spawnIOTmp(wasmOptPath, source, [...args, '-o']);
+        return await spawnIOTmp(wasmOptBin, source, [...args, '-o']);
     } catch (e) {
         if (e.toString().includes('BasicBlock requested')) {
             return wasmOpt(source, args);

--- a/packages/jco/src/cmd/transpile.js
+++ b/packages/jco/src/cmd/transpile.js
@@ -122,6 +122,7 @@ async function wasm2Js(source) {
  *   multiMemory?: bool,
  *   experimentalIdlImports?: bool,
  *   optArgs?: string[],
+ *   wasmOptBin?: string[],
  * }} opts
  * @returns {Promise<{ files: { [filename: string]: Uint8Array }, imports: string[], exports: [string, 'function' | 'instance'][] }>}
  */

--- a/packages/jco/src/jco.js
+++ b/packages/jco/src/jco.js
@@ -234,6 +234,7 @@ program
         []
     )
     .option('--all-features', 'enable all features')
+    .option("--wasm-opt-bin <path-to-wasm-opt>', 'wasm-opt binary path (default: '')")
     .action(asyncAction(types));
 
 program
@@ -345,6 +346,7 @@ program
     )
     .option('--asyncify', 'runs Asyncify pass in wasm-opt')
     .option('-q, --quiet')
+    .option("--wasm-opt-bin <path-to-wasm-opt>', 'wasm-opt binary path (default: '')")
     .allowExcessArguments(true)
     .action(asyncAction(opt));
 


### PR DESCRIPTION
This commit adds the option to specify a path to the `wasm-opt` binary when using `jco transpile` and `jco opt`.

Resolves #378