### PR TITLE
docs(jco): update mdbook to 0.5.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,13 +18,7 @@ jobs:
       - name: Setup mdBook
         uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2.0.0
         with:
-          mdbook-version: '0.4.52'
-
-      - uses: taiki-e/install-action@542cebaaed782771e619bd5609d97659d109c492 # v2.66.7
-        with:
-          tool: >-
-            mdbook-alerts@0.7.0,
-            mdbook-linkcheck@0.7.7
+          mdbook-version: '0.5.2'
 
       - run: mdbook build docs
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -2,14 +2,9 @@
 title = "jco"
 authors = ["Guy Bedford", "Yosh Wuyts", "Victor Adossi"]
 language = "en"
-multilingual = false
 
 src = "src"
 
 [output.html]
 git-repository-url = "https://github.com/bytecodealliance/jco"
 edit-url-template = "https://github.com/bytecodealliance/jco/tree/main/docs/{path}"
-
-[preprocessor.alerts]
-
-[output.linkcheck]

--- a/docs/src/troubleshooting/common-issues.md
+++ b/docs/src/troubleshooting/common-issues.md
@@ -1,0 +1,1 @@
+# Common issues

--- a/docs/src/wit-type-representations.md
+++ b/docs/src/wit-type-representations.md
@@ -135,10 +135,10 @@ option<string, u32>
 
 Jco represents options as an optional value or undefined, so some examples:
 
-| Type                  | Representation (TS)                     | Example                               |
-|-----------------------|-----------------------------------------|---------------------------------------|
-| `option<u32>`         | <code>number \| undefined</code>                    | `option<u32>` -> <code>number \| undefined</code> |
-| `option<option<u32>>` | <code>{ tag: "some" \| "none", val: number }</code> | `option<u32>` -> <code>number \| undefined</code> |
+| Type                  | Representation (TS)                      | Example                                |
+|-----------------------|------------------------------------------|----------------------------------------|
+| `option<u32>`         | `number \| undefined`                    | `option<u32>` -> `number \| undefined` |
+| `option<option<u32>>` | `{ tag: "some" \| "none", val: number }` | `option<u32>` -> `number \| undefined` |
 
 > [!WARNING]
 > "single level" `option`s are easy to reason about, but the doubly nested case (`option<option<_>>`) is more complex.


### PR DESCRIPTION
This commit updates `mdbook` to the latest 0.5.x, so that version is used in CI.

Unfortunately, this update breaks the linkcheck and alerts machinery that we were using, but the built in support works well (except for linkcheck).

As it seems the upstream projects are now behind/not frequently maintained, keeping up to date with mdbook is the higher priority.

Resolves #630