### PR TITLE
fix(bindgen): use ponyfill for `Promise.withResolvers`

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/component.rs
+++ b/crates/js-component-bindgen/src/intrinsics/component.rs
@@ -135,7 +135,7 @@ impl ComponentIntrinsic {
                     "
                     class {class_name} {{
                         #callingAsyncImport = false;
-                        #syncImportWait = Promise.withResolvers();
+                        #syncImportWait = promiseWithResolvers();
                         #lock = null;
 
                         mayLeave = true;
@@ -156,7 +156,7 @@ impl ComponentIntrinsic {
 
                         #notifySyncImportEnd() {{
                             const existing = this.#syncImportWait;
-                            this.#syncImportWait = Promise.withResolvers();
+                            this.#syncImportWait = promiseWithResolvers();
                             existing.resolve();
                         }}
 
@@ -218,7 +218,7 @@ impl ComponentIntrinsic {
                                 if (finishedTicket === ticket - 1n) {{ break; }}
                             }}
 
-                            const {{ promise, resolve }} = Promise.withResolvers();
+                            const {{ promise, resolve }} = promiseWithResolvers();
                             this.#lock = {{
                                 ticket,
                                 promise,

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -61,7 +61,7 @@ pub enum Intrinsic {
     Host(HostIntrinsic),
 
     // Polyfills
-    PromiseWithResolversPolyfill,
+    PromiseWithResolversPonyfill,
 
     /// Enable debug logging
     DebugLog,
@@ -198,7 +198,7 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
         AsyncTaskIntrinsic::UnpackCallbackResult,
     ));
     args.intrinsics
-        .insert(Intrinsic::PromiseWithResolversPolyfill);
+        .insert(Intrinsic::PromiseWithResolversPonyfill);
     args.intrinsics
         .insert(Intrinsic::Host(HostIntrinsic::PrepareCall));
     args.intrinsics
@@ -674,11 +674,13 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
                 ));
             }
 
-            Intrinsic::PromiseWithResolversPolyfill => {
+            Intrinsic::PromiseWithResolversPonyfill => {
                 output.push_str(
                     r#"
-                    if (!Promise.withResolvers) {
-                        Promise.withResolvers = () => {
+                    function promiseWithResolvers() {
+                        if (Promise.withResolvers) {
+                            return Promise.withResolvers();
+                        } else {
                             let resolve;
                             let reject;
                             const promise = new Promise((res, rej) => {
@@ -686,7 +688,7 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
                                 reject = rej;
                             });
                             return { promise, resolve, reject };
-                        };
+                        }
                     }
                 "#,
                 );
@@ -959,7 +961,7 @@ impl Intrinsic {
 
             // Debugging
             Intrinsic::DebugLog => "_debugLog",
-            Intrinsic::PromiseWithResolversPolyfill => unreachable!("always global"),
+            Intrinsic::PromiseWithResolversPonyfill => unreachable!("always global"),
 
             // Types
             Intrinsic::ConstantI32Min => "I32_MIN",

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -599,7 +599,7 @@ impl AsyncTaskIntrinsic {
                                promise: completionPromise,
                                resolve: resolveCompletionPromise,
                                reject: rejectCompletionPromise,
-                           }} = Promise.withResolvers();
+                           }} = promiseWithResolvers();
                            this.#completionPromise = completionPromise;
 
                            this.#onResolve = (results) => {{
@@ -785,7 +785,7 @@ impl AsyncTaskIntrinsic {
                             }}
 
                             // Build a promise that this task can await on which resolves when it is awoken
-                            const {{ promise, resolve, reject }} = Promise.withResolvers();
+                            const {{ promise, resolve, reject }} = promiseWithResolvers();
                             this.awaitableResume = () => {{
                                 {debug_log_fn}('[{task_class}] resuming after onBlock', {{ taskID: this.#id }});
                                 resolve();
@@ -988,7 +988,7 @@ impl AsyncTaskIntrinsic {
                             if (args.waitable) {{
                                 this.#waitable = args.waitable;
                             }} else {{
-                                const {{ promise, resolve, reject }} = Promise.withResolvers();
+                                const {{ promise, resolve, reject }} = promiseWithResolvers();
                                 this.#waitableResolve = resolve;
                                 this.#waitableReject = reject;
 


### PR DESCRIPTION
Hi! Thanks for this project :)

Polyfills are nice but [also have some problems](https://github.com/sindresorhus/ponyfill#the-problem-with-polyfills). Would it be of interest to use a ponyfill, along the lines of the changes in this PR, instead?

Thanks for considering!