### PR TITLE
fix(jco): require utf8 decoder for flat string lifts

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -373,6 +373,22 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
 
     if args
         .intrinsics
+        .contains(&Intrinsic::Lift(LiftIntrinsic::LiftFlatStringUtf8))
+    {
+        args.intrinsics
+            .insert(Intrinsic::String(StringIntrinsic::Utf8Decoder));
+    }
+
+    if args
+        .intrinsics
+        .contains(&Intrinsic::Lift(LiftIntrinsic::LiftFlatStringUtf16))
+    {
+        args.intrinsics
+            .insert(Intrinsic::String(StringIntrinsic::Utf16Decoder));
+    }
+
+    if args
+        .intrinsics
         .contains(&Intrinsic::AsyncTask(AsyncTaskIntrinsic::StartCurrentTask))
         || args
             .intrinsics


### PR DESCRIPTION
This commit fixes a bug by which strings loaded from memory during async returns did not have the shared decoder (created via intrinsic) present.

This commit stops short of reworking the dependency resolution code to be closer to the site of usage (i.e. in the various `*Intrinsic` enum members), but that can/should be done in the future.