### PR TITLE
test(jco): impove fixed length list test

### DIFF
--- a/packages/jco/test/cm/fixed-length-lists.js
+++ b/packages/jco/test/cm/fixed-length-lists.js
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 
-import { suite, test } from "vitest";
+import { suite, test, assert } from "vitest";
 
 import { setupAsyncTest } from "../helpers.js";
 import { LOCAL_TEST_COMPONENTS_DIR } from "../common.js";
@@ -8,15 +8,24 @@ import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
 
 suite("fixed length lists", () => {
     test("transpile", async () => {
-        const { cleanup } = await setupAsyncTest({
+        const { cleanup, instance } = await setupAsyncTest({
             component: {
                 path: join(LOCAL_TEST_COMPONENTS_DIR, "fixed-length-lists.wasm"),
                 imports: new WASIShim().getImportObject(),
             },
-            jco: {
-                transpile: {},
-            },
+            // jco: {
+            //     transpile: {
+            //         extraArgs: {
+            //             minify: false,
+            //         }
+            //     },
+            // },
         });
+
+        const input = [...new Array(17)].map(() => Math.random() <= 0.5);
+        const output = instance["jco:test-components/fixed-length-lists-fn"].takesReturnsFixed(input);
+        assert.lengthOf(output, 32);
+        assert.deepEqual(output, input.map(Number).concat([...new Array(32 - 17)].map(() => 0)));
 
         await cleanup();
     });


### PR DESCRIPTION
While fixed length list are under test in other areas of the codebase, the happy-path non-async usage test was underspecified.

This commit improves the fixed length list test which was testing compilation but *not* functionality of the added fixed length list feature.