### PR TITLE
feat(p2-shim): add support for retrieving HTTP server address

### DIFF
--- a/packages/preview2-shim/lib/io/calls.js
+++ b/packages/preview2-shim/lib/io/calls.js
@@ -62,6 +62,7 @@ export const HTTP_SERVER_STOP = ++call_id << CALL_SHIFT;
 export const HTTP_SERVER_INCOMING_HANDLER = ++call_id << CALL_SHIFT;
 export const HTTP_SERVER_SET_OUTGOING_RESPONSE = ++call_id << CALL_SHIFT;
 export const HTTP_SERVER_CLEAR_OUTGOING_RESPONSE = ++call_id << CALL_SHIFT;
+export const HTTP_SERVER_GET_ADDRESS = ++call_id << CALL_SHIFT;
 export const HTTP_OUTGOING_BODY_DISPOSE = ++call_id << CALL_SHIFT;
 
 // Clocks

--- a/packages/preview2-shim/lib/io/worker-http.js
+++ b/packages/preview2-shim/lib/io/worker-http.js
@@ -27,6 +27,10 @@ export function clearOutgoingResponse(id) {
     responses.delete(id);
 }
 
+export async function getHttpServerAddress(id) {
+    return servers.get(id).address();
+}
+
 export async function setOutgoingResponse(
     id,
     { statusCode, headers, streamId }

--- a/packages/preview2-shim/lib/io/worker-thread.js
+++ b/packages/preview2-shim/lib/io/worker-thread.js
@@ -8,6 +8,7 @@ import {
     setOutgoingResponse,
     startHttpServer,
     stopHttpServer,
+    getHttpServerAddress,
 } from './worker-http.js';
 import { Readable } from 'node:stream';
 import { read } from 'node:fs';
@@ -29,6 +30,7 @@ import {
     HTTP_SERVER_SET_OUTGOING_RESPONSE,
     HTTP_SERVER_START,
     HTTP_SERVER_STOP,
+    HTTP_SERVER_GET_ADDRESS,
     INPUT_STREAM_BLOCKING_READ,
     INPUT_STREAM_BLOCKING_SKIP,
     INPUT_STREAM_CREATE,
@@ -417,6 +419,8 @@ function handle(call, id, payload) {
         return setOutgoingResponse(id, payload);
     case HTTP_SERVER_CLEAR_OUTGOING_RESPONSE:
         return clearOutgoingResponse(id);
+    case HTTP_SERVER_GET_ADDRESS:
+        return getHttpServerAddress(id);
 
         // Sockets name resolution
     case SOCKET_RESOLVE_ADDRESS_CREATE_REQUEST:

--- a/packages/preview2-shim/lib/nodejs/http.js
+++ b/packages/preview2-shim/lib/nodejs/http.js
@@ -9,6 +9,7 @@ import {
     HTTP_SERVER_SET_OUTGOING_RESPONSE,
     HTTP_SERVER_START,
     HTTP_SERVER_STOP,
+    HTTP_SERVER_GET_ADDRESS,
     OUTPUT_STREAM_CREATE,
     OUTPUT_STREAM_DISPOSE,
 } from '../io/calls.js';
@@ -775,6 +776,9 @@ export class HTTPServer {
         // set a dummy interval, to keep the process alive since the server is off-thread
         this.#liveEventLoopInterval = setInterval(() => {}, 10_000);
         ioCall(HTTP_SERVER_START, this.#id, { port, host });
+    }
+    address() {
+        return ioCall(HTTP_SERVER_GET_ADDRESS, this.#id);
     }
     stop() {
         if (this.#stopped) {

--- a/packages/preview2-shim/test/test.js
+++ b/packages/preview2-shim/test/test.js
@@ -500,6 +500,23 @@ suite("Node.js Preview2", () => {
   });
 });
 
+suite("HTTPServer", () => {
+    test(
+        "HTTPServer: can retrieve randomized server address",
+        testWithGCWrap(async () => {
+            const { HTTPServer } = await import("@bytecodealliance/preview2-shim/http");
+            const server = new HTTPServer({
+                handle() {
+                    throw new Error("never called");
+                }
+            });
+            server.listen(0);
+            const address = server.address();
+            assert(Number.isSafeInteger(address?.port) && address?.port != 0, "a random port was assigned and retrieved");
+        }),
+    );
+});
+
 suite("Instantiation", () => {
   test("WASIShim export (random)", async () => {
     const { random } = await import("@bytecodealliance/preview2-shim");


### PR DESCRIPTION
This commit adds support for retrieving the port of a created `HTTPServer` that is listening. This is helpful for servers that should be started on port 0 (w/ OS support for random port selection), so that users can get the resolved address out later, if needed.