### PR TITLE
fix(p2-shim): missing browser shim bits

### DIFF
--- a/packages/preview2-shim/lib/browser/filesystem.js
+++ b/packages/preview2-shim/lib/browser/filesystem.js
@@ -325,6 +325,103 @@ export const preopens = {
 export const types = {
     Descriptor,
     DirectoryEntryStream,
+    filesystemErrorCode(err) {
+        return convertFsError(err.payload);
+    },
 };
+
+function convertFsError(e) {
+    switch (e.code) {
+    case 'EACCES':
+        return 'access';
+    case 'EAGAIN':
+    case 'EWOULDBLOCK':
+        return 'would-block';
+    case 'EALREADY':
+        return 'already';
+    case 'EBADF':
+        return 'bad-descriptor';
+    case 'EBUSY':
+        return 'busy';
+    case 'EDEADLK':
+        return 'deadlock';
+    case 'EDQUOT':
+        return 'quota';
+    case 'EEXIST':
+        return 'exist';
+    case 'EFBIG':
+        return 'file-too-large';
+    case 'EILSEQ':
+        return 'illegal-byte-sequence';
+    case 'EINPROGRESS':
+        return 'in-progress';
+    case 'EINTR':
+        return 'interrupted';
+    case 'EINVAL':
+        return 'invalid';
+    case 'EIO':
+        return 'io';
+    case 'EISDIR':
+        return 'is-directory';
+    case 'ELOOP':
+        return 'loop';
+    case 'EMLINK':
+        return 'too-many-links';
+    case 'EMSGSIZE':
+        return 'message-size';
+    case 'ENAMETOOLONG':
+        return 'name-too-long';
+    case 'ENODEV':
+        return 'no-device';
+    case 'ENOENT':
+        return 'no-entry';
+    case 'ENOLCK':
+        return 'no-lock';
+    case 'ENOMEM':
+        return 'insufficient-memory';
+    case 'ENOSPC':
+        return 'insufficient-space';
+    case 'ENOTDIR':
+    case 'ERR_FS_EISDIR':
+        return 'not-directory';
+    case 'ENOTEMPTY':
+        return 'not-empty';
+    case 'ENOTRECOVERABLE':
+        return 'not-recoverable';
+    case 'ENOTSUP':
+        return 'unsupported';
+    case 'ENOTTY':
+        return 'no-tty';
+        // windows gives this error for badly structured `//` reads
+        // this seems like a slightly better error than unknown given
+        // that it's a common footgun
+    case -4094:
+    case 'ENXIO':
+        return 'no-such-device';
+    case 'EOVERFLOW':
+        return 'overflow';
+    case 'EPERM':
+        return 'not-permitted';
+    case 'EPIPE':
+        return 'pipe';
+    case 'EROFS':
+        return 'read-only';
+    case 'ESPIPE':
+        return 'invalid-seek';
+    case 'ETXTBSY':
+        return 'text-file-busy';
+    case 'EXDEV':
+        return 'cross-device';
+    case 'UNKNOWN':
+        switch (e.errno) {
+        case -4094:
+            return 'no-such-device';
+        default:
+            throw e;
+        }
+    default:
+        throw e;
+    }
+}
 
 export { types as filesystemTypes };

--- a/packages/preview2-shim/lib/browser/http.js
+++ b/packages/preview2-shim/lib/browser/http.js
@@ -142,4 +142,14 @@ export const types = {
     listenToFutureIncomingResponse(_f) {
         console.log('[types] Listen to future incoming response');
     },
+    Fields: class Fields {},
+    FutureIncomingResponse: new class FutureIncomingResponse {},
+    IncomingBody: new class IncomingBody {},
+    IncomingRequest: new class IncomingRequest {},
+    IncomingResponse: new class IncomingResponse {},
+    OutgoingBody: new class OutgoingBody {},
+    OutgoingRequest: new class OutgoingRequest {},
+    OutgoingResponse: new class OutgoingResponse {},
+    RequestOptions: new class RequestOptions {},
+    ResponseOutparam: new class ResponseOutparam {},
 };

--- a/packages/preview2-shim/lib/browser/io.js
+++ b/packages/preview2-shim/lib/browser/io.js
@@ -190,4 +190,5 @@ export const poll = {
     Pollable,
     pollList,
     pollOne,
+    poll: pollOne,
 };


### PR DESCRIPTION
This commit fixes an issue that was exposed when all imports are checked for existence during import. The browser shims at present not only are incomplete, but they're also missing key functions and classes that should be present.

This commit unfortunately doesn't actually bring the browser implementation up to snuff -- rather we simply add the placeholders that should be there (and will fail if use is attempted at runtime).

Up until now imports were not checked for existence, but the usefulness of explicit upfront errors (instead of less scruable ones later) is a good tradeoff.

In the future an option to disable import checks may be added.