### PR TITLE
Fix getGlobalCurrentTaskMeta null handling

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -884,7 +884,7 @@ impl Intrinsic {
                     r#"
                       function {get_current_global_task_meta_fn}(componentIdx) {{
                           const v = {global_current_task_meta_obj}[componentIdx];
-                          if (v === undefined) {{ return v; }}
+                          if (v === undefined || v === null) {{ return undefined; }}
                           return {{ ...v }};
                       }}
                     "#,


### PR DESCRIPTION
## Description

`_getGlobalCurrentTaskMeta` treats a cleared task slot (`null`) as a valid meta object. `_clearCurrentTask` sets `CURRENT_TASK_META[componentIdx] = null`, but the getter only checks for `undefined`, so `null` passes through and `{...null}` returns `{}` truthy, but with no `taskID`. This causes `_lowerImportBackwardsCompat` to skip its auto-task-creation fallback and throw `invalid/missing async task meta`.

This shows up when an import fires between two export calls. Export trampolines for types that need allocation (strings, lists, etc.) call `realloc` via `_utf8AllocateAndEncode` before creating their task. If the component has imports wired into internal functions (allocator internals like `dlmalloc::memalign`), those imports go through `_lowerImportBackwardsCompat` in a window where `CURRENT_TASK_META` is `null` from the previous export's cleanup but no new task exists yet.

```
Error: invalid/missing async task meta
    at _lowerImportBackwardsCompat (component.js)
    at component.wasm._ZN8dlmalloc8dlmalloc17Dlmalloc$LT$A$GT$8memalign17h4d574c3a3414c418E
```

The fix adds a `null` check alongside the existing `undefined` check in the intrinsic codegen. A codegen test is added to `initialization.js` that transpiles the `non-wizered-init` component and verifies the generated `_getGlobalCurrentTaskMeta` includes the null check. This is a string match on generated code rather than a behavioral test, a proper integration test would need a component with imports wired into allocator internals to actually trigger the crash, which is hard to set up generically. The codegen assertion is a pragmatic alternative that catches accidental removal of the null check. I'll file a [follow-up issue](https://github.com/bytecodealliance/jco/issues/1379) for a behavioral test that exercises the actual failure path.