### PR TITLE
fix: let instead of const on `backpressureCleared`

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/component.rs
+++ b/crates/js-component-bindgen/src/intrinsics/component.rs
@@ -220,7 +220,7 @@ impl ComponentIntrinsic {
                         hasBackpressure() {{ return this.#backpressure > 0; }}
 
                         waitForBackpressure() {{
-                            const backpressureCleared = false;
+                            let backpressureCleared = false;
                             const cstate = this;
                             cstate.addBackpressureWaiter();
                             const handlerID = this.registerHandler({{


### PR DESCRIPTION
`const backpressureCleared` is reassigned, so it fails to compile. Set to let instead.