### PR TITLE
fix(bindgen): allow extended const wasm feature during parse

### DIFF
--- a/crates/js-component-bindgen/src/lib.rs
+++ b/crates/js-component-bindgen/src/lib.rs
@@ -133,6 +133,7 @@ pub fn transpile(component: &[u8], opts: TranspileOpts) -> Result<Transpiled> {
             | WasmFeatures::CM_ASYNC_BUILTINS
             | WasmFeatures::CM_ASYNC_STACKFUL
             | WasmFeatures::CM_ERROR_CONTEXT
+            | WasmFeatures::EXTENDED_CONST
             | WasmFeatures::MEMORY64
             | WasmFeatures::MULTI_MEMORY,
     );


### PR DESCRIPTION
This commit enables the extended const feature for wasmparser to enable parsing components as generated by componentize-py (and other toolchains, in the future).

Resolves #1083 