### PR TITLE
fix(ci): use git cliff path filtering for jco-std

### DIFF
--- a/packages/jco-std/cliff.toml
+++ b/packages/jco-std/cliff.toml
@@ -79,3 +79,7 @@ tag_pattern = "^jco-std-v[0-9]+.[0-9]+.[0-9]+(-beta|-rc|-alpha)?"
 link_parsers = [
     { pattern = "\\(#(\\d+)\\)$", href = "https://github.com/bytecodealliance/jco/pull/$1" },
 ]
+
+include_paths = [
+    "packages/jco-std/**/*",
+]


### PR DESCRIPTION
This commit adds path filtering to git-cliff for use when generating changelogs and releases for jco-std.