### PR TITLE
fix(ci): pin wasm-tools to 1.240.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
 
       - uses: taiki-e/cache-cargo-install-action@7447f04c51f2ba27ca35e7f1e28fab848c5b3ba7 # v2.3.1
         with:
-          tool: wasm-tools
+          tool: wasm-tools@1.240.0
 
       # Determine weval version
       - name: Determine weval version


### PR DESCRIPTION
This commit reverts wasm-tools used in tests to 1.240.0 to avoid pulling in changes to the async typing that will cause `wasm-tools compose` to not validate in tests.