### PR TITLE
fix(ci): use git-cliff path filtering

### DIFF
--- a/crates/js-component-bindgen/cliff.toml
+++ b/crates/js-component-bindgen/cliff.toml
@@ -79,3 +79,8 @@ tag_pattern = "^js-component-bindgen-v[0-9]+.[0-9]+.[0-9]+(-beta|-rc|-alpha)?"
 link_parsers = [
     { pattern = "\\(#(\\d+)\\)$", href = "https://github.com/bytecodealliance/jco/pull/$1" },
 ]
+
+include_paths = [
+    "crates/js-component-bindgen/**/*",
+    "crates/js-component-bindgen-component/**/*",
+]

--- a/packages/jco-transpile/cliff.toml
+++ b/packages/jco-transpile/cliff.toml
@@ -79,3 +79,7 @@ tag_pattern = "^jco-transpile-v[0-9]+.[0-9]+.[0-9]+(-beta|-rc|-alpha)?"
 link_parsers = [
     { pattern = "\\(#(\\d+)\\)$", href = "https://github.com/bytecodealliance/jco/pull/$1" },
 ]
+
+include_paths = [
+    "packages/jco-transpile/**/*",
+]

--- a/packages/jco/cliff.toml
+++ b/packages/jco/cliff.toml
@@ -79,3 +79,7 @@ tag_pattern = "^jco-v[0-9]+.[0-9]+.[0-9]+(-beta|-rc|-alpha)?"
 link_parsers = [
     { pattern = "\\(#(\\d+)\\)$", href = "https://github.com/bytecodealliance/jco/pull/$1" },
 ]
+
+include_paths = [
+    "packages/jco/**/*",
+]

--- a/packages/preview2-shim/cliff.toml
+++ b/packages/preview2-shim/cliff.toml
@@ -79,3 +79,7 @@ tag_pattern = "^preview2-shim-v[0-9]+.[0-9]+.[0-9]+(-beta|-rc|-alpha)?"
 link_parsers = [
     { pattern = "\\(#(\\d+)\\)$", href = "https://github.com/bytecodealliance/jco/pull/$1" },
 ]
+
+include_paths = [
+    "packages/preview2-shim/**/*",
+]

--- a/packages/preview3-shim/cliff.toml
+++ b/packages/preview3-shim/cliff.toml
@@ -79,3 +79,7 @@ tag_pattern = "^preview3-shim-v[0-9]+.[0-9]+.[0-9]+(-beta|-rc|-alpha)?"
 link_parsers = [
     { pattern = "\\(#(\\d+)\\)$", href = "https://github.com/bytecodealliance/jco/pull/$1" },
 ]
+
+include_paths = [
+    "packages/preview3-shim/**/*",
+]


### PR DESCRIPTION
This commit updates all subprojects that use git cliff to use path filtering.