### PR TITLE
feat(jco): support async export generation for guest-types

### DIFF
--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -101,6 +101,7 @@ pub fn ts_bindgen(
             (imports.into_iter().collect(), exports.into_iter().collect())
         }
     };
+
     let mut bindgen = TsBindgen {
         src: Source::default(),
         interface_names: LocalNames::default(),
@@ -310,7 +311,7 @@ pub fn ts_bindgen(
     //
     // With the current representation of a "world" this is an import object
     // per-imported-interface where the type of that field is defined by the
-    // interface itbindgen.
+    // interface bindgen.
     if opts.instantiation.is_some() {
         uwriteln!(bindgen.src, "export interface ImportObject {{");
         bindgen.src.push_str(&bindgen.import_object);
@@ -680,8 +681,11 @@ impl TsBindgen {
                 }
 
                 let func_name = func.name.clone();
+
                 let canonicalized_fn_name = match resolve.canonicalized_id_of(interface_id) {
-                    Some(canon_iface_name) => format!("{canon_iface_name}#{func_name}"),
+                    Some(canon_iface_name) => {
+                        format!("{}#{func_name}", canon_iface_name.trim_start_matches("$"))
+                    }
                     // NOTE: we can't get canonicalized interface names for anonymous interfaces
                     // so we use the function name bare
                     None => func_name,

--- a/packages/jco/src/common.d.ts
+++ b/packages/jco/src/common.d.ts
@@ -14,6 +14,7 @@ export function writeFiles(files: any, summaryTitle: any): Promise<void>;
 export const isWindows: boolean;
 export const ASYNC_WASI_IMPORTS: string[];
 export const ASYNC_WASI_EXPORTS: string[];
+export const DEFAULT_ASYNC_MODE: "sync";
 export { readFileCli as readFile };
 declare function readFileCli(file: any, encoding: any): Promise<Buffer<ArrayBufferLike>>;
 //# sourceMappingURL=common.d.ts.map

--- a/packages/jco/src/common.d.ts.map
+++ b/packages/jco/src/common.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"common.d.ts","sourceRoot":"","sources":["common.js"],"names":[],"mappings":"AA4BA,+CAEC;AACD,0CAIC;AAED,0CASC;AAED,mEAcC;AAED,wDAoBC;AAED;;;;GAIG;AACH,6CAEC;AAWD,8FAiCC;AAED,yEAmBC;AArJD,gCAA8C;AAE9C,0CASE;AAEF,0CAGE;;AAsEF,yFAMC"}
+{"version":3,"file":"common.d.ts","sourceRoot":"","sources":["common.js"],"names":[],"mappings":"AA8BA,+CAEC;AACD,0CAIC;AAED,0CASC;AAED,mEAcC;AAED,wDAoBC;AAED;;;;GAIG;AACH,6CAEC;AAWD,8FAiCC;AAED,yEAmBC;AAvJD,gCAA8C;AAE9C,0CASE;AAEF,0CAGE;AAEF,iCAAkC,MAAM,CAAC;;AAsEzC,yFAMC"}

--- a/packages/jco/src/common.js
+++ b/packages/jco/src/common.js
@@ -25,6 +25,8 @@ export const ASYNC_WASI_EXPORTS = [
     'wasi:http/incoming-handler#handle',
 ];
 
+export const DEFAULT_ASYNC_MODE = 'sync';
+
 let _showSpinner = false;
 export function setShowSpinner(val) {
     _showSpinner = val;

--- a/packages/jco/src/jco.js
+++ b/packages/jco/src/jco.js
@@ -224,7 +224,7 @@ program
     )
     .option(
         '--async-exports <exports...>',
-        'EXPERIMENTAL: async component exports (examples: "wasi:cli/run@#run", "handle")'
+        'EXPERIMENTAL: async component exports (examples: "ns:pkg/iface#func", "wasi:cli/run@0.2.3#run", "handle")'
     )
     .option('-q, --quiet', 'disable output summary')
     .option(
@@ -234,7 +234,9 @@ program
         []
     )
     .option('--all-features', 'enable all features')
-    .option("--wasm-opt-bin <path-to-wasm-opt>', 'wasm-opt binary path (default: '')")
+    .option(
+        "--wasm-opt-bin <path-to-wasm-opt>', 'wasm-opt binary path (default: 'binaryen/bin/wasm-opt')"
+    )
     .action(asyncAction(types));
 
 program
@@ -253,6 +255,18 @@ program
         []
     )
     .option('--all-features', 'enable all features')
+    .option(
+        '--async-exports <exports...>',
+        'EXPERIMENTAL: generate async exports (examples: "ns:pkg/iface#func", "wasi:cli/run@0.2.3#run", "handle")'
+    )
+    .addOption(
+        new Option(
+            '--async-mode [mode]',
+            'EXPERIMENTAL: use async imports and exports'
+        )
+            .choices(['sync', 'jspi'])
+            .preset('sync')
+    )
     .action(asyncAction(guestTypes));
 
 program
@@ -346,7 +360,9 @@ program
     )
     .option('--asyncify', 'runs Asyncify pass in wasm-opt')
     .option('-q, --quiet')
-    .option("--wasm-opt-bin <path-to-wasm-opt>', 'wasm-opt binary path (default: '')")
+    .option(
+        "--wasm-opt-bin <path-to-wasm-opt>', 'wasm-opt binary path (default: 'binaryen/bin/wasm-opt')"
+    )
     .allowExcessArguments(true)
     .action(asyncAction(opt));
 

--- a/packages/jco/test/p3/transpile.js
+++ b/packages/jco/test/p3/transpile.js
@@ -26,6 +26,7 @@ suite('Transpile (WASI P3)', () => {
             jco: {
                 transpile: {
                     extraArgs: {
+                        asyncMode: 'jspi',
                         asyncExports: ['local:local/run#run'],
                     },
                 },


### PR DESCRIPTION
This commit enables generation of async exports when building guest types for a component. Since an async export requires JSPI on the part of the host/embedding environment, we also require that async-export JSPI be enabled as well.

Resolves #623