### PR TITLE
fix(ops): only print contributors for non-new releases

### DIFF
--- a/crates/js-component-bindgen/cliff.toml
+++ b/crates/js-component-bindgen/cliff.toml
@@ -23,7 +23,7 @@ body = """
     {% endfor %}
 {% endfor %}\n
 
-{%- if github -%}
+{%- if github and previous.version -%}
 {% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
   {% raw %}\n{% endraw -%}
   ## New Contributors

--- a/packages/jco-std/cliff.toml
+++ b/packages/jco-std/cliff.toml
@@ -23,7 +23,7 @@ body = """
     {% endfor %}
 {% endfor %}\n
 
-{%- if github -%}
+{%- if github and previous.version -%}
 {% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
   {% raw %}\n{% endraw -%}
   ## New Contributors

--- a/packages/jco-transpile/cliff.toml
+++ b/packages/jco-transpile/cliff.toml
@@ -23,7 +23,7 @@ body = """
     {% endfor %}
 {% endfor %}\n
 
-{%- if github -%}
+{%- if github and previous.version -%}
 {% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
   {% raw %}\n{% endraw -%}
   ## New Contributors

--- a/packages/jco/cliff.toml
+++ b/packages/jco/cliff.toml
@@ -23,7 +23,7 @@ body = """
     {% endfor %}
 {% endfor %}\n
 
-{%- if github -%}
+{%- if github and previous.version -%}
 {% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
   {% raw %}\n{% endraw -%}
   ## New Contributors

--- a/packages/preview2-shim/cliff.toml
+++ b/packages/preview2-shim/cliff.toml
@@ -23,7 +23,7 @@ body = """
     {% endfor %}
 {% endfor %}\n
 
-{%- if github -%}
+{%- if github and previous.version -%}
 {% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
   {% raw %}\n{% endraw -%}
   ## New Contributors

--- a/packages/preview3-shim/cliff.toml
+++ b/packages/preview3-shim/cliff.toml
@@ -23,7 +23,7 @@ body = """
     {% endfor %}
 {% endfor %}\n
 
-{%- if github -%}
+{%- if github and previous.version -%}
 {% if github.contributors | filter(attribute="is_first_time", value=true) | length != 0 %}
   {% raw %}\n{% endraw -%}
   ## New Contributors


### PR DESCRIPTION
This commit limits printing new contributors only for *successive* releases after the first for a given project.

This is currently the easiest way for `git-cliff` to avoid pulling in *all* project contributors (from all time) to any new 0.0.1 release for a project.