### PR TITLE
refactor(transpile): remove chalk dependency

### DIFF
--- a/packages/jco-transpile/package.json
+++ b/packages/jco-transpile/package.json
@@ -52,7 +52,6 @@
   },
   "dependencies": {
     "@bytecodealliance/preview2-shim": "^0.17.3",
-    "chalk-template": "^1",
     "terser": "^5"
   }
 }

--- a/packages/jco-transpile/src/common.js
+++ b/packages/jco-transpile/src/common.js
@@ -8,8 +8,7 @@ import {
 } from 'node:fs/promises';
 import { spawn } from 'node:child_process';
 import { platform, argv0 } from 'node:process';
-
-import c from 'chalk-template';
+import * as nodeUtils from 'node:utils';
 
 /** Detect a windows environment */
 export const isWindows = platform === 'win32';
@@ -19,6 +18,14 @@ const DEFAULT_SIGNIFICANT_DIGITS = 4;
 
 /** Nubmer of bytes in a kilobyte */
 const BYTES_MAGNITUDE = 1024;
+
+/** Partial polyfill for 'node:utils' `styleText()` */
+export function styleText(styles, text) {
+    if (nodeUtils.styleText) {
+        return nodeUtils.styleText(styles, text);
+    }
+    return text;
+}
 
 /**
  * Convert a given number into the string that would appropriately represent it,
@@ -120,7 +127,7 @@ export async function readFile(file, encoding) {
     try {
         return await fsReadFile(file, encoding);
     } catch {
-        throw c`Unable to read file {bold ${file}}`;
+        throw `Unable to read file ${styleText('bold', file)}`;
     }
 }
 


### PR DESCRIPTION
This commit removes the `chalk-template` dependency. While we were not vulnerable to the upstream malicious code injection that happened to chalk and related deps, the chalk dependency is no longer needed when using Node 20.x and above.

For node versions 20 or other platforms that do not have the dependency, we use a polyfill that simply loses the colored output.

This is a breaking change in a sense as output will change and users that are on node 18 and rely on the color output will get output that is inconsistent from before, but removing this dependency is a high priority at this point and the repercussions are likely minor from the light semver breakage.

Link: https://github.com/chalk/chalk/issues/656