### PR TITLE
feat(bindgen): p3 futures support

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1456,7 +1456,7 @@ impl Bindgen for FunctionBindgen<'_> {
                         const started = await task.enter();
                         if (!started) {{
                             {debug_log_fn}('[Instruction::AsyncTaskReturn] failed to enter task', {{
-                                taskID: preparedTask.id(),
+                                taskID: task.id(),
                                 subtaskID: currentSubtask?.id(),
                             }});
                             throw new Error("failed to enter task");
@@ -1646,7 +1646,7 @@ impl Bindgen for FunctionBindgen<'_> {
                         const started = await task.enter({{ isHost: hostProvided }});
                         if (!started) {{
                             {debug_log_fn}('[Instruction::CallInterface] failed to enter task', {{
-                                taskID: preparedTask.id(),
+                                taskID: task.id(),
                                 subtaskID: currentSubtask?.id(),
                             }});
                             throw new Error("failed to enter task");
@@ -2612,84 +2612,92 @@ impl Bindgen for FunctionBindgen<'_> {
             }
 
             Instruction::FutureLift { payload, ty } => {
-                let future_ty = &crate::dealias(self.resolve, *ty);
+                let future_new_from_lift_fn = self.intrinsic(Intrinsic::AsyncFuture(
+                    AsyncFutureIntrinsic::FutureNewFromLift,
+                ));
 
-                // TODO: we must generate the lifting function *before* function bindgen happens
-                // (see commented async param lift code generation), because inside here
-                // we do not have access to the interface types required to generate
-                //
-                // Alternatively, we can implement gen_flat_{lift,lower}_fn_js_expr for
-                // TypeDefs with a resolve as well (and make sure the code works with either)
-                //
-                // TODO(breaking): consider adding more information to bindgen (pointer to component types?)
-                match payload {
-                    Some(payload_ty) => {
-                        match payload_ty {
-                            // TODO: reuse existing lifts
-                            Type::Bool
-                            | Type::U8
-                            | Type::U16
-                            | Type::U32
-                            | Type::U64
-                            | Type::S8
-                            | Type::S16
-                            | Type::S32
-                            | Type::S64
-                            | Type::F32
-                            | Type::F64
-                            | Type::Char
-                            | Type::String
-                            | Type::ErrorContext => uwriteln!(
-                                self.src,
-                                "const payloadLiftFn = () => {{ throw new Error('lift for {payload_ty:?}'); }}",
-                            ),
-                            Type::Id(payload_ty_id) => {
-                                if self.resource_map.contains_key(payload_ty_id) {
-                                    let ResourceTable { data, .. } =
-                                        &self.resource_map[payload_ty_id];
-                                    uwriteln!(
-                                        self.src,
-                                        "const payloadLiftFn = () => {{ throw new Error('lift for {} (identifier {})'); }}",
-                                        payload_ty_id.index(),
-                                        match data {
-                                            ResourceData::Host { local_name, .. } => local_name,
-                                            ResourceData::Guest { resource_name, .. } =>
-                                                resource_name,
-                                        }
-                                    );
-                                } else {
-                                    // TODO: generate lift fns (see TODO above)
-                                    // NOTE: the missing type here is normally a result with nested types...
-                                    // the resource_map may not be indexing these properly
-                                    //
-                                    // eprintln!("warning: missing resource map def {:#?}", self.resolve.types[*payload_ty_id]);
-                                }
-                            }
+                // We must look up the type idx to find the future
+                let type_id = &crate::dealias(self.resolve, *ty);
+                let ResourceTable {
+                    imported: true,
+                    data:
+                        ResourceData::Guest {
+                            extra:
+                                Some(ResourceExtraData::Future {
+                                    table_idx: future_table_idx_ty,
+                                    elem_ty: future_element_ty,
+                                }),
+                            ..
+                        },
+                } = self
+                    .resource_map
+                    .get(type_id)
+                    .expect("missing resource mapping for future lift")
+                else {
+                    unreachable!("invalid resource table observed during future lift");
+                };
+
+                // if a future element is present, it should match the payload we're getting
+                let (lift_fn_js, lower_fn_js) = match future_element_ty {
+                    Some(PayloadTypeMetadata {
+                        ty,
+                        lift_js_expr,
+                        lower_js_expr,
+                        ..
+                    }) => {
+                        assert_eq!(Some(*ty), **payload, "future element type mismatch");
+                        (lift_js_expr.to_string(), lower_js_expr.to_string())
+                    }
+                    None => (
+                        "() => {{ throw new Error('no lift fn'); }}".into(),
+                        "() => {{ throw new Error('no lower fn'); }}".into(),
+                    ),
+                };
+                if let Some(PayloadTypeMetadata { ty, .. }) = future_element_ty {
+                    assert_eq!(Some(*ty), **payload, "future element type mismatch");
+                }
+
+                let tmp = self.tmp();
+                let result_var = format!("futureResult{tmp}");
+
+                // We only need to attempt to do an immediate lift in non-async cases,
+                // as the return of the function execution ('above' in the code)
+                // will be the future idx
+                if !self.is_async {
+                    // If we're dealing with a sync function, we can use the return directly
+                    let arg_future_end_idx = operands
+                        .first()
+                        .expect("unexpectedly missing future end return arg in FutureLift");
+
+                    let (payload_ty_size32_js, payload_ty_align32_js) =
+                        if let Some(payload_ty) = payload {
+                            (
+                                self.sizes.size(payload_ty).size_wasm32().to_string(),
+                                self.sizes.align(payload_ty).align_wasm32().to_string(),
+                            )
+                        } else {
+                            ("null".into(), "null".into())
                         };
 
-                        // // TODO: save payload type size below and more information about the type w/ the future?
-                        // let payload_ty_size = self.sizes.size(payload_ty).size_wasm32();
+                    let future_table_idx = future_table_idx_ty.as_u32();
+                    let component_idx = self.canon_opts.instance.as_u32();
 
-                        // NOTE: here, rather than create a new `Future` "resource" using the saved
-                        // ResourceData, we use the future.new intrinsic directly.
-                        //
-                        // TODO: differentiate "locally" created futures and futures that are lifted in?
-                        //
-                        let tmp = self.tmp();
-                        let result_var = format!("futureResult{tmp}");
-                        let component_idx = self.canon_opts.instance.as_u32();
-                        let future_new_fn =
-                            self.intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureNew));
-                        uwriteln!(
-                            self.src,
-                            "const {result_var} = {future_new_fn}({{ componentIdx: {component_idx}, futureTypeRep: {} }});",
-                            future_ty.index(),
-                        );
-                        results.push(result_var.clone());
-                    }
-
-                    None => unreachable!("future with no payload unsupported"),
+                    uwriteln!(
+                        self.src,
+                        "
+                        const {result_var} = {future_new_from_lift_fn}({{
+                            componentIdx: {component_idx},
+                            futureTableIdx: {future_table_idx},
+                            futureEndWaitableIdx: {arg_future_end_idx},
+                            payloadLiftFn: {lift_fn_js},
+                            payloadLowerFn: {lower_fn_js},
+                            payloadTypeSize32: {payload_ty_size32_js},
+                            payloadTypeAlign32: {payload_ty_align32_js},
+                        }});",
+                    );
                 }
+
+                results.push(result_var.clone());
             }
 
             Instruction::StreamLower { ty, .. } => {
@@ -2928,7 +2936,6 @@ impl Bindgen for FunctionBindgen<'_> {
                         };
 
                     let stream_table_idx = stream_table_idx_ty.as_u32();
-                    let is_unit_stream = payload.is_none();
 
                     uwriteln!(
                         self.src,
@@ -2941,7 +2948,6 @@ impl Bindgen for FunctionBindgen<'_> {
                             payloadLowerFn: {lower_fn_js},
                             payloadTypeSize32: {payload_ty_size32_js},
                             payloadTypeAlign32: {payload_ty_align32_js},
-                            isUnitStream: {is_unit_stream},
                         }});",
                     );
                 }

--- a/crates/js-component-bindgen/src/intrinsics/component.rs
+++ b/crates/js-component-bindgen/src/intrinsics/component.rs
@@ -1,12 +1,13 @@
 //! Intrinsics that represent helpers that manage per-component state
 
-use crate::{
-    intrinsics::{
-        Intrinsic,
-        p3::{async_stream::AsyncStreamIntrinsic, waitable::WaitableIntrinsic},
-    },
-    source::Source,
-};
+use std::fmt::Write as _;
+
+use crate::intrinsics::Intrinsic;
+use crate::intrinsics::p3::async_future::AsyncFutureIntrinsic;
+use crate::intrinsics::p3::async_stream::AsyncStreamIntrinsic;
+use crate::intrinsics::p3::waitable::WaitableIntrinsic;
+use crate::source::Source;
+use crate::uwriteln;
 
 /// This enum contains intrinsics that manage per-component state
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
@@ -84,7 +85,7 @@ impl ComponentIntrinsic {
         match self {
             Self::GlobalAsyncStateMap => {
                 let var_name = Self::GlobalAsyncStateMap.name();
-                output.push_str(&format!("const {var_name} = new Map();\n"));
+                uwriteln!(output, r#"const {var_name} = new Map();"#);
             }
 
             Self::BackpressureInc => {
@@ -127,6 +128,9 @@ impl ComponentIntrinsic {
                 let internal_stream_class = AsyncStreamIntrinsic::InternalStreamClass.name();
                 let global_stream_map = AsyncStreamIntrinsic::GlobalStreamMap.name();
                 let global_stream_table_map = AsyncStreamIntrinsic::GlobalStreamTableMap.name();
+                let internal_future_class = AsyncFutureIntrinsic::InternalFutureClass.name();
+                let global_future_map = AsyncFutureIntrinsic::GlobalFutureMap.name();
+                let global_future_table_map = AsyncFutureIntrinsic::GlobalFutureTableMap.name();
                 let waitable_class = Intrinsic::Waitable(WaitableIntrinsic::WaitableClass).name();
                 let get_or_create_async_state_fn = Self::GetOrCreateAsyncState.name();
                 let promise_with_resolvers_fn = Intrinsic::PromiseWithResolversPonyfill.name();
@@ -655,6 +659,128 @@ impl ComponentIntrinsic {
 
                             return streamEnd;
                         }}
+
+                        createFuture(args) {{
+                            {debug_log_fn}('[{component_async_state_class}#createFuture()] args', args);
+                            const {{ tableIdx, elemMeta, hostInjectFn }} = args;
+                            if (tableIdx === undefined) {{ throw new Error("missing table idx while adding future"); }}
+                            if (elemMeta === undefined) {{ throw new Error("missing element metadata while adding future"); }}
+
+                            const {{ table: futureTable, componentIdx }} = {global_future_table_map}[tableIdx];
+                            if (!futureTable) {{
+                                throw new Error(`missing global future table lookup for table [${{tableIdx}}] while creating future`);
+                            }}
+                            if (componentIdx !== this.#componentIdx) {{
+                                throw new Error('component idx mismatch while creating future');
+                            }}
+
+                            const readWaitable = this.createWaitable();
+                            const writeWaitable = this.createWaitable();
+
+                            const future = new {internal_future_class}({{
+                                tableIdx,
+                                componentIdx: this.#componentIdx,
+                                elemMeta,
+                                readWaitable,
+                                writeWaitable,
+                                hostInjectFn,
+                            }});
+                            future.setGlobalFutureMapRep({global_future_map}.insert(future));
+
+                            const writeEnd = future.writeEnd();
+                            writeEnd.setWaitableIdx(this.handles.insert(writeEnd));
+                            writeEnd.setHandle(futureTable.insert(writeEnd));
+                            if (writeEnd.futureTableIdx() !== tableIdx) {{ throw new Error("unexpectedly mismatched future table"); }}
+
+                            const writeEndWaitableIdx = writeEnd.waitableIdx();
+                            const writeEndHandle = writeEnd.handle();
+                            writeWaitable.setTarget(`waitable for future write end (waitable [${{writeEndWaitableIdx}}])`);
+                            writeEnd.setTarget(`future write end (waitable [${{writeEndWaitableIdx}}])`);
+
+                            const readEnd = future.readEnd();
+                            readEnd.setWaitableIdx(this.handles.insert(readEnd));
+                            readEnd.setHandle(futureTable.insert(readEnd));
+                            if (readEnd.futureTableIdx() !== tableIdx) {{ throw new Error("unexpectedly mismatched future table"); }}
+
+                            const readEndWaitableIdx = readEnd.waitableIdx();
+                            const readEndHandle = readEnd.handle();
+                            readWaitable.setTarget(`waitable for read end (waitable [${{readEndWaitableIdx}}])`);
+                            readEnd.setTarget(`future read end (waitable [${{readEndWaitableIdx}}])`);
+
+                            return {{
+                                writeEnd,
+                                writeEndWaitableIdx,
+                                writeEndHandle,
+                                readEndWaitableIdx,
+                                readEndHandle,
+                                readEnd,
+                            }};
+                        }}
+
+                        getFutureEnd(args) {{
+                            {debug_log_fn}('[{component_async_state_class}#getFutureEnd()] args', args);
+                            const {{ tableIdx, futureEndHandle, futureEndWaitableIdx }} = args;
+                            if (tableIdx === undefined) {{
+                                throw new Error('missing table idx while getting future end');
+                            }}
+
+                            const {{ table, componentIdx }} = {global_future_table_map}[tableIdx];
+                            const cstate = {get_or_create_async_state_fn}(componentIdx);
+
+                            let futureEnd;
+                            if (futureEndWaitableIdx !== undefined) {{
+                                futureEnd = cstate.handles.get(futureEndWaitableIdx);
+                            }} else if (futureEndHandle !== undefined) {{
+                                if (!table) {{ throw new Error(`missing/invalid table [${{tableIdx}}] while getting future end`); }}
+                                futureEnd = table.get(futureEndHandle);
+                            }} else {{
+                                console.log("args?", args);
+                                throw new TypeError("must specify either waitable idx or handle to retrieve future");
+                            }}
+
+                            if (!futureEnd) {{
+                                throw new Error(`missing future end (tableIdx [${{tableIdx}}], handle [${{futureEndHandle}}], waitableIdx [${{futureEndWaitableIdx}}])`);
+                            }}
+                            if (tableIdx && futureEnd.futureTableIdx() !== tableIdx) {{
+                                throw new Error(`future end table idx [${{futureEnd.futureTableIdx()}}] does not match [${{tableIdx}}]`);
+                            }}
+
+                            return futureEnd;
+                        }}
+
+                        removeFutureEndFromTable(args) {{
+                            {debug_log_fn}('[{component_async_state_class}#removeFutureEndFromTable()] args', args);
+
+                            const {{ tableIdx, futureWaitableIdx }} = args;
+                            if (tableIdx === undefined) {{ throw new Error("missing table idx while removing future end"); }}
+                            if (futureWaitableIdx === undefined) {{
+                                throw new Error("missing future end waitable idx while removing future end");
+                            }}
+
+                            const {{ table, componentIdx }} = {global_future_table_map}[tableIdx];
+                            if (!table) {{ throw new Error(`missing/invalid table [${{tableIdx}}] while removing future end`); }}
+
+                            const cstate = {get_or_create_async_state_fn}(componentIdx);
+
+                            const futureEnd = cstate.handles.get(futureWaitableIdx);
+                            if (!futureEnd) {{
+                                throw new Error(`missing future end (handle [${{futureWaitableIdx}}], table [${{tableIdx}}])`);
+                            }}
+                            const handle = futureEnd.handle();
+
+                            let removed = cstate.handles.remove(futureWaitableIdx);
+                            if (!removed) {{
+                                throw new Error(`failed to remove futureEnd from handles (waitable idx [${{futureWaitableIdx}}]), component [${{componentIdx}}])`);
+                            }}
+
+                            removed = table.remove(handle);
+                            if (!removed) {{
+                                throw new Error(`failed to remove futureEnd from table (handle [${{handle}}]), table [${{tableIdx}}], component [${{componentIdx}}])`);
+                            }}
+
+                            return futureEnd;
+                        }}
+
                     }}
                     "#,
                 ));

--- a/crates/js-component-bindgen/src/intrinsics/conversion.rs
+++ b/crates/js-component-bindgen/src/intrinsics/conversion.rs
@@ -1,6 +1,10 @@
 //! Intrinsics that represent helpers perform conversions
 
-use crate::{intrinsics::Intrinsic, source::Source};
+use std::fmt::Write;
+
+use crate::intrinsics::Intrinsic;
+use crate::source::Source;
+use crate::uwriteln;
 
 /// This enum contains intrinsics that help perform type conversions
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
@@ -115,41 +119,102 @@ impl ConversionIntrinsic {
                 const i64ToF64 = i => (i64ToF64I[0] = i, i64ToF64F[0]);
             ",
             ),
-            Self::ToBigInt64 => output.push_str("
-                const toInt64 = val => BigInt.asIntN(64, BigInt(val));
+
+            Self::F64ToI64 => output.push_str("
+                const f64ToI64 = f => (i64ToF64F[0] = f, i64ToF64I[0]);
             "),
 
-            Self::ToBigUint64 => output.push_str("
-                const toUint64 = val => BigInt.asUintN(64, BigInt(val));
-            "),
+            Self::ToBigInt64 => {
+                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                uwriteln!(
+                    output,
+                    r#"
+                      function toInt64(val) {{
+                          const converted = BigInt(val)
+                          {ensure_valid_numeric_primitive_fn}('s64', converted);
+                          return BigInt.asIntN(64, converted);
+                      }}
+                    "#
+                )
+            },
 
-            Self::ToInt16 => output.push_str("
-                function toInt16(val) {
-                    val >>>= 0;
-                    val %= 2 ** 16;
-                    if (val >= 2 ** 15) {
-                        val -= 2 ** 16;
-                    }
-                    return val;
-                }
-            "),
+            Self::ToBigUint64 => {
+                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                uwriteln!(
+                    output,
+                    r#"
+                      function toUint64(val) {{
+                          const converted = BigInt(val)
+                          {ensure_valid_numeric_primitive_fn}('u64', converted);
+                          return BigInt.asUintN(64, converted);
+                      }}
+                    "#
+                );
+            },
 
-            Self::ToInt32 => output.push_str("
-                function toInt32(val) {
-                    return val >> 0;
-                }
-            "),
+            Self::ToInt16 => {
+                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                uwriteln!(
+                    output,
+                    r#"
+                      function toInt16(val) {{
+                          {ensure_valid_numeric_primitive_fn}('s16', val);
+                          val >>>= 0;
+                          val %= 2 ** 16;
+                          if (val >= 2 ** 15) {{
+                              val -= 2 ** 16;
+                          }}
+                          return val;
+                      }}
+                    "#
+                );
+            },
 
-            Self::ToInt8 => output.push_str("
-                function toInt8(val) {
-                    val >>>= 0;
-                    val %= 2 ** 8;
-                    if (val >= 2 ** 7) {
-                        val -= 2 ** 8;
-                    }
-                    return val;
-                }
-            "),
+            Self::ToUint16 => {
+                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                uwriteln!(
+                    output,
+                    r#"
+                      function toUint16(val) {{
+                          {ensure_valid_numeric_primitive_fn}('u16', val);
+                          val >>>= 0;
+                          val %= 2 ** 16;
+                          return val;
+                      }}
+                    "#
+                )
+            },
+
+            Self::ToInt32 => {
+                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                uwriteln!(
+                    output,
+                    r#"
+                      function toInt32(val) {{
+                          {ensure_valid_numeric_primitive_fn}('s32', val);
+                          return val >> 0;
+                      }}
+                    "#
+                );
+            },
+
+            Self::ToInt8 => {
+                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                uwriteln!(
+                    output,
+                    r#"
+                      function toInt8(val) {{
+                          {ensure_valid_numeric_primitive_fn}('s8', val);
+                          val >>>= 0;
+                          val %= 2 ** 8;
+                          if (val >= 2 ** 7) {{
+                              val -= 2 ** 8;
+                          }}
+                          return val;
+                      }}
+                   "#
+                );
+            },
 
             Self::ToResultString => output.push_str("
                 function toResultString(obj) {
@@ -171,31 +236,34 @@ impl ConversionIntrinsic {
                 }
             "),
 
-            Self::ToUint16 => output.push_str("
-                function toUint16(val) {
-                    val >>>= 0;
-                    val %= 2 ** 16;
-                    return val;
-                }
-            "),
 
-            Self::ToUint32 => output.push_str("
-                function toUint32(val) {
-                    return val >>> 0;
-                }
-            "),
+            Self::ToUint32 => {
+                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                uwriteln!(
+                    output,
+                    r#"
+                      function toUint32(val) {{
+                          {ensure_valid_numeric_primitive_fn}('u32', val);
+                          return val >>> 0;
+                      }}
+                    "#
+                )
+            },
 
-            Self::ToUint8 => output.push_str("
-                function toUint8(val) {
-                    val >>>= 0;
-                    val %= 2 ** 8;
-                    return val;
-                }
-            "),
-
-            Self::F64ToI64 => output.push_str("
-                const f64ToI64 = f => (i64ToF64F[0] = f, i64ToF64I[0]);
-            "),
+            Self::ToUint8 => {
+                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                uwriteln!(
+                    output,
+                    r#"
+                      function toUint8(val) {{
+                          {ensure_valid_numeric_primitive_fn}('u8', val);
+                          val >>>= 0;
+                          val %= 2 ** 8;
+                          return val;
+                      }}
+                    "#
+                );
+            },
 
             Self::I32ToChar => {
                 output.push_str("

--- a/crates/js-component-bindgen/src/intrinsics/lift.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lift.rs
@@ -1,11 +1,14 @@
 //! Intrinsics that represent helpers that enable Lift integration
+use std::fmt::Write;
 
 use crate::intrinsics::Intrinsic;
 use crate::intrinsics::component::ComponentIntrinsic;
+use crate::intrinsics::p3::async_future::AsyncFutureIntrinsic;
 use crate::intrinsics::p3::async_stream::AsyncStreamIntrinsic;
 use crate::intrinsics::p3::error_context::ErrCtxIntrinsic;
 use crate::intrinsics::string::StringIntrinsic;
 use crate::source::Source;
+use crate::uwriteln;
 
 use super::conversion::ConversionIntrinsic;
 
@@ -251,7 +254,10 @@ impl LiftIntrinsic {
             Self::LiftFlatBool => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_bool_fn = self.name();
-                output.push_str(&format!("
+
+                uwriteln!(
+                    output,
+                    r#"
                     function {lift_flat_bool_fn}(ctx) {{
                         {debug_log_fn}('[{lift_flat_bool_fn}()] args', {{ ctx }});
                         let val;
@@ -274,13 +280,17 @@ impl LiftIntrinsic {
 
                         return [val, ctx];
                     }}
-                "));
+                "#
+                );
             }
 
             Self::LiftFlatS8 => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_s8_fn = self.name();
-                output.push_str(&format!("
+
+                uwriteln!(
+                    output,
+                    r#"
                     function {lift_flat_s8_fn}(ctx) {{
                         {debug_log_fn}('[{lift_flat_s8_fn}()] args', {{ ctx }});
                         let val;
@@ -302,13 +312,17 @@ impl LiftIntrinsic {
 
                         return [val, ctx];
                     }}
-                "));
+                "#
+                );
             }
 
             Self::LiftFlatU8 => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_u8_fn = self.name();
-                output.push_str(&format!(r#"
+
+                uwriteln!(
+                    output,
+                    r#"
                     function {lift_flat_u8_fn}(ctx) {{
                         {debug_log_fn}('[{lift_flat_u8_fn}()] args', {{ ctx }});
                         let val;
@@ -331,13 +345,17 @@ impl LiftIntrinsic {
 
                         return [val, ctx];
                     }}
-                "#));
+                "#
+                );
             }
 
             Self::LiftFlatS16 => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_s16_fn = self.name();
-                output.push_str(&format!("
+
+                uwriteln!(
+                    output,
+                    r#"
                     function {lift_flat_s16_fn}(ctx) {{
                         {debug_log_fn}('[{lift_flat_s16_fn}()] args', {{ ctx }});
                         let val;
@@ -359,13 +377,17 @@ impl LiftIntrinsic {
 
                         return [val, ctx];
                     }}
-                "));
+                "#
+                );
             }
 
             Self::LiftFlatU16 => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_u16_fn = self.name();
-                output.push_str(&format!("
+
+                uwriteln!(
+                    output,
+                    r#"
                     function {lift_flat_u16_fn}(ctx) {{
                         {debug_log_fn}('[{lift_flat_u16_fn}()] args', {{ ctx }});
                         let val;
@@ -391,13 +413,17 @@ impl LiftIntrinsic {
 
                         return [val, ctx];
                     }}
-                "));
+                "#
+                );
             }
 
             Self::LiftFlatS32 => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_s32_fn = self.name();
-                output.push_str(&format!("
+
+                uwriteln!(
+                    output,
+                    r#"
                     function {lift_flat_s32_fn}(ctx) {{
                         {debug_log_fn}('[{lift_flat_s32_fn}()] args', {{ ctx }});
                         let val;
@@ -419,13 +445,17 @@ impl LiftIntrinsic {
 
                         return [val, ctx];
                     }}
-                "));
+                "#
+                );
             }
 
             Self::LiftFlatU32 => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_u32_fn = self.name();
-                output.push_str(&format!(r#"
+
+                uwriteln!(
+                    output,
+                    r#"
                     function {lift_flat_u32_fn}(ctx) {{
                         {debug_log_fn}('[{lift_flat_u32_fn}()] args', {{ ctx }});
                         let val;
@@ -446,13 +476,17 @@ impl LiftIntrinsic {
 
                         return [val, ctx];
                     }}
-                "#));
+                "#
+                );
             }
 
             Self::LiftFlatS64 => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_s64_fn = self.name();
-                output.push_str(&format!("
+
+                uwriteln!(
+                    output,
+                    r#"
                     function {lift_flat_s64_fn}(ctx) {{
                         {debug_log_fn}('[{lift_flat_s64_fn}()] args', {{ ctx }});
                         let val;
@@ -476,13 +510,17 @@ impl LiftIntrinsic {
 
                         return [val, ctx];
                     }}
-                "));
+                "#
+                );
             }
 
             Self::LiftFlatU64 => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_u64_fn = self.name();
-                output.push_str(&format!("
+
+                uwriteln!(
+                    output,
+                    r#"
                     function {lift_flat_u64_fn}(ctx) {{
                         {debug_log_fn}('[{lift_flat_u64_fn}()] args', {{ ctx }});
                         let val;
@@ -505,13 +543,17 @@ impl LiftIntrinsic {
 
                         return [val, ctx];
                     }}
-                "));
+                "#
+                );
             }
 
             Self::LiftFlatFloat32 => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_f32_fn = self.name();
-                output.push_str(&format!("
+
+                uwriteln!(
+                    output,
+                    r#"
                     function {lift_flat_f32_fn}(ctx) {{
                         {debug_log_fn}('[{lift_flat_f32_fn}()] args', {{ ctx }});
                         let val;
@@ -534,7 +576,8 @@ impl LiftIntrinsic {
 
                         return [val, ctx];
                     }}
-                "));
+                "#
+                );
             }
 
             Self::LiftFlatFloat64 => {
@@ -1029,23 +1072,75 @@ impl LiftIntrinsic {
             Self::LiftFlatBorrow => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_borrow_fn = self.name();
-                output.push_str(&format!("
+                uwriteln!(
+                    output,
+                    r#"
                     function {lift_flat_borrow_fn}(componentTableIdx, size, memory, vals, storagePtr, storageLen) {{
                         {debug_log_fn}('[{lift_flat_borrow_fn}()] args', {{ size, memory, vals, storagePtr, storageLen }});
                         throw new Error('flat lift for borrowed resources is not supported!');
                     }}
-                "));
+                "#
+                );
             }
 
             Self::LiftFlatFuture => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let lift_flat_future_fn = self.name();
-                output.push_str(&format!("
-                    function {lift_flat_future_fn}(componentTableIdx, memory, vals, storagePtr, storageLen) {{
-                        {debug_log_fn}('[{lift_flat_future_fn}()] args', {{ size, memory, vals, storagePtr, storageLen }});
-                        throw new Error('flat lift for futures not yet implemented!');
+                let get_or_create_async_state_fn =
+                    Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
+                let global_future_table_map = AsyncFutureIntrinsic::GlobalFutureTableMap.name();
+                let lift_u32 = Self::LiftFlatU32.name();
+
+                uwriteln!(
+                    output,
+                    r#"
+                    function {lift_flat_future_fn}(meta) {{
+                        const {{
+                            futureTableIdx,
+                            componentIdx,
+                        }} = meta;
+
+                        return function {lift_flat_future_fn}Inner(ctx) {{
+                            {debug_log_fn}('[{lift_flat_future_fn}()] args', {{ ctx }});
+
+                            const futureMeta = {global_future_table_map}[futureTableIdx];
+                            if (futureMeta.componentIdx !== componentIdx) {{
+                                throw new Error('unexpectedly mismatched component idx');
+                            }}
+                            const {{ table }} = futureMeta;
+                            if (componentIdx === undefined || !table) {{
+                                throw new Error(`invalid global future table state for table [${{tableIdx}}]`);
+                            }}
+
+                            let futureEndWaitableIdx;
+                            if (ctx.useDirectParams) {{
+                                futureEndWaitableIdx = ctx.params[0];
+                                ctx.params = ctx.params.slice(1);
+                            }} else {{
+                                const [waitableIdx, newCtx] = {lift_u32}(ctx);
+                                ctx = newCtx;
+                                futureEndWaitableIdx = waitableIdx;
+                            }}
+
+                            if (futureEndWaitableIdx === undefined) {{ throw new Error('missing future idx'); }}
+
+                            const cstate = {get_or_create_async_state_fn}(componentIdx);
+                            if (!cstate) {{ throw new Error(`missing async state for component [${{componentIdx}}]`); }}
+
+                            const futureEnd = cstate.getFutureEnd({{ tableIdx: futureTableIdx, futureEndWaitableIdx }});
+                            if (!futureEnd) {{
+                                throw new Error(`missing future end [${{futureEndWaitableIdx}}] (table [${{futureTableIdx}}]) in component [${{componentIdx}}] during lift`);
+                            }}
+
+                            if (ctx.isBorrowed) {{ throw new Error('cannot lift flat future of borrowed type'); }}
+                            if (futureEnd.isWritable()) {{ throw new Error('only readable futures can be lifted'); }}
+                            if (!futureEnd.isIdleState()) {{ throw new Error('futures must be in idle state'); }}
+
+                            return [ futureEnd.promise(), ctx ];
+                        }};
                     }}
-                "));
+                "#
+                );
             }
 
             Self::LiftFlatStream => {
@@ -1063,9 +1158,6 @@ impl LiftIntrinsic {
                         const {{
                             streamTableIdx,
                             componentIdx,
-                            isBorrowedType,
-                            isNoneType,
-                            isNumericTypeJs,
                         }} = meta;
 
                         return function {lift_flat_stream_fn}Inner(ctx) {{

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -134,12 +134,6 @@ pub enum Intrinsic {
     HasOwnProperty,
     InstantiateCore,
 
-    /// JS helper function for check whether a given type is borrowed
-    ///
-    /// Generally the only kind of type that can be borrowed is a resource
-    /// handle, so this helper checks for that.
-    IsBorrowedType,
-
     /// Tracking of component memories
     GlobalComponentMemoryMap,
 
@@ -475,23 +469,6 @@ impl Intrinsic {
                 ));
             }
 
-            Intrinsic::IsBorrowedType => {
-                let debug_log_fn = Intrinsic::DebugLog.name();
-                let is_borrowed_type_fn = Intrinsic::IsBorrowedType.name();
-                let defined_resource_tables = Intrinsic::DefinedResourceTables.name();
-                output.push_str(&format!("
-                    function {is_borrowed_type_fn}(componentIdx, typeIdx) {{
-                        {debug_log_fn}('[{is_borrowed_type_fn}()] args', {{ componentIdx, typeIdx }});
-                        const table = {defined_resource_tables}[componentIdx];
-                        if (!table) {{ return false; }}
-                        const handle = table[(typeIdx << 1) + 1];
-                        if (!handle) {{ return false; }}
-                        const isOwned = (handle & T_FLAG) !== 0;
-                        return !isOwned;
-                    }}
-                "));
-            }
-
             Intrinsic::ManagedBufferClass => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let managed_buffer_class = Intrinsic::ManagedBufferClass.name();
@@ -660,6 +637,7 @@ impl Intrinsic {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let buffer_manager_class = Intrinsic::BufferManagerClass.name();
                 let managed_buffer_class = Intrinsic::ManagedBufferClass.name();
+
                 output.push_str(&format!(r#"
                     class {buffer_manager_class} {{
                         #buffers = new Map();
@@ -1509,6 +1487,30 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
         ]);
     }
 
+    if args
+        .intrinsics
+        .contains(&Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureNew))
+    {
+        args.intrinsics.extend([
+            &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::GlobalFutureMap),
+            &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::GlobalFutureTableMap),
+            &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureWritableEndClass),
+            &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureReadableEndClass),
+        ]);
+    }
+
+    if args.intrinsics.contains(&Intrinsic::AsyncFuture(
+        AsyncFutureIntrinsic::FutureWritableEndClass,
+    )) || args.intrinsics.contains(&Intrinsic::AsyncFuture(
+        AsyncFutureIntrinsic::FutureReadableEndClass,
+    )) {
+        args.intrinsics.extend([
+            &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::InternalFutureClass),
+            &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureEndClass),
+            &Intrinsic::AsyncEventCodeEnum,
+        ]);
+    }
+
     if args.intrinsics.contains(&Intrinsic::GlobalBufferManager) {
         args.intrinsics.extend([&Intrinsic::BufferManagerClass]);
     }
@@ -1649,7 +1651,6 @@ impl Intrinsic {
             Intrinsic::ConstantI32Min => "I32_MIN",
             Intrinsic::ConstantI32Max => "I32_MAX",
             Intrinsic::TypeCheckValidI32 => "_typeCheckValidI32",
-            Intrinsic::IsBorrowedType => "_isBorrowedType",
             Intrinsic::TypeCheckAsyncFn => "_typeCheckAsyncFn",
             Intrinsic::AsyncFunctionCtor => "ASYNC_FN_CTOR",
 

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
@@ -1,33 +1,51 @@
-//! Intrinsics that represent helpers that enable Stream integration
+//! Intrinsics that represent helpers that enable Future integration
+
+use std::fmt::Write;
 
 use crate::intrinsics::Intrinsic;
 use crate::intrinsics::component::ComponentIntrinsic;
 use crate::source::Source;
+use crate::uwriteln;
 
 use super::async_task::AsyncTaskIntrinsic;
 
-/// This enum contains intrinsics that enable Stream
+/// This enum contains intrinsics that enable Futures
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq)]
 pub enum AsyncFutureIntrinsic {
+    /// Global that stores futures
+    ///
+    /// ```ts
+    /// type i32 = number;
+    /// type FutureEnd = FutureWritableEndClass | FutureReadableEndClass;
+    /// type GlobalFutureMap<T> = Map<i32, FutureEnd>;
+    /// ```
+    GlobalFutureMap,
+
+    /// Map of future tables to component indices
+    GlobalFutureTableMap,
+
     /// The definition of the `FutureWritableEnd` JS class
     ///
     /// This class serves as a shared implementation used by writable and readable ends
     FutureEndClass,
+
+    /// The definition of the `HostFuture` JS class
+    ///
+    /// This class serves as an implementation for top level host-managed futures,
+    /// internal to the bindgen generated logic.
+    ///
+    /// External code is no expected to work in terms of `HostFuture`, but rather deal with `Future`s
+    ///
+    HostFutureClass,
+
+    /// An internal future class that coordinates boht writable and readable ends
+    InternalFutureClass,
 
     /// The definition of the `FutureWritableEnd` JS class
     FutureWritableEndClass,
 
     /// The definition of the `FutureReadableEnd` JS class
     FutureReadableEndClass,
-
-    /// Global that stores futures by component instance
-    ///
-    /// ```ts
-    /// type i32 = number;
-    /// type Future = object; // see FutureClass
-    /// type GlobalFutureMap = Map<i32, Future>;
-    /// ```
-    GlobalFutureMap,
 
     /// Create a new future
     ///
@@ -43,6 +61,22 @@ pub enum AsyncFutureIntrinsic {
     /// function futureNew(typeRep: u32): u64;
     /// ```
     FutureNew,
+
+    /// Create a new future during a lift (`Instruction::FutureLift`).
+    ///
+    /// This is distinct from plain future creation, because we are provided more information,
+    /// particularly the relevant types to teh future and lift/lower fns for the future.
+    ///
+    /// ```ts
+    /// type Ctx = {
+    ///     componentIdx: number,
+    ///     futureTableIdx: number,
+    ///     elemMeta: object,
+    /// }
+    /// function futureNewFromLift(ctx: Ctx);
+    /// ```
+    ///
+    FutureNewFromLift,
 
     /// Read from a future
     ///
@@ -161,6 +195,11 @@ pub enum AsyncFutureIntrinsic {
     /// function futureDropWritable(futureRep: u32, writerRep: u32): bool;
     /// ```
     FutureDropWritable,
+
+    /// Instruction emitted by FACT modules that enables the transfer of a future
+    ///
+    /// See [`Trampoline::FutureTransfer`]
+    FutureTransfer,
 }
 
 impl AsyncFutureIntrinsic {
@@ -171,23 +210,44 @@ impl AsyncFutureIntrinsic {
 
     /// Retrieve global names for this intrinsic
     pub fn get_global_names() -> impl IntoIterator<Item = &'static str> {
-        []
+        [
+            Self::FutureCancelRead.name(),
+            Self::FutureCancelWrite.name(),
+            Self::FutureDropReadable.name(),
+            Self::FutureDropWritable.name(),
+            Self::FutureEndClass.name(),
+            Self::FutureNew.name(),
+            Self::FutureNewFromLift.name(),
+            Self::FutureRead.name(),
+            Self::FutureReadableEndClass.name(),
+            Self::FutureTransfer.name(),
+            Self::FutureWritableEndClass.name(),
+            Self::FutureWrite.name(),
+            Self::GlobalFutureMap.name(),
+            Self::GlobalFutureTableMap.name(),
+            Self::InternalFutureClass.name(),
+        ]
     }
 
     /// Get the name for the intrinsic
     pub fn name(&self) -> &'static str {
         match self {
-            Self::GlobalFutureMap => "FUTURES",
-            Self::FutureEndClass => "FutureEnd",
-            Self::FutureWritableEndClass => "FutureWritableEnd",
-            Self::FutureReadableEndClass => "FutureReadableEnd",
-            Self::FutureNew => "futureNew",
-            Self::FutureRead => "futureRead",
-            Self::FutureWrite => "futureWrite",
-            Self::FutureDropReadable => "futureDropReadable",
-            Self::FutureDropWritable => "futureDropWritable",
             Self::FutureCancelRead => "futureCancelRead",
             Self::FutureCancelWrite => "futureCancelWrite",
+            Self::FutureDropReadable => "futureDropReadable",
+            Self::FutureDropWritable => "futureDropWritable",
+            Self::FutureEndClass => "FutureEnd",
+            Self::FutureNew => "futureNew",
+            Self::FutureNewFromLift => "futureNewFromLift",
+            Self::FutureRead => "futureRead",
+            Self::FutureReadableEndClass => "FutureReadableEnd",
+            Self::FutureTransfer => "futureTransfer",
+            Self::FutureWritableEndClass => "FutureWritableEnd",
+            Self::FutureWrite => "futureWrite",
+            Self::GlobalFutureMap => "FUTURES",
+            Self::GlobalFutureTableMap => "FUTURE_TABLES",
+            Self::HostFutureClass => "HostFuture",
+            Self::InternalFutureClass => "InternalFuture",
         }
     }
 
@@ -198,230 +258,948 @@ impl AsyncFutureIntrinsic {
                 let global_future_map = Self::GlobalFutureMap.name();
                 let rep_table_class = Intrinsic::RepTableClass.name();
                 output.push_str(&format!(
-                    "
-                    const {global_future_map} = new {rep_table_class}();
-                "
+                    r#"
+                    const {global_future_map} = new {rep_table_class}({{ target: 'global future map' }});
+                    "#
+                ));
+            }
+
+            Self::GlobalFutureTableMap => {
+                let global_future_table_map = Self::GlobalFutureTableMap.name();
+                output.push_str(&format!(
+                    r#"
+                    const {global_future_table_map} = {{}};
+                    "#
+                ));
+            }
+
+            // The host future class is used exclusively *inside* the host implementation,
+            // to represent future that have been lifted (or originated) external to a given
+            // component.
+            //
+            // For example, after a component-internal future is lifted from a component (normally
+            // by way of returning it from a function), that future will have been made into a host
+            // future, and *may* give actual end users access via the `createUserFuture()` function.
+            //
+            // At present since futures can only give away the read-end, this usually means that the
+            // host future will be used to often give away the *read* end.
+            //
+            Self::HostFutureClass => {
+                let debug_log_fn = Intrinsic::DebugLog.name();
+                let host_future_class_name = self.name();
+                let get_or_create_async_state_fn =
+                    Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
+                let promise_with_resolvers_fn = Intrinsic::PromiseWithResolversPonyfill.name();
+
+                output.push_str(&format!(
+                    r#"
+                    class {host_future_class_name} {{
+                        #componentIdx;
+                        #futureEndWaitableIdx;
+                        #futureTableIdx;
+
+                        #payloadLiftFn;
+                        #payloadLowerFn;
+
+                        #userFuture;
+
+                        #rep = null;
+
+                        constructor(args) {{
+                            {debug_log_fn}('[{host_future_class_name}#constructor()] args', args);
+                            if (args.componentIdx === undefined) {{ throw new TypeError("missing component idx"); }}
+                            this.#componentIdx = args.componentIdx;
+
+                            if (!args.payloadLiftFn) {{ throw new TypeError("missing payload lift fn"); }}
+                            this.#payloadLiftFn = args.payloadLiftFn;
+
+                            if (!args.payloadLowerFn) {{ throw new TypeError("missing payload lower fn"); }}
+                            this.#payloadLowerFn = args.payloadLowerFn;
+
+                            if (args.futureEndWaitableIdx === undefined) {{ throw new Error("missing future idx"); }}
+                            if (args.futureTableIdx === undefined) {{ throw new Error("missing future table idx"); }}
+                            this.#futureEndWaitableIdx = args.futureEndWaitableIdx;
+                            this.#futureTableIdx = args.futureTableIdx;
+                        }}
+
+                        setRep(rep) {{ this.#rep = rep; }}
+                        getFutureEndWaitableIdx() {{ return this.#futureEndWaitableIdx; }}
+
+                        createUserFuture() {{
+                           if (this.#userFuture) {{ return this.#userFuture; }}
+                           if (this.#rep === null) {{ throw new Error("unexpectedly missing rep for host future"); }}
+
+                           const cstate = {get_or_create_async_state_fn}(this.#componentIdx);
+                           if (!cstate) {{ throw new Error(`missing async state for component [${{this.#componentIdx}}]`); }}
+
+                           const futureEnd = cstate.getFutureEnd({{
+                               tableIdx: this.#futureTableIdx,
+                               futureEndWaitableIdx: this.#futureEndWaitableIdx
+                           }});
+                           if (!futureEnd) {{
+                               throw new Error(`missing future [${{this.#futureEndWaitableIdx}}] (table [${{this.#futureTableIdx}}], component [${{this.#componentIdx}}]`);
+                           }}
+
+                            this.#userFuture = {promise_with_resolvers_fn}();
+
+                            this.#userFuture.reject(new Error("TODO"));
+
+                            return this.#userFuture.promise;
+                        }}
+                    }}
+                    "#
                 ));
             }
 
             Self::FutureEndClass => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let future_end_class = Self::FutureEndClass.name();
-                output.push_str(&format!("
+
+                uwriteln!(
+                    output,
+                    r#"
                     class {future_end_class} {{
-                        #elementTypeRep = null;
-                        #componentIdx = null;
+                        static CopyResult = {{
+                            COMPLETED: 0,
+                            DROPPED: 1,
+                            CANCELLED: 2,
+                        }};
+
+                        static CopyState = {{
+                            IDLE: 1,
+                            SYNC_COPYING: 2,
+                            ASYNC_COPYING: 3,
+                            CANCELLING_COPY: 4,
+                            DONE: 5,
+                        }};
+
+                        #pendingBufferMeta;
+                        #waitable;
+                        #copyState = {future_end_class}.CopyState.IDLE;
+
+                        #dropped = false;
 
                         constructor(args) {{
                             {debug_log_fn}('[{future_end_class}#constructor()] args', args);
-                            if (!args?.elementTypeRep || typeof args.elementTypeRep !== 'number') {{
-                                throw new TypeError('missing elementTypeRep [' + args.elementTypeRep + ']');
-                            }}
-                            if (args.elementTypeRep <= 0 || args.elementTypeRep > 2_147_483_647)  {{
-                                throw new TypeError('invalid  elementTypeRep [' + args.elementTypeRep + ']');
-                            }}
-                            this.#elementTypeRep = args.elementTypeRep;
-                            this.#componentIdx = args.componentIdx ??= null;
+
+                            if (!args.pendingBufferMeta) {{ throw new Error("missing pending buffer"); }}
+                            this.#pendingBufferMeta = args.pendingBufferMeta;
+
+                            if (!args.waitable) {{ throw new Error("missing pending buffer"); }}
+                            this.#waitable = args.waitable;
                         }}
 
-                        elementTypeRep() {{ return this.#elementTypeRep; }}
-                        isHostOwned() {{ return this.#componentIdx === -1; }}
+                        getWaitable() {{ return this.#waitable; }}
+                        setWaitable(w) {{ this.#waitable = w; }}
+
+                        setCopyState(state) {{ this.#copyState = state; }}
+                        getCopyState() {{ return this.#copyState; }}
+
+                        isDoneState() {{ return this.getCopyState() === {future_end_class}.CopyState.DONE; }}
+                        isCancelledState() {{ return this.getCopyState() === {future_end_class}.CopyState.CANCELLED; }}
+                        isIdleState() {{ return this.getCopyState() === {future_end_class}.CopyState.IDLE; }}
+
+                        isCopying() {{
+                            switch (this.#copyState) {{
+                                case {future_end_class}.CopyState.IDLE:
+                                case {future_end_class}.CopyState.DONE:
+                                    return false;
+                                    break;
+                                case {future_end_class}.CopyState.SYNC_COPYING:
+                                case {future_end_class}.CopyState.ASYNC_COPYING:
+                                case {future_end_class}.CopyState.CANCELLING_COPY:
+                                    return true;
+                                    break;
+                                default:
+                                    throw new Error('invalid/unknown copying state');
+                            }}
+                        }}
+
+                        setPendingBufferMeta(args) {{
+                            const {{ componentIdx, buffer, onCopyDoneFn }} = args;
+                            this.#pendingBufferMeta.componentIdx = componentIdx;
+                            this.#pendingBufferMeta.buffer = buffer;
+                            this.#pendingBufferMeta.onCopyDoneFn = onCopyDoneFn;
+                        }}
+
+                        resetPendingBufferMeta() {{
+                            this.setPendingBufferMeta({{ componentIdx: null, buffer: null, onCopyDoneFn: null }});
+                        }}
+
+                        getPendingBufferMeta() {{ return this.#pendingBufferMeta; }}
+
+                        resetAndNotifyPending(result) {{
+                            const f = this.#pendingBufferMeta.onCopyDoneFn;
+                            this.resetPendingBufferMeta();
+                            if (f) {{ f(result); }}
+                        }}
+
+                        setPendingEvent(fn) {{
+                            if (!this.#waitable) {{ throw new Error('missing/invalid waitable'); }}
+                            {debug_log_fn}('[{future_end_class}#setPendingEvent()]', {{
+                                waitable: this.#waitable,
+                                waitableinSet: this.#waitable.isInSet(),
+                                componentIdx: this.#waitable.componentIdx(),
+                            }});
+                            this.#waitable.setPendingEvent(fn);
+                        }}
+
+                        hasPendingEvent() {{
+                            if (!this.#waitable) {{ throw new Error('missing/invalid waitable'); }}
+                            return this.#waitable.hasPendingEvent();
+                        }}
+
+                        getPendingEvent() {{
+                            if (!this.#waitable) {{ throw new Error('missing/invalid waitable'); }}
+                            {debug_log_fn}('[{future_end_class}#getPendingEvent()]', {{
+                                waitable: this.#waitable,
+                                waitableinSet: this.#waitable.isInSet(),
+                                componentIdx: this.#waitable.componentIdx(),
+                            }});
+                            const event = this.#waitable.getPendingEvent();
+                            return event;
+                        }}
+
+                        isDropped() {{ return this.#dropped; }}
+
+                        drop() {{
+                            if (this.#dropped) {{ throw new Error('future already dropped'); }}
+
+                            if (this.#pendingBufferMeta.buffer) {{
+                                if (!pendingBufferMeta.buffer.isWritable()) {{
+                                    throw new Error('non-writable pending buffer during drop (reader blocked)');
+                                }}
+                                this.resetAndNotifyPending({future_end_class}.CopyResult.DROPPED);
+                            }}
+
+                            this.#dropped = true;
+                        }}
+
                     }}
-                "));
+                "#
+                );
             }
 
             Self::FutureReadableEndClass | Self::FutureWritableEndClass => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
-                let (class_name, future_var_name, js_future_var_type) = match self {
+                let (class_name, _future_var_name, _js_future_var_type) = match self {
                     Self::FutureReadableEndClass => (self.name(), "promise", "Promise"),
                     Self::FutureWritableEndClass => (self.name(), "resolve", "Function"),
-                    _ => unreachable!("impossible future readable end class intrinsic"),
+                    _ => unreachable!(),
                 };
                 let future_end_class = Self::FutureEndClass.name();
-                output.push_str(&format!("
+                let global_buffer_mgr = Intrinsic::GlobalBufferManager.name();
+                let async_event_code_enum = Intrinsic::AsyncEventCodeEnum.name();
+
+                // Generate the inner read/write logic necessary for eitther kind of write end
+                // this will be called internally (usually during guest reads), via places like
+                // `Instruction::FutureRead`/`Instruction::FutureWrite`
+                let (_inner_rw_fn_name, inner_rw_fn) = match self {
+                    Self::FutureReadableEndClass => (
+                        "_read",
+                        format!(
+                            r#"
+                          async _read(args) {{
+                              const {{ buffer, onCopyDoneFn, componentIdx }} = args;
+                              if (!buffer) {{ throw new Error('missing buffer for future read'); }}
+
+                              if (this.isDropped()) {{ throw new Error('cannot read from dropped future'); }}
+                              if (buffer.remaining() !== 1) {{
+                                  throw new Error(`invalid remaining values in buffer (expecetd one, received [${{buffer.remaining()}}]`);
+                              }}
+
+                              const meta = this.getPendingBufferMeta();
+                              if (!meta) {{ throw new Error("missing pending buffer metadata"); }}
+                              if (!meta.buffer) {{
+                                  this.setPendingBufferMeta({{
+                                      buffer,
+                                      componentIdx,
+                                      onCopyDoneFn,
+                                  }});
+                                  return;
+                              }}
+
+                              if (componentIdx === meta.componentIdx && !this.#elemMeta.isNoneOrNumberType) {{
+                                  throw new Error('same-component future reads not allowed for non-numeric types');
+                              }}
+
+                              buffer.write(meta.buffer.read(1));
+                              this.resetAndNotifyPending({future_end_class}.CopyResult.COMPLETED);
+                              onCopyDoneFn({future_end_class}.CopyResult.COMPLETED);
+                          }}
+                        "#,
+                        ),
+                    ),
+
+                    Self::FutureWritableEndClass => (
+                        "_write",
+                        format!(
+                            r#"
+                          async _write(args) {{
+                              const {{ buffer, onCopyDoneFn, componentIdx }} = args;
+                              if (!buffer) {{ throw new Error('missing buffer for future write'); }}
+
+                              if (buffer.remaining() !== 1) {{
+                                  throw new Error("invalid remaining capacity for pending buffer");
+                              }}
+
+                              if (this.isDropped()) {{
+                                  onCopyDoneFn({future_end_class}.CopyResult.DROPPED);
+                                  return;
+                              }}
+
+                              const meta = this.getPendingBufferMeta();
+                              if (!meta) {{ throw new Error("missing pending buffer metadata"); }}
+                              if (!meta.buffer) {{
+                                  this.setPendingBufferMeta({{
+                                      buffer,
+                                      onCopyDoneFn,
+                                  }});
+                                  return;
+                              }}
+
+                              if (componentIdx === meta.componentIdx && !this.#elemMeta.isNoneOrNumberType) {{
+                                  throw new Error('same-component future writes not allowed for non-numeric types');
+                              }}
+
+                              meta.buffer.write(buffer.read(1));
+                              this.resetAndNotifyPending({future_end_class}.CopyResult.COMPLETED);
+                              onCopyDoneFn({future_end_class}.CopyResult.COMPLETED);
+                          }}
+                        "#
+                        ),
+                    ),
+                    _ => unreachable!(),
+                };
+
+                // Read/Write function that is called when a component (guest) is performing the read/write
+                let (_guest_rw_fn_name, guest_rw_fn) = match self {
+                    Self::FutureReadableEndClass => (
+                        "guestRead",
+                        format!(
+                            r#"
+                              // TODO: rename, guestRead also handles host reads (when data is present)...
+                              async guestRead(args) {{
+                                  {debug_log_fn}('[{class_name}#guestRead()] args', args);
+                                  const {{
+                                      componentIdx,
+                                      stringEncoding,
+                                      memory,
+                                      realloc,
+                                      ptr,
+                                      data,
+                                  }} = args;
+
+                                  if (this.#elemMeta.stringEncoding === undefined && stringEncoding) {{
+                                      this.#elemMeta.stringEncoding = stringEncoding;
+                                  }}
+
+                                  const elemMeta = this.#elemMeta;
+
+                                  if (this.#elemMeta.isBorrowed) {{
+                                      throw new Error('cannot call future.read on a borrow');
+                                  }}
+
+                                  let buffer = args.buffer;
+                                  if (!buffer) {{
+                                      const createBufferRes = {global_buffer_mgr}.createBuffer({{
+                                          componentIdx,
+                                          memory,
+                                          realloc,
+                                          start: ptr,
+                                          data,
+                                          count: 1,
+                                          isReadable: this.isWritable(),
+                                          isWritable: this.isReadable(),
+                                          elemMeta: this.#elemMeta,
+                                      }});
+                                      buffer = createBufferRes.buffer;
+                                  }}
+
+                                  const futureEvent = (res) => {{
+                                      if (buffer.remaining() === 0) {{
+                                          if (res !== {future_end_class}.CopyResult.COMPLETED) {{
+                                              throw new Error('invalid buffer state, expected zero remaining post-completion');
+                                          }}
+                                      }} else {{
+                                          if (res === {future_end_class}.CopyResult.COMPLETED) {{
+                                              throw new Error('invalid buffer state, expected 1 remaining post-completion');
+                                          }}
+                                      }}
+                                      if (res === {future_end_class}.CopyResult.DROPPED || res === {future_end_class}.CopyResult.COMPLETED) {{
+                                          this.setCopyState({future_end_class}.CopyState.DONE);
+                                      }} else {{
+                                          this.setCopyState({future_end_class}.CopyState.IDLE);
+                                      }}
+                                      // TODO(fix): componentIdx may be -1 for the host here... is that allowed?
+                                      return {{ code: {async_event_code_enum}.FUTURE_READ, payload0: componentIdx, payload1: res }};
+                                  }};
+
+                                  const isReadableEnd = this.isReadable();
+                                  const onCopyDoneFn = (res) => {{
+                                      if (res === {future_end_class}.CopyResult.DROPPED && isReadableEnd) {{
+                                          throw new Error('cannot read from a dropped future');
+                                      }}
+                                      this.setPendingEvent(() => futureEvent(res));
+                                  }};
+
+                                  await this._read({{
+                                      buffer,
+                                      onCopyDoneFn,
+                                      componentIdx,
+                                  }});
+
+                                  return {{ buffer }};
+                              }}
+                            "#
+                        ),
+                    ),
+                    Self::FutureWritableEndClass => (
+                        "guestWrite",
+                        format!(
+                            r#"
+                              async guestWrite(args) {{
+                                  {debug_log_fn}('[{class_name}#guestWrite()] args', args);
+                                  const {{
+                                      componentIdx,
+                                      stringEncoding,
+                                      isAsync,
+                                      memory,
+                                      realloc,
+                                      ptr,
+                                      data,
+                                  }} = args;
+
+                                  if (this.#elemMeta.stringEncoding === undefined && stringEncoding) {{
+                                      this.#elemMeta.stringEncoding = stringEncoding;
+                                  }}
+
+                                  const elemMeta = this.#elemMeta;
+
+                                  if (this.#elemMeta.isBorrowed) {{
+                                      throw new Error('cannot call future.read on a borrow');
+                                  }}
+
+                                  let buffer = args.buffer;
+                                  if (!buffer) {{
+                                      const createBufferRes = {global_buffer_mgr}.createBuffer({{
+                                          componentIdx,
+                                          memory,
+                                          realloc,
+                                          start: ptr,
+                                          data,
+                                          count: 1,
+                                          isReadable: this.isWritable(),
+                                          isWritable: this.isReadable(),
+                                          elemMeta: this.#elemMeta,
+                                      }});
+                                      buffer = createBufferRes.buffer;
+                                  }}
+
+                                  const futureEvent = (res) => {{
+                                      if (buffer.remaining() === 0) {{
+                                          if (res !== {future_end_class}.CopyResult.COMPLETED) {{
+                                              throw new Error('invalid buffer state, expected zero remaining post-completion');
+                                          }}
+                                      }} else {{
+                                          if (res === {future_end_class}.CopyResult.COMPLETED) {{
+                                              throw new Error('invalid buffer state, expected 1 remaining post-completion');
+                                          }}
+                                      }}
+                                      if (res === {future_end_class}.CopyResult.DROPPED || res === {future_end_class}.CopyResult.COMPLETED) {{
+                                          this.setCopyState({future_end_class}.CopyState.DONE);
+                                      }} else {{
+                                          this.setCopyState({future_end_class}.CopyState.IDLE);
+                                      }}
+                                      // TODO: componentIdx *may* be -1 here
+                                      return {{ code: {async_event_code_enum}.FUTURE_WRITE, payload0: componentIdx, payload1: res }};
+                                  }};
+
+                                  const onCopyDoneFn = (res) => {{
+                                      this.setPendingEvent(() => futureEvent(res));
+                                  }};
+
+                                  await this._write({{
+                                      buffer,
+                                      onCopyDoneFn,
+                                      componentIdx,
+                                  }});
+
+                                  return {{ buffer }};
+                              }}
+                            "#
+                        ),
+                    ),
+                    _ => unreachable!(),
+                };
+
+                // Read/Write function that is called when the host is performing the read/write
+                let (_host_rw_fn_name, host_rw_fn) = match self {
+                    Self::FutureReadableEndClass => (
+                        "hostRead",
+                        format!(
+                            r#"
+                              async hostRead(args) {{
+                                  const {{ stringEncoding }} = args;
+
+                                  const {{ buffer }} = await this.guestRead({{
+                                      stringEncoding,
+                                      isAsync: true,
+                                      data: [],
+                                      componentIdx: -1,
+                                  }});
+
+                                  if (!this.hasPendingEvent()) {{
+                                      this.setCopyState({future_end_class}.CopyState.ASYNC_COPYING);
+
+                                       // Wait for the write to complete
+                                       await new Promise((resolve) => {{
+                                           let waitInterval = setInterval(() => {{
+                                               if (!this.hasPendingEvent()) {{ return; }}
+                                               clearInterval(waitInterval);
+                                               resolve();
+                                           }});
+                                       }});
+
+                                       // Perform another write, reusing the buffer
+                                       const {{ buffer }} = await this.guestRead({{
+                                           buffer,
+                                           stringEncoding,
+                                           isAsync: true,
+                                       }});
+
+                                       if (!this.hasPendingEvent()) {{
+                                           throw new Error("missing pending event after blocked future read");
+                                       }}
+                                  }}
+
+                                  const {{ code, payload0: index, payload1: payload }} = this.getPendingEvent();
+                                  if (code !== {async_event_code_enum}.FUTURE_READ) {{
+                                      throw new Error(`mismatched event code [${{code}}] for host future read`);
+                                  }}
+                                  if (index !== -1) {{ throw new Error('mismatched component idx'); }}
+
+                                  const vs = buffer.read(1);
+                                  if (vs.length !== 1) {{ throw new Error('multiple results from future'); }}
+
+                                  return vs[0];
+                              }}
+                            "#
+                        ),
+                    ),
+                    Self::FutureWritableEndClass => (
+                        "hostWrite",
+                        format!(
+                            r#"
+                              async hostWrite(args) {{
+                                  const {{ stringEncoding, value }} = args;
+
+                                  const {{ buffer }} = await this.guestWrite({{
+                                      stringEncoding,
+                                      isAsync: true,
+                                      data: [value],
+                                      componentIdx: -1,
+                                  }});
+
+                                  if (!this.hasPendingEvent()) {{
+                                      if (!isAsync) {{ throw new Error("all host writes are async"); }}
+                                      this.setCopyState({future_end_class}.CopyState.ASYNC_COPYING);
+
+                                       // Wait for the write to complete
+                                       await new Promise((resolve) => {{
+                                           let waitInterval = setInterval(() => {{
+                                               if (!this.hasPendingEvent()) {{ return; }}
+                                               clearInterval(waitInterval);
+                                               resolve();
+                                           }});
+                                       }});
+
+                                       // Perform another write, reusing the buffer
+                                       const {{ buffer }} = await this.guestWrite({{
+                                           buffer,
+                                           stringEncoding,
+                                           isAsync: true,
+                                       }});
+
+                                       if (!this.hasPendingEvent()) {{
+                                           throw new Error("missing pending event after blocked future write");
+                                       }}
+                                  }}
+
+                                  const {{ code, payload0: index, payload1: payload }} = this.getPendingEvent();
+                                  if (code !== {async_event_code_enum}.FUTURE_WRITE) {{
+                                      throw new Error(`mismatched event code [${{code}}] for host future write`);
+                                  }}
+                                  if (index !== -1) {{ throw new Error('mismatched component idx'); }}
+                              }}
+                            "#
+                        ),
+                    ),
+                    _ => unreachable!(),
+                };
+
+                let type_getters = match self {
+                    Self::FutureWritableEndClass => "
+                         isReadable() { return false; }
+                         isWritable() { return true; }
+                    "
+                    .to_string(),
+                    Self::FutureReadableEndClass => "
+                         isReadable() { return true; }
+                         isWritable() { return false; }
+                    "
+                    .to_string(),
+                    _ => unreachable!(),
+                };
+
+                let drop_check = match self {
+                    Self::FutureReadableEndClass => "",
+                    Self::FutureWritableEndClass => {
+                        r#"
+                          if (this.isWritable() && !this.isDoneState()) {{
+                              throw new Error('trap: futures must not be dropped before being completed');
+                          }}
+                        "#
+                    }
+                    _ => unreachable!(),
+                };
+
+                uwriteln!(
+                    output,
+                    r#"
                     class {class_name} extends {future_end_class} {{
-                        #copying = false;
-                        #{future_var_name} = null;
-                        #dropped = false;
+                        #globalFutureMapRep;
+                        #futureTableIdx;
+                        #isHostOwned;
+                        #hostInjectFn;
+                        #elemMeta;
+                        #handle;
+
+                        target;
 
                         constructor(args) {{
                             {debug_log_fn}('[{class_name}#constructor()] args', args);
                             super(args);
-                            if (!args.{future_var_name} || !(args.{future_var_name} instanceof {js_future_var_type})) {{
-                                throw new TypeError('missing/invalid {future_var_name}, expected {js_future_var_type}');
-                            }}
-                            this.#{future_var_name} = args.{future_var_name};
+
+                            if (!args.elemMeta) {{ throw new Error('missing/invalid element meta'); }}
+                            this.#elemMeta = args.elemMeta;
+
+                            if (args.tableIdx === undefined) {{ throw new Error('missing index for future table idx'); }}
+                            this.#futureTableIdx = args.tableIdx;
+
+                            this.#hostInjectFn = args.hostInjectFn;
+                            this.#isHostOwned = args.hostOwned;
+
+                            this.#hostInjectFn = args.hostInjectFn;
                         }}
 
-                        isCopying() {{ return this.#copying; }}
+                        {type_getters}
+
+                        setTarget(tgt) {{ this.target = tgt; }}
+
+                        getElemMeta() {{ return {{...this.#elemMeta}}; }}
+                        futureTableIdx() {{ return this.#futureTableIdx; }}
+
+                        globalFutureMapRep() {{ return this.#globalFutureMapRep; }}
+                        setGlobalFutureMapRep(rep) {{ this.#globalFutureMapRep = rep; }}
+
+                        waitableIdx() {{ return this.getWaitable().idx(); }}
+                        setWaitableIdx(idx) {{
+                            const w = this.getWaitable();
+                            w.setIdx(idx);
+                            w.setTarget(`waitable for {class_name} (waitable [${{idx}}])`);
+                        }}
+
+                        handle() {{ return this.#handle; }}
+                        setHandle(h) {{ this.#handle = h; }}
+
+                        setHostInjectFn(f) {{
+                            if (this.#hostInjectFn) {{ throw new Error('host injection fn is already set'); }}
+                            this.#hostInjectFn = f;
+                        }}
+
+                        promise() {{
+                            // NOTE: we return a "thenable" here to ensure that simply lifting the future does
+                            // not trigger a host read.
+                            return {{
+                                then: (resolve, reject) => {{
+                                    this.hostRead({{ stringEncoding: 'utf8' }}).then(resolve, reject);
+                                 }}
+                             }};
+                        }}
+
+                        cancel() {{
+                            {debug_log_fn}('[{future_end_class}#cancel()]');
+                            this.resetAndNotifyPending({future_end_class}.CopyResult.CANCELLED);
+                        }}
+
+                        {inner_rw_fn}
+                        {guest_rw_fn}
+                        {host_rw_fn}
 
                         drop() {{
-                            if (this.#dropped) {{ throw new Error('already dropped'); }}
-                            if (this.#copying) {{ throw new Error('cannot drop while copying'); }}
-
-                            if (!this.#{future_var_name}) {{ throw new Error('missing/invalid {future_var_name}'); }}
-                            this.#{future_var_name}.close();
-
+                            {drop_check}
                             super.drop();
-                            this.#dropped = true;
                         }}
                     }}
-                "));
+                "#
+                );
             }
 
-            // TODO: Futures need a class
+            Self::InternalFutureClass => {
+                let debug_log_fn = Intrinsic::DebugLog.name();
+                let internal_future_class = Self::InternalFutureClass.name();
+                let write_end_class = Self::FutureWritableEndClass.name();
+                let read_end_class = Self::FutureReadableEndClass.name();
+
+                uwriteln!(
+                    output,
+                    r#"
+                    class {internal_future_class} {{
+                        #globalFutureMapRep;
+                        #pendingBufferMeta = {{}}; // Shared between read and write ends
+                        #elemMeta;
+
+                        #readEnd;
+                        #writeEnd;
+
+                        constructor(args) {{
+                            {debug_log_fn}('[{internal_future_class}#constructor()] args', args);
+                            if (!args.elemMeta) {{ throw new Error('missing/invalid future element metadata'); }}
+                            if (args.tableIdx === undefined) {{ throw new Error('missing/invalid future table idx'); }}
+                            if (!args.readWaitable) {{ throw new Error('missing/invalid read waitable'); }}
+                            if (!args.writeWaitable) {{ throw new Error('missing/invalid write waitable'); }}
+                            const {{
+                                tableIdx,
+                                elemMeta,
+                                readWaitable,
+                                writeWaitable,
+                            }} = args;
+
+                            this.#elemMeta = args.elemMeta;
+
+                            let dropped = false;
+                            const setDroppedFn = () => {{ dropped = true }};
+                            const isDroppedFn = () => dropped;
+
+                            this.#readEnd = new {read_end_class}({{
+                                tableIdx,
+                                elemMeta: this.#elemMeta,
+                                pendingBufferMeta: this.#pendingBufferMeta,
+                                target: "future read end (@ init)",
+                                waitable: readWaitable,
+                                // Only in-component read-ends need the host inject fn if provided,
+                                // as that function will *inject* a write when the future is checked
+                                // from inside the guest.
+                                hostInjectFn: args.hostInjectFn,
+                                setDroppedFn,
+                                isDroppedFn,
+                            }});
+
+                            this.#writeEnd = new {write_end_class}({{
+                                tableIdx,
+                                elemMeta: this.#elemMeta,
+                                pendingBufferMeta: this.#pendingBufferMeta,
+                                target: "future write end (@ init)",
+                                waitable: writeWaitable,
+                                hostOwned: true,
+                                setDroppedFn,
+                                isDroppedFn,
+                            }});
+                        }}
+
+                        elemMeta() {{ return this.#elemMeta; }}
+                        readEnd() {{ return this.#readEnd; }}
+                        writeEnd() {{ return this.#writeEnd; }}
+
+                        globalFutureMapRep() {{ return this.#globalFutureMapRep; }}
+                        setGlobalFutureMapRep(rep) {{
+                            this.#globalFutureMapRep = rep;
+                            this.#readEnd.setGlobalFutureMapRep(rep);
+                            this.#writeEnd.setGlobalFutureMapRep(rep);
+                        }}
+                    }}
+                "#
+                );
+            }
+
             Self::FutureNew => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let future_new_fn = Self::FutureNew.name();
-                let future_readable_end_class = Self::FutureReadableEndClass.name();
-                let future_writable_end_class = Self::FutureWritableEndClass.name();
-                let global_future_map = Self::GlobalFutureMap.name();
                 let current_task_get_fn =
                     Intrinsic::AsyncTask(AsyncTaskIntrinsic::GetCurrentTask).name();
                 let get_or_create_async_state_fn =
                     Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
-                output.push_str(&format!("
-                    function {future_new_fn}(componentIdx, elementTypeRep) {{
-                        {debug_log_fn}('[{future_new_fn}()] args', {{ componentIdx, elementTypeRep }});
 
-                        const task = {current_task_get_fn}(componentIdx);
+                uwriteln!(
+                    output,
+                    r#"
+                    function {future_new_fn}(ctx) {{
+                        {debug_log_fn}('[{future_new_fn}()] args', {{ ctx }});
+                        const {{ componentIdx, futureTableIdx, elemMeta }} = ctx;
+
+                        const taskMeta = {current_task_get_fn}(componentIdx);
+                        if (!taskMeta) {{ throw new Error('invalid/missing async task meta'); }}
+                        const task = taskMeta.task;
                         if (!task) {{ throw new Error('invalid/missing async task'); }}
 
-                        const state = {get_or_create_async_state_fn}(componentIdx);
-                        if (!state.mayLeave) {{ throw new Error('component instance is not marked as may leave'); }}
+                        const cstate = {get_or_create_async_state_fn}(componentIdx);
+                        if (!cstate.mayLeave) {{ throw new Error('component instance is not marked as may leave'); }}
 
-                        let future = new Promise();
-                        let writeEndWaitableIdx = {global_future_map}.insert(new {future_writable_end_class}({{
-                            isFuture: true,
-                            elementTypeRep,
-                        }}));
-                        let readEndWaitableIdx = {global_future_map}.insert(new {future_readable_end_class}({{
-                            isFuture: true,
-                            elementTypeRep,
-                        }}));
+                        const {{ readEnd, writeEnd }} = cstate.createFuture({{
+                            tableIdx: futureTableIdx,
+                            elemMeta,
+                        }});
+
+                        let writeEndWaitableIdx = writeEnd.waitableIdx();
+                        let readEndWaitableIdx = readEnd.waitableIdx();
 
                         return BigInt(writeEndWaitableIdx) << 32n | BigInt(readEndWaitableIdx);
                     }}
-                "));
+                "#
+                );
             }
 
-            // TODO: fix return from processFn
+            Self::FutureNewFromLift => {
+                let debug_log_fn = Intrinsic::DebugLog.name();
+                let future_new_from_lift_fn = self.name();
+                let global_future_map =
+                    Intrinsic::AsyncFuture(AsyncFutureIntrinsic::GlobalFutureMap).name();
+                let host_future_class =
+                    Intrinsic::AsyncFuture(AsyncFutureIntrinsic::HostFutureClass).name();
+
+                output.push_str(&format!(
+                    r#"
+                    function {future_new_from_lift_fn}(ctx) {{
+                        {debug_log_fn}('[{future_new_from_lift_fn}()] args', {{ ctx }});
+                        const {{
+                            componentIdx,
+                            futureEndWaitableIdx,
+                            futureTableIdx,
+                            payloadLiftFn,
+                            payloadTypeSize32,
+                            payloadLowerFn,
+                        }} = ctx;
+
+                        const future = new {host_future_class}({{
+                            componentIdx,
+                            futureEndWaitableIdx,
+                            futureTableIdx,
+                            payloadLiftFn: payloadLiftFn,
+                            payloadLowerFn: payloadLowerFn,
+                        }});
+
+                        const rep = {global_future_map}.insert(future);
+                        future.setRep(rep);
+
+                        return future.createUserFuture();
+                    }}
+                "#
+                ));
+            }
+
             Self::FutureWrite | Self::FutureRead => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
-                let future_write_fn = self.name();
-                let global_future_map = Self::GlobalFutureMap.name();
-                let global_buffer_mgr = Intrinsic::GlobalBufferManager.name();
-                let is_write = matches!(self, Self::FutureWrite);
-                let future_end_class = if is_write {
-                    Self::FutureWritableEndClass.name()
-                } else {
-                    Self::FutureReadableEndClass.name()
-                };
-                let is_borrowed_type = Intrinsic::IsBorrowedType.name();
                 let get_or_create_async_state_fn =
                     Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
-                let async_blocked_constant =
+                let current_task_get_fn =
+                    Intrinsic::AsyncTask(AsyncTaskIntrinsic::GetCurrentTask).name();
+                let event_code_enum = Intrinsic::AsyncEventCodeEnum.name();
+                let async_blocked_const =
                     Intrinsic::AsyncTask(AsyncTaskIntrinsic::AsyncBlockedConstant).name();
-                output.push_str(&format!("
-                    function {future_write_fn}(
-                        componentIdx,
-                        memoryIdx,
-                        reallocIdx,
-                        stringEncoding,
-                        isAsync,
-                        futureIdx,
-                        typeIdx,
-                        futureEndIdx,
+
+                let future_op_fn = self.name();
+                let (guest_op_fn, future_end_class) = match self {
+                    Self::FutureWrite => ("guestWrite", Self::FutureWritableEndClass.name()),
+                    Self::FutureRead => ("guestRead", Self::FutureReadableEndClass.name()),
+                    _ => unreachable!(),
+                };
+                let future_end_base_class = Self::FutureEndClass.name();
+
+                let event_code = match self {
+                    Self::FutureWrite => format!("{event_code_enum}.FUTURE_WRITE"),
+                    Self::FutureRead => format!("{event_code_enum}.FUTURE_READ"),
+                    _ => unreachable!(),
+                };
+
+                uwriteln!(
+                    output,
+                    r#"
+                    async function {future_op_fn}(
+                        ctx,
+                        futureEndWaitableIdx,
                         ptr,
-                        count,
                     ) {{
-                        {debug_log_fn}('[{future_write_fn}()] args', {{
+                        {debug_log_fn}('[{future_op_fn}()] args', {{
+                            ctx,
+                            futureEndWaitableIdx,
+                            ptr,
+                        }});
+                        const {{
                             componentIdx,
+                            futureTableIdx,
                             memoryIdx,
+                            getMemoryFn,
                             reallocIdx,
+                            getReallocFn,
                             stringEncoding,
                             isAsync,
-                            futureIdx,
-                            typeIdx,
-                            futureEndIdx,
-                            ptr,
-                            count,
-                        }});
+                        }} = ctx;
 
-                        const state = {get_or_create_async_state_fn}(componentIdx);
-                        if (!state.mayLeave) {{ throw new Error('component instance is not marked as may leave'); }}
+                        const taskMeta = {current_task_get_fn}(componentIdx);
+                        if (!taskMeta) {{ throw new Error('missing task metadata during future operation'); }}
 
-                        const future = {global_future_map}.get(futureIdx);
-                        if (!future) {{ throw new Error('missing future'); }}
+                        const task = taskMeta.task;
+                        if (!task) {{ throw new Error('missing task in metadata during future operation'); }}
 
-                        const futureEnd = {global_future_map}.get(futureEndIdx);
-                        if (!futureEnd) {{ throw new Error('missing future end'); }}
-                        if (!(futureEnd instanceof {future_end_class})) {{ throw new Error('invalid future end, expected [{future_end_class}]'); }}
+                        const cstate = {get_or_create_async_state_fn}(componentIdx);
+                        if (!cstate.mayLeave) {{ throw new Error('component instance is not marked as may leave'); }}
 
-                        if (future.elementTypeRep() !== futureEnd.elementTypeRep()) {{
-                          throw new Error('future type rep [' + future.elementTypeRep() + '] does not match future end [' + futureEnd.elementTypeRep() + ']');
+                        if (!task.mayBlock() && !isAsync) {{
+                            throw new Error('only tasks that may block may call future.{future_op_fn}');
                         }}
 
-                        if (futureEnd.isCopying()) {{ throw new Error('future end is copying'); }}
-                        if (futureEnd.isDone()) {{ throw new Error('future end is done'); }}
+                        const futureEnd = cstate.getFutureEnd({{ tableIdx: futureTableIdx, futureEndWaitableIdx }});
+                        if (!futureEnd) {{
+                            throw new Error(`missing future with waitable idx [${{futureEndWaitableIdx}}] (component [${{componentIdx}}])`);
+                        }}
+                        if (!(futureEnd instanceof {future_end_class})) {{
+                            throw new Error('invalid future end, expected [{future_end_class}]');
+                        }}
+                        if (!futureEnd.isIdleState()) {{
+                            throw new Error('future state must be idle before {future_op_fn}');
+                        }}
 
-                        if ({is_borrowed_type}(componentIdx, future.elementTypeRep())) {{ throw new Error('borrowed types not supported'); }}
-
-                        const {{ id: bufferID }} = {global_buffer_mgr}.createBuffer({{
+                        await futureEnd.{guest_op_fn}({{
                             componentIdx,
-                            start,
-                            len,
-                            typeIdx,
-                            writable,
-                            readable,
-                            target: `future read/write`,
                             stringEncoding,
+                            memory: getMemoryFn(),
+                            realloc: getReallocFn(),
+                            ptr,
                         }});
 
-                        const processFn = (result) => {{
-                          if ({global_buffer_mgr}.remaining(bufferID) === 0 && result != CopyResult.COMPLETED) {{
-                            throw new Error('incomplete copy with future data remanining');
-                          }}
-                          if ({global_buffer_mgr}.remaining(bufferID) !== 0 && result === CopyResult.COMPLETED) {{
-                            throw new Error('remaining data with completed copy');
-                          }}
-
-                          futureEnd.clearCopying();
-
-                          if (result === CopyResult.DROPPED || result === CopyResult.FUTURE_WRITE) {{
-                            e.markDone();
-                          }}
-
-                          return {{ eventCode, index, result }};
-                        }};
-
-                        futureEnd.copy({{
-                            bufferID,
-                            onCopyDone: (result) => {{
-                              if (result === CopyResult.DROPPED && eventCode === EventCode.FUTURE_WRITE) {{
-                                throw new Error('cannot have a future write when the future is dropped');
-                              }}
-                              futureEnd.setEvent(processFn(result));
+                        if (!futureEnd.hasPendingEvent()) {{
+                            if (isAsync) {{
+                                futureEnd.setCopyState({future_end_base_class}.CopyState.ASYNC_COPYING);
+                                return {async_blocked_const};
+                            }} else {{
+                                futureEnd.setCopyState({future_end_base_class}.CopyState.SYNC_COPYING);
+                                await task.suspendUntil({{
+                                    readyFn: () => futureEnd.hasPendingEvent(),
+                                }});
                             }}
-                        }});
-
-                        if (!isAsync && !e.hasPendingEvent()) {{
-                          // TODO: replace with what block on used to be? wait for?
-                          // await task.blockOn({{ promise: e.waitForPendingEvent(), isAsync: false }});
-                          throw new Error('not implemented');
                         }}
 
-                        if (futureEnd.hasPendingEvent()) {{
-                          const {{ code, payload0: index, payload1 }} = futureEnd.getPendingEvent();
-                          if (code !== eventCode || index != 1) {{
-                            throw new Error('invalid event, does not match expected event code');
-                          }}
-                          return payload;
-                        }}
+                        const {{ code, payload0: index, payload1: payload }} = futureEnd.getPendingEvent();
+                        if (code !== {event_code}) {{
+                             throw new Error(`mismatched event code [${{code}}] (expected {event_code})`);
+                         }}
+                        if (index !== componentIdx) {{ throw new Error('mismatched component idx'); }}
 
-                        return {async_blocked_constant};
+                        return payload;
                     }}
-                "));
+                "#
+                );
             }
 
             Self::FutureCancelRead | Self::FutureCancelWrite => {
@@ -435,37 +1213,35 @@ impl AsyncFutureIntrinsic {
                 let future_cancel_fn = self.name();
                 let get_or_create_async_state_fn =
                     Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
-                let global_future_map = Self::GlobalFutureMap.name();
                 let async_blocked_const =
                     Intrinsic::AsyncTask(AsyncTaskIntrinsic::AsyncBlockedConstant).name();
                 let async_event_code_enum = Intrinsic::AsyncEventCodeEnum.name();
-                output.push_str(&format!("
+
+                output.push_str(&format!(r#"
                     async function {future_cancel_fn}(
-                        componentIdx,
-                        futureIdx,
-                        isAsync,
+                        ctx,
                         futureEndIdx,
                     ) {{
                         {debug_log_fn}('[{future_cancel_fn}()] args', {{
-                            componentIdx,
-                            futureIdx,
-                            isAsync,
-                            futureEndIdx,
+                            ctx,
+                            futureEndWaitableIdx,
                         }});
+                        const {{ componentIdx, futureTableIdx, isAsync }} = ctx;
 
-                        const state = {get_or_create_async_state_fn}(componentIdx);
-                        if (!state.mayLeave) {{ throw new Error('component instance is not marked as may leave'); }}
+                        const cstate = {get_or_create_async_state_fn}(componentIdx);
+                        if (!cstate.mayLeave) {{ throw new Error('component instance is not marked as may leave'); }}
 
-                        const futureEnd = {global_future_map}.get(futureEndIdx);
-                        if (!futureEnd) {{ throw new Error('missing future end with idx [' + futureEndIdx + ']'); }}
-                        if (!(futureEnd instanceof {future_end_class})) {{ throw new Error('invalid future end, expected value of type [{future_end_class}]'); }}
-
-                        const future = {global_future_map}.get(futureIdx);
-                        if (!future) {{ throw new Error('missing future with idx [' + futureIdx + ']'); }}
-
-                        if (futureEnd.elementTypeRep() !== future.elementTypeRep()) {{
-                          throw new Error('future type [' + future.elementTypeRep() + '], does not match future end type [' + futureEnd.elementTypeRep() + ']');
+                        let futureEnd = cstate.getFutureEnd({{ tableIdx: futureTableIdx, futureEndWaitableIdx }});
+                        if (!futureEnd) {{ throw new Error(`missing future end with idx [${{futureEndWaitableIdx}}]`); }}
+                        if (!(futureEnd instanceof {future_end_class})) {{
+                            throw new Error('invalid future end, expected value of type [{future_end_class}]');
                         }}
+
+                        futureEnd = cstate.removeFutureEndFromTable({{
+                            tableIdx: futureTableIdx,
+                            futureWaitableIdx: futureEndWaitableIdx,
+                        }});
+                        if (!futureEnd) {{ throw new Error(`missing future with idx [${{futureEndWaitableIdx}}]`); }}
 
                         if (!futureEnd.isCopying()) {{ throw new Error('future end is not copying, cannot cancel'); }}
 
@@ -489,7 +1265,7 @@ impl AsyncFutureIntrinsic {
 
                         return payload;
                     }}
-                "));
+                "#));
             }
 
             // TODO: fill in future class impl (check for matching element types)
@@ -497,7 +1273,6 @@ impl AsyncFutureIntrinsic {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let future_drop_fn = self.name();
                 let is_writable = matches!(self, Self::FutureDropWritable);
-                let global_future_map = Self::GlobalFutureMap.name();
                 let future_end_class = if is_writable {
                     Self::FutureWritableEndClass.name()
                 } else {
@@ -505,31 +1280,45 @@ impl AsyncFutureIntrinsic {
                 };
                 let get_or_create_async_state_fn =
                     Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
-                output.push_str(&format!("
-                    function {future_drop_fn}(
-                        futureIdx,
-                        futureEndIdx,
-                    ) {{
-                        {debug_log_fn}('[{future_drop_fn}()] args', {{
-                            futureIdx,
-                            futureEndIdx,
+                output.push_str(&format!(r#"
+                    function {future_drop_fn}(ctx, futureEndWaitableIdx) {{
+                        {debug_log_fn}('[{future_drop_fn}()] args', {{ ctx }});
+                        const {{ componentIdx, futureTableIdx }} = ctx;
+
+                        const cstate = {get_or_create_async_state_fn}(componentIdx);
+                        if (!cstate.mayLeave) {{ throw new Error('component instance is not marked as may leave'); }}
+
+                        const futureEnd = cstate.removeFutureEndFromTable({{
+                            tableIdx: futureTableIdx,
+                            futureWaitableIdx: futureEndWaitableIdx
                         }});
-
-                        const state = {get_or_create_async_state_fn}(componentIdx);
-                        if (!state.mayLeave) {{ throw new Error('component instance is not marked as may leave'); }}
-
-                        const future = {global_future_map}.remove(futureIdx);
-
-                        const futureEnd = {global_future_map}.remove(futureEndIdx);
-                        if (!(futureEnd instanceof {future_end_class})) {{ throw new Error('invalid future end, expected [{future_end_class}]'); }}
-
-                        if (futureEnd.elementTypeRep() !== future.elementTypeRep()) {{
-                          throw new Error('future type [' + future.elementTypeRep() + '], does not match future end type [' + futureEnd.elementTypeRep() + ']');
+                        if (!(futureEnd instanceof {future_end_class})) {{
+                            throw new Error('invalid future end, expected [{future_end_class}]');
                         }}
 
                         futureEnd.drop();
                     }}
-                "));
+                "#));
+            }
+
+            Self::FutureTransfer => {
+                let debug_log_fn = Intrinsic::DebugLog.name();
+                let future_transfer_fn = self.name();
+                output.push_str(&format!(
+                    r#"
+                      function {future_transfer_fn}(ctx) {{
+                        const params = [...arguments];
+                        {debug_log_fn}('[{future_transfer_fn}()] args', {{
+                            ctx,
+                            params,
+                        }});
+                        console.log('[{future_transfer_fn}()] args', {{
+                            ctx,
+                            params,
+                        }});
+                    }}
+                    "#
+                ));
             }
         }
     }

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -74,14 +74,11 @@ pub enum AsyncStreamIntrinsic {
     /// particularly the relevant types to teh stream and lift/lower fns for the stream.
     ///
     /// ```ts
-    /// type params = {
+    /// type Ctx = {
     ///     componentIdx: number,
-    ///     streamTypeRep: number,
-    ///     payloadLiftFn: Array<Function>,
-    ///     payloadLowerFn: Array<Function>,
-    ///     isUnitStream: boolean,
+    ///     elemMeta: object,
     /// }
-    /// function streamNewFromLift(p: params);
+    /// function streamNewFromLift(ctx: Ctx);
     /// ```
     ///
     StreamNewFromLift,
@@ -560,8 +557,8 @@ impl AsyncStreamIntrinsic {
                                 // If the buffer came from the same component that is currently doing the operation
                                 // we're doing a inter-component write, and only unit or numeric types are allowed
                                 const pendingElemIsNoneOrNumeric = pendingElemMeta.isNone || pendingElemMeta.isNumeric;
-                                if (this.#pendingBufferMeta.componentIdx === buffer.componentIdx() && !pendingElemIsNoneOrNumeric) {{
-                                    throw new Error("trap: cannot stream non-numeric types within the same component (send)");
+                                if (this.#pendingBufferMeta.componentIdx === buffer.componentIdx() && buffer.componentIdx() !== -1 && !pendingElemIsNoneOrNumeric) {{
+                                    throw new Error(`trap: cannot stream non-numeric types within the same component (component [${{buffer.componentIdx()}}], send)`);
                                 }}
 
                                 // If original capacities were zero, we're dealing with a unit stream,
@@ -640,8 +637,8 @@ impl AsyncStreamIntrinsic {
                                 // If the buffer came from the same component that is currently doing the operation
                                 // we're doing a inter-component read, and only unit or numeric types are allowed
                                 const pendingElemIsNoneOrNumeric = pendingElemMeta.isNone || pendingElemMeta.isNumeric;
-                                if (this.#pendingBufferMeta.componentIdx === buffer.componentIdx() && !pendingElemIsNoneOrNumeric) {{
-                                    throw new Error("trap: cannot stream non-numeric types within the same component (read)");
+                                if (this.#pendingBufferMeta.componentIdx === buffer.componentIdx() && buffer.componentIdx() !== -1 && !pendingElemIsNoneOrNumeric) {{
+                                    throw new Error(`trap: cannot stream non-numeric types within the same component (component [${{buffer.componentIdx()}}] read)`);
                                 }}
 
                                 const pendingRemaining = this.#pendingBufferMeta.buffer.remaining();
@@ -1192,21 +1189,13 @@ impl AsyncStreamIntrinsic {
                 output.push_str(&format!(
                     r#"
                     class {internal_stream_class_name} {{
-                        #readEnd;
-                        #readEndWaitableIdx;
-                        #readEndDropped;
-
-                        #writeEnd;
-                        #writeEndWaitableIdx;
-                        #writeEndDropped;
-
                         #pendingBufferMeta = {{}}; // shared between read/write ends
                         #elemMeta;
 
                         #globalStreamMapRep;
 
-                        #readWaitPromise = null;
-                        #writeWaitPromise = null;
+                        #readEnd;
+                        #writeEnd;
 
                         constructor(args) {{
                             {debug_log_fn}('[{internal_stream_class_name}#constructor()] args', args);
@@ -1291,7 +1280,6 @@ impl AsyncStreamIntrinsic {
 
                         #payloadLiftFn;
                         #payloadLowerFn;
-                        #isUnitStream;
 
                         #userStream;
 
@@ -1312,8 +1300,6 @@ impl AsyncStreamIntrinsic {
                             if (args.streamTableIdx === undefined) {{ throw new Error("missing stream table idx"); }}
                             this.#streamEndWaitableIdx = args.streamEndWaitableIdx;
                             this.#streamTableIdx = args.streamTableIdx;
-
-                            this.#isUnitStream = args.isUnitStream;
                         }}
 
                         setRep(rep) {{ this.#rep = rep; }}
@@ -1399,7 +1385,6 @@ impl AsyncStreamIntrinsic {
 
                             this.#dropFn = args.dropFn;
                         }}
-
 
                         [{symbol_async_iterator}]() {{ return this; }}
 
@@ -1528,7 +1513,6 @@ impl AsyncStreamIntrinsic {
                             payloadLiftFn,
                             payloadTypeSize32,
                             payloadLowerFn,
-                            isUnitStream,
                         }} = ctx;
 
                         const stream = new {host_stream_class}({{
@@ -1537,7 +1521,6 @@ impl AsyncStreamIntrinsic {
                             streamTableIdx,
                             payloadLiftFn: payloadLiftFn,
                             payloadLowerFn: payloadLowerFn,
-                            isUnitStream,
                         }});
 
                         const rep = {global_stream_map}.insert(stream);

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -13,7 +13,7 @@ use wasmtime_environ::component::{
     CoreDef, CoreExport, Export, ExportItem, FixedEncoding, GlobalInitializer, InstantiateModule,
     InterfaceType, LinearMemoryOptions, LoweredIndex, ResourceIndex, RuntimeComponentInstanceIndex,
     RuntimeImportIndex, RuntimeInstanceIndex, StaticModuleIndex, Trampoline, TrampolineIndex,
-    TypeDef, TypeFuncIndex, TypeResourceTableIndex, TypeStreamTableIndex,
+    TypeDef, TypeFuncIndex, TypeFutureTableIndex, TypeResourceTableIndex, TypeStreamTableIndex,
 };
 use wasmtime_environ::component::{
     ExtractCallback, NameMapNoIntern, Transcode, TypeComponentLocalErrorContextTableIndex,
@@ -243,6 +243,14 @@ pub fn transpile_bindgen(
         stream_tables.insert(stream_table_idx, stream_table_ty.instance);
     }
 
+    // Generate mapping of future tables to components that are related
+    let mut future_tables = BTreeMap::new();
+    for idx in 0..component.component.num_future_tables {
+        let future_table_idx = TypeFutureTableIndex::from_u32(idx as u32);
+        let future_table_ty = &types[future_table_idx];
+        future_tables.insert(future_table_idx, future_table_ty.instance);
+    }
+
     // Generate mapping of err_ctx tables to components that are related
     let mut err_ctx_tables = BTreeMap::new();
     for idx in 0..component.component.num_error_context_tables {
@@ -290,6 +298,7 @@ pub fn transpile_bindgen(
         resources_initialized: BTreeMap::new(),
         resource_tables_initialized: BTreeMap::new(),
         stream_tables,
+        future_tables,
         err_ctx_tables,
     };
     instantiator.sizes.fill(resolve);
@@ -620,6 +629,9 @@ pub(crate) struct Instantiator<'a, 'b> {
     /// Mapping of stream table indices to component indices
     stream_tables: BTreeMap<TypeStreamTableIndex, RuntimeComponentInstanceIndex>,
 
+    /// Mapping of future table indices to component indices
+    future_tables: BTreeMap<TypeFutureTableIndex, RuntimeComponentInstanceIndex>,
+
     /// Mapping of err ctx indices to component indices
     err_ctx_tables:
         BTreeMap<TypeComponentLocalErrorContextTableIndex, RuntimeComponentInstanceIndex>,
@@ -793,6 +805,18 @@ impl<'a> Instantiator<'a, '_> {
         for (table_idx, component_idx) in self.stream_tables.iter() {
             self.src.js.push_str(&format!(
                 "{global_stream_table_map}[{}] = {{ componentIdx: {}, table: new {rep_table_class}() }};\n",
+                table_idx.as_u32(),
+                component_idx.as_u32(),
+            ));
+        }
+
+        // Set up global future map, which is used by intrinsics like future.transfer
+        let global_future_table_map =
+            Intrinsic::AsyncFuture(AsyncFutureIntrinsic::GlobalFutureTableMap).name();
+        let rep_table_class = Intrinsic::RepTableClass.name();
+        for (table_idx, component_idx) in self.future_tables.iter() {
+            self.src.js.push_str(&format!(
+                "{global_future_table_map}[{}] = {{ componentIdx: {}, table: new {rep_table_class}() }};\n",
                 table_idx.as_u32(),
                 component_idx.as_u32(),
             ));
@@ -1088,6 +1112,7 @@ impl<'a> Instantiator<'a, '_> {
                 | Trampoline::FutureDropWritable { .. }
                 | Trampoline::FutureRead { .. }
                 | Trampoline::FutureWrite { .. }
+                | Trampoline::FutureNew { .. }
                 | Trampoline::LowerImport { .. }
                 | Trampoline::PrepareCall { .. }
                 | Trampoline::ResourceDrop { .. }
@@ -1595,164 +1620,259 @@ impl<'a> Instantiator<'a, '_> {
                 uwriteln!(self.src.js, "const trampoline{i} = {stream_transfer_fn};\n",);
             }
 
-            Trampoline::FutureNew { ty, .. } => {
+            Trampoline::FutureNew { instance, ty } => {
                 let future_new_fn = self
                     .bindgen
                     .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureNew));
+                let future_table_idx = ty.as_u32();
+                let component_idx = instance.as_u32();
+
+                // Build element metadata
+                let future_table_ty = &self.types[*ty];
+                let future_ty = &self.types[future_table_ty.ty];
+                let (
+                    payload_size32,
+                    payload_align32,
+                    payload_flat_count_js,
+                    payload_lift_fn_js,
+                    payload_lower_fn_js,
+                    is_borrowed,
+                    is_none_type,
+                    is_numeric_type,
+                    is_async_value,
+                ) = match future_ty.payload {
+                    None => (
+                        0,
+                        0,
+                        "0".into(),
+                        "() => {{ throw new Error('empty future payload'); }}".into(),
+                        "() => {{ throw new Error('empty future payload'); }}".into(),
+                        false,
+                        true,
+                        false,
+                        false,
+                    ),
+                    Some(payload_ty) => {
+                        let cabi = self.types.canonical_abi(&payload_ty);
+                        (
+                            cabi.size32,
+                            cabi.align32,
+                            cabi.flat_count
+                                .map(|v| format!("{v}"))
+                                .unwrap_or_else(|| "null".into()),
+                            gen_flat_lift_fn_js_expr(self, &payload_ty, &None),
+                            gen_flat_lower_fn_js_expr(self, &payload_ty, &None),
+                            matches!(payload_ty, InterfaceType::Borrow(_)),
+                            false,
+                            matches!(
+                                payload_ty,
+                                InterfaceType::U8
+                                    | InterfaceType::U16
+                                    | InterfaceType::U32
+                                    | InterfaceType::U64
+                                    | InterfaceType::S8
+                                    | InterfaceType::S16
+                                    | InterfaceType::S32
+                                    | InterfaceType::S64
+                                    | InterfaceType::Float32
+                                    | InterfaceType::Float64
+                            ),
+                            matches!(
+                                payload_ty,
+                                InterfaceType::Stream(_) | InterfaceType::Future(_)
+                            ),
+                        )
+                    }
+                };
+                let payload_ty_name_js = future_ty
+                    .payload
+                    .map(|iface_ty| format!("'{iface_ty:?}'"))
+                    .unwrap_or_else(|| "null".into());
+
                 uwriteln!(
                     self.src.js,
-                    "const trampoline{i} = {future_new_fn}.bind(null, {});\n",
-                    ty.as_u32(),
+                    r#"
+                      const trampoline{i} = {future_new_fn}.bind(null, {{
+                          componentIdx: {component_idx},
+                          futureTableIdx: {future_table_idx},
+                          elemMeta: {{
+                              liftFn: {payload_lift_fn_js},
+                              lowerFn: {payload_lower_fn_js},
+                              payloadTypeName: {payload_ty_name_js},
+                              isNone: {is_none_type},
+                              isNumeric: {is_numeric_type},
+                              isBorrowed: {is_borrowed},
+                              isAsyncValue: {is_async_value},
+                              flatCount: {payload_flat_count_js},
+                              align32: {payload_align32},
+                              size32: {payload_size32},
+                          }},
+                      }});
+                    "#,
                 );
             }
 
-            Trampoline::FutureRead { ty, options, .. } => {
+            Trampoline::FutureWrite {
+                instance,
+                ty,
+                options,
+            }
+            | Trampoline::FutureRead {
+                instance,
+                ty,
+                options,
+            } => {
+                let intrinsic_fn = match trampoline {
+                    Trampoline::FutureRead { .. } => self
+                        .bindgen
+                        .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureRead)),
+                    Trampoline::FutureWrite { .. } => self
+                        .bindgen
+                        .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureWrite)),
+                    _ => unreachable!("invalid trampoline"),
+                };
+
                 let options = self
                     .component
                     .options
                     .get(*options)
                     .expect("failed to find options");
-
-                let future_idx = ty.as_u32();
-
                 let CanonicalOptions {
-                    instance,
+                    async_,
                     string_encoding,
                     callback,
                     post_return,
-                    async_,
                     data_model:
                         CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
                     ..
                 } = options
                 else {
-                    unreachable!("unexpected memory data model during future.read");
+                    unreachable!("unexpected memory data model during future intrinsic");
                 };
-                let component_instance_id = instance.as_u32();
-                let memory_idx = memory.expect("missing memory idx for future.read").as_u32();
-                let realloc_idx = realloc
-                    .map(|v| v.as_u32().to_string())
-                    .unwrap_or_else(|| "null".into());
-                let string_encoding = string_encoding_js_literal(string_encoding);
 
+                assert_eq!(
+                    *instance, options.instance,
+                    "component instances should match"
+                );
                 assert!(
                     callback.is_none(),
-                    "callback should not be present for future read"
+                    "callback should not be present for future intrinsic"
                 );
                 assert!(
                     post_return.is_none(),
-                    "post_return should not be present for future read"
+                    "post_return should not be present for future intrinsic"
                 );
 
-                let future_read_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureRead));
-                uwriteln!(
-                    self.src.js,
-                    r#"const trampoline{i} = {future_read_fn}.bind(
-                         null,
-                         {component_instance_id},
-                         {memory_idx},
-                         {realloc_idx},
-                         {string_encoding},
-                         {async_},
-                         {future_idx},
-                     );
-                    "#,
-                );
-            }
-
-            Trampoline::FutureWrite { ty, options, .. } => {
-                let options = self
-                    .component
-                    .options
-                    .get(*options)
-                    .expect("failed to find options");
-
-                let future_idx = ty.as_u32();
-                let CanonicalOptions {
-                    instance,
-                    string_encoding,
-                    async_,
-                    data_model:
-                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
-                    ..
-                } = options
-                else {
-                    unreachable!("unexpected memory data model during future.write");
-                };
-                let component_instance_id = instance.as_u32();
+                let future_table_idx = ty.as_u32();
+                let component_idx = instance.as_u32();
                 let memory_idx = memory
-                    .expect("missing memory idx for future.write")
+                    .expect("missing memory idx for future intrinsic")
                     .as_u32();
-                let realloc_idx = realloc
-                    .map(|v| v.as_u32().to_string())
-                    .unwrap_or_else(|| "null".into());
+                let (realloc_idx, get_realloc_fn_js) = match realloc {
+                    Some(idx) => (
+                        idx.as_u32().to_string(),
+                        format!("() => realloc{}", idx.as_u32()),
+                    ),
+                    None => ("null".into(), "() => null".to_string()),
+                };
                 let string_encoding = string_encoding_js_literal(string_encoding);
 
-                let future_write_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureWrite));
                 uwriteln!(
                     self.src.js,
-                    r#"const trampoline{i} = {future_write_fn}.bind(
-                         null,
-                         {component_instance_id},
-                         {memory_idx},
-                         {realloc_idx},
-                         {string_encoding},
-                         {async_},
-                         {future_idx},
-                     );
+                    r#"
+                      const trampoline{i} = new WebAssembly.Suspending({intrinsic_fn}.bind(
+                          null,
+                          {{
+                              componentIdx: {component_idx},
+                              memoryIdx: {memory_idx},
+                              getMemoryFn: () => memory{memory_idx},
+                              reallocIdx: {realloc_idx},
+                              getReallocFn: {get_realloc_fn_js},
+                              stringEncoding: {string_encoding},
+                              futureTableIdx: {future_table_idx},
+                              isAsync: {async_},
+                          }},
+                      ));
                     "#,
                 );
             }
 
-            Trampoline::FutureCancelRead { ty, async_, .. } => {
-                let future_cancel_read_fn = self.bindgen.intrinsic(Intrinsic::AsyncFuture(
-                    AsyncFutureIntrinsic::FutureCancelRead,
-                ));
+            Trampoline::FutureCancelRead {
+                instance,
+                ty,
+                async_,
+            }
+            | Trampoline::FutureCancelWrite {
+                instance,
+                ty,
+                async_,
+            } => {
+                let future_cancel_op_fn = match trampoline {
+                    Trampoline::FutureCancelRead { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureCancelRead),
+                    ),
+                    Trampoline::FutureCancelWrite { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureCancelWrite),
+                    ),
+                    _ => unreachable!(),
+                };
+
+                let component_idx = instance.as_u32();
+                let future_table_idx = ty.as_u32();
+
                 uwriteln!(
                     self.src.js,
-                    "const trampoline{i} = {future_cancel_read_fn}.bind(null, {future_idx}, {async_});\n",
-                    future_idx = ty.as_u32(),
+                    r#"
+                      const trampoline{i} = new WebAssembly.Suspending({future_cancel_op_fn}.bind(
+                          null,
+                          {{
+                              futureTableIdx: {future_table_idx},
+                              componentIdx: {component_idx},
+                              isAsync: {async_},
+                          }},
+                      ));
+                    "#,
                 );
             }
 
-            Trampoline::FutureCancelWrite { ty, async_, .. } => {
-                let future_cancel_write_fn = self.bindgen.intrinsic(Intrinsic::AsyncFuture(
-                    AsyncFutureIntrinsic::FutureCancelWrite,
-                ));
+            Trampoline::FutureDropReadable { instance, ty }
+            | Trampoline::FutureDropWritable { instance, ty } => {
+                let future_drop_op_fn = match trampoline {
+                    Trampoline::FutureDropReadable { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureDropReadable),
+                    ),
+                    Trampoline::FutureDropWritable { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureDropWritable),
+                    ),
+                    _ => unreachable!(),
+                };
+
+                let component_idx = instance.as_u32();
+                let future_table_idx = ty.as_u32();
+
                 uwriteln!(
                     self.src.js,
-                    "const trampoline{i} = {future_cancel_write_fn}.bind(null, {future_idx}, {async_});\n",
-                    future_idx = ty.as_u32(),
+                    r#"
+                      const trampoline{i} = new WebAssembly.Suspending({future_drop_op_fn}.bind(
+                          null,
+                          {{
+                              futureTableIdx: {future_table_idx},
+                              componentIdx: {component_idx},
+                          }},
+                      ));
+                "#
                 );
             }
 
-            Trampoline::FutureDropReadable { ty, .. } => {
-                let future_drop_readable_fn = self.bindgen.intrinsic(Intrinsic::AsyncFuture(
-                    AsyncFutureIntrinsic::FutureDropReadable,
-                ));
+            Trampoline::FutureTransfer => {
+                let future_drop_writable_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureTransfer));
                 uwriteln!(
                     self.src.js,
-                    "const trampoline{i} = {future_drop_readable_fn}.bind(null, {future_idx});\n",
-                    future_idx = ty.as_u32(),
+                    "const trampoline{i} = {future_drop_writable_fn};"
                 );
             }
-
-            Trampoline::FutureDropWritable { ty, .. } => {
-                let future_drop_writable_fn = self.bindgen.intrinsic(Intrinsic::AsyncFuture(
-                    AsyncFutureIntrinsic::FutureDropWritable,
-                ));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {future_drop_writable_fn}.bind(null, {future_idx});\n",
-                    future_idx = ty.as_u32(),
-                );
-            }
-
-            Trampoline::FutureTransfer => todo!("Trampoline::FutureTransfer"),
 
             Trampoline::ErrorContextNew { ty, options, .. } => {
                 let CanonicalOptions {
@@ -5046,53 +5166,20 @@ pub fn gen_flat_lift_fn_js_expr(
 
         InterfaceType::Future(ty_idx) => {
             instantiator.add_intrinsic(Intrinsic::Lift(LiftIntrinsic::LiftFlatFuture));
-            let table_idx = ty_idx.as_u32();
             let f = Intrinsic::Lift(LiftIntrinsic::LiftFlatFuture).name();
-            format!("{f}.bind(null, {table_idx})")
+            let table_idx = ty_idx.as_u32();
+            let table_ty = &component_types[*ty_idx];
+            let component_idx = table_ty.instance.as_u32();
+            format!("{f}({{ futureTableIdx: {table_idx}, componentIdx: {component_idx} }})")
         }
 
         InterfaceType::Stream(ty_idx) => {
             instantiator.add_intrinsic(Intrinsic::Lift(LiftIntrinsic::LiftFlatStream));
-            let table_idx = ty_idx.as_u32();
             let f = Intrinsic::Lift(LiftIntrinsic::LiftFlatStream).name();
+            let table_idx = ty_idx.as_u32();
             let table_ty = &component_types[*ty_idx];
             let component_idx = table_ty.instance.as_u32();
-            let stream_ty_idx = table_ty.ty;
-            let stream_ty = &component_types[stream_ty_idx];
-            let payload = stream_ty.payload;
-
-            // TODO(fix): payload u8 should be special cased here
-
-            let (is_borrowed, is_none_type_js, is_numeric_type_js) = match payload {
-                None => (false, true, false),
-                Some(t) => (
-                    matches!(t, InterfaceType::Borrow(_)),
-                    false,
-                    matches!(
-                        ty,
-                        InterfaceType::U8
-                            | InterfaceType::U16
-                            | InterfaceType::U32
-                            | InterfaceType::U64
-                            | InterfaceType::S8
-                            | InterfaceType::S16
-                            | InterfaceType::S32
-                            | InterfaceType::S64
-                            | InterfaceType::Float32
-                            | InterfaceType::Float64
-                    ),
-                ),
-            };
-
-            format!(
-                r#"{f}({{
-                 streamTableIdx: {table_idx},
-                 componentIdx: {component_idx},
-                 isBorrowedType: {is_borrowed},
-                 isNoneType: {is_none_type_js},
-                 isNumericTypeJs: {is_numeric_type_js},
-             }})"#
-            )
+            format!("{f}({{ streamTableIdx: {table_idx}, componentIdx: {component_idx} }})")
         }
 
         InterfaceType::ErrorContext(ty_idx) => {
@@ -5616,10 +5703,93 @@ pub fn gen_flat_lower_fn_js_expr(
 
         InterfaceType::Future(ty_idx) => {
             instantiator.add_intrinsic(Intrinsic::Lower(LowerIntrinsic::LowerFlatFuture));
-            let table_idx = ty_idx.as_u32();
             let f = Intrinsic::Lower(LowerIntrinsic::LowerFlatFuture).name();
+            let table_idx = ty_idx.as_u32();
+            let table_ty = &component_types[*ty_idx];
+            let component_idx = table_ty.instance.as_u32();
+            let future_ty_idx = table_ty.ty;
+            let future_ty = &component_types[future_ty_idx];
+            let payload = future_ty.payload;
+            let payload_ty_name_js = future_ty
+                .payload
+                .map(|iface_ty| format!("'{iface_ty:?}'"))
+                .unwrap_or_else(|| "null".into());
 
-            format!("{f}.bind(null, {table_idx})")
+            // Gather element metadata
+            let (
+                payload_size32,
+                payload_align32,
+                payload_flat_count_js,
+                payload_lift_fn_js,
+                payload_lower_fn_js,
+                is_borrowed,
+                is_none_type,
+                is_numeric_type,
+                is_async_value,
+            ) = match payload {
+                None => (
+                    0,
+                    0,
+                    "0".into(),
+                    "() => {{ throw new Error('empty future payload'); }}".into(),
+                    "() => {{ throw new Error('empty future payload'); }}".into(),
+                    false,
+                    true,
+                    false,
+                    false,
+                ),
+                Some(payload_ty) => {
+                    let cabi = instantiator.types.canonical_abi(&payload_ty);
+                    (
+                        cabi.size32,
+                        cabi.align32,
+                        cabi.flat_count
+                            .map(|v| format!("{v}"))
+                            .unwrap_or_else(|| "null".into()),
+                        gen_flat_lift_fn_js_expr(instantiator, &payload_ty, extra_resource_map),
+                        gen_flat_lower_fn_js_expr(instantiator, &payload_ty, extra_resource_map),
+                        matches!(payload_ty, InterfaceType::Borrow(_)),
+                        false,
+                        matches!(
+                            payload_ty,
+                            InterfaceType::U8
+                                | InterfaceType::U16
+                                | InterfaceType::U32
+                                | InterfaceType::U64
+                                | InterfaceType::S8
+                                | InterfaceType::S16
+                                | InterfaceType::S32
+                                | InterfaceType::S64
+                                | InterfaceType::Float32
+                                | InterfaceType::Float64
+                        ),
+                        matches!(
+                            payload_ty,
+                            InterfaceType::Stream(_) | InterfaceType::Future(_)
+                        ),
+                    )
+                }
+            };
+
+            format!(
+                r#"{f}.bind(null, {{
+                       futureTableIdx: {table_idx},
+                       componentIdx: {component_idx},
+                       elemMeta: {{
+                           liftFn: {payload_lift_fn_js},
+                           lowerFn: {payload_lower_fn_js},
+                           payloadTypeName: {payload_ty_name_js},
+                           isNone: {is_none_type},
+                           isNumeric: {is_numeric_type},
+                           isBorrowed: {is_borrowed},
+                           isAsyncValue: {is_async_value},
+                           flatCount: {payload_flat_count_js},
+                           align32: {payload_align32},
+                           size32: {payload_size32},
+                       }},
+                   }})
+                "#
+            )
         }
 
         InterfaceType::Stream(ty_idx) => {
@@ -5709,7 +5879,6 @@ pub fn gen_flat_lower_fn_js_expr(
                            align32: {payload_align32},
                            size32: {payload_size32},
                        }},
-
                    }})
                 "#
             )

--- a/crates/test-components/src/bin/future_tx.rs
+++ b/crates/test-components/src/bin/future_tx.rs
@@ -1,0 +1,238 @@
+use std::sync::atomic::AtomicU32;
+
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "future-tx",
+        with: {
+            "jco:test-components/get-future-async/example-guest-resource": generate,
+        }
+    });
+    export!(Component);
+}
+
+use wit_bindgen::{FutureReader, StreamReader};
+
+use bindings::exports::jco::test_components::get_future_async;
+use bindings::exports::jco::test_components::get_future_async::GuestExampleGuestResource;
+use bindings::jco::test_components::resources::ExampleResource;
+use bindings::wit_future::FuturePayload;
+use bindings::{wit_future, wit_stream};
+
+struct Component;
+
+static RESOURCE_DISPOSE_COUNT: AtomicU32 = AtomicU32::new(0);
+
+/// Guest-local implementation of `example-resource`
+///
+/// This resource is returned by component exported fucntions, but note
+/// that is is *distinct* from the resource that is provided by the host
+/// and passed in.
+///
+/// This component can look and behave and be linked to the external resource
+/// implementation (forwarding calls to it), but it is *not* the same.
+///
+pub struct ExR(u32);
+
+impl get_future_async::GuestExampleGuestResource for ExR {
+    fn new(id: u32) -> Self {
+        ExR(id)
+    }
+
+    fn get_id(&self) -> u32 {
+        self.0
+    }
+
+    async fn get_id_async(&self) -> u32 {
+        self.0
+    }
+}
+
+// NOTE: we need a default implementation
+impl Default for get_future_async::ExampleRecord {
+    fn default() -> Self {
+        get_future_async::ExampleRecord {
+            id: 0,
+            id_str: "<default>".into(),
+        }
+    }
+}
+
+impl Drop for ExR {
+    fn drop(&mut self) {
+        RESOURCE_DISPOSE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Release);
+    }
+}
+
+impl get_future_async::Guest for Component {
+    type ExampleGuestResource = ExR;
+
+    async fn get_future_bool(v: bool) -> FutureReader<bool> {
+        future_value_async(v)
+    }
+
+    async fn get_future_u32(v: u32) -> FutureReader<u32> {
+        future_value_async(v)
+    }
+
+    async fn get_future_s32(v: i32) -> FutureReader<i32> {
+        future_value_async(v)
+    }
+
+    async fn get_future_u8(vals: u8) -> FutureReader<u8> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_s8(vals: i8) -> FutureReader<i8> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_u16(vals: u16) -> FutureReader<u16> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_s16(vals: i16) -> FutureReader<i16> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_u64(vals: u64) -> FutureReader<u64> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_s64(vals: i64) -> FutureReader<i64> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_f32(vals: f32) -> FutureReader<f32> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_f64(vals: f64) -> FutureReader<f64> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_string(vals: String) -> FutureReader<String> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_record(
+        vals: get_future_async::ExampleRecord,
+    ) -> FutureReader<get_future_async::ExampleRecord> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_variant(
+        v: get_future_async::ExampleVariant,
+    ) -> FutureReader<get_future_async::ExampleVariant> {
+        future_value_async(v)
+    }
+
+    async fn get_future_tuple(v: (u32, i32, String)) -> FutureReader<(u32, i32, String)> {
+        future_value_async(v)
+    }
+
+    async fn get_future_flags(
+        v: get_future_async::ExampleFlags,
+    ) -> FutureReader<get_future_async::ExampleFlags> {
+        future_value_async(v)
+    }
+
+    async fn get_future_enum(
+        vals: get_future_async::ExampleEnum,
+    ) -> FutureReader<get_future_async::ExampleEnum> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_option_string(vals: Option<String>) -> FutureReader<Option<String>> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_result_string(
+        vals: Result<String, String>,
+    ) -> FutureReader<Result<String, String>> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_list_u8(vals: Vec<u8>) -> FutureReader<Vec<u8>> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_list_string(vals: Vec<String>) -> FutureReader<Vec<String>> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_list_record(
+        vals: Vec<get_future_async::ExampleRecord>,
+    ) -> FutureReader<Vec<get_future_async::ExampleRecord>> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_fixed_list_u32(vals: [u32; 5]) -> FutureReader<[u32; 5]> {
+        future_value_async(vals)
+    }
+
+    async fn get_future_example_resource_own(
+        v: u32,
+    ) -> FutureReader<get_future_async::ExampleGuestResource> {
+        future_value_async(get_future_async::ExampleGuestResource::new(ExR::new(v)))
+    }
+
+    fn get_example_resource_own_disposes() -> u32 {
+        RESOURCE_DISPOSE_COUNT.load(std::sync::atomic::Ordering::Acquire)
+    }
+
+    async fn get_future_future_string(v: String) -> FutureReader<FutureReader<String>> {
+        let (tx, rx) = wit_future::new(|| unreachable!());
+        wit_bindgen::spawn(async move {
+            let (nested_tx, nested_rx) = wit_future::new(|| unreachable!());
+            // NOTE: order here matters, we must first write the inner rx out before actually filling it
+            let _ = tx.write(nested_rx).await;
+            let _ = nested_tx.write(v).await;
+        });
+        rx
+    }
+
+    async fn get_future_example_resource_own_attr(v: ExampleResource) -> FutureReader<u32> {
+        let (tx, rx) = wit_future::new(|| unreachable!());
+        wit_bindgen::spawn(async move {
+            let _ = tx.write(v.get_id()).await;
+        });
+        rx
+    }
+
+    // NOTE: Spool means this function will replay received values
+    async fn get_future_stream_string_spool(
+        vals: Vec<String>,
+    ) -> FutureReader<StreamReader<String>> {
+        let (future_tx, future_rx) = wit_future::new(|| unreachable!());
+        let (mut stream_tx, stream_rx) = wit_stream::new();
+        wit_bindgen::spawn(async move {
+            let _ = future_tx.write(stream_rx).await;
+            for v in vals {
+                stream_tx.write_one(v).await;
+            }
+        });
+        future_rx
+    }
+
+    async fn get_future_stream_string(
+        v: StreamReader<String>,
+    ) -> FutureReader<StreamReader<String>> {
+        let (future_tx, future_rx) = wit_future::new(|| unreachable!());
+        wit_bindgen::spawn(async move {
+            let _ = future_tx.write(v).await;
+        });
+        future_rx
+    }
+}
+
+fn future_value_async<T: FuturePayload>(v: T) -> FutureReader<T> {
+    let (tx, rx) = wit_future::new(|| unreachable!("default value should not be used"));
+    wit_bindgen::spawn(async move {
+        let _ = tx.write(v).await;
+    });
+    rx
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/src/bin/stream_tx.rs
+++ b/crates/test-components/src/bin/stream_tx.rs
@@ -11,7 +11,7 @@ mod bindings {
     export!(Component);
 }
 
-use wit_bindgen::StreamReader;
+use wit_bindgen::{FutureReader, StreamReader};
 
 use bindings::exports::jco::test_components::get_stream_async;
 use bindings::exports::jco::test_components::get_stream_async::GuestExampleGuestResource;
@@ -57,131 +57,113 @@ impl Drop for ExR {
 impl get_stream_async::Guest for Component {
     type ExampleGuestResource = ExR;
 
-    async fn get_stream_u32(vals: Vec<u32>) -> Result<StreamReader<u32>, String> {
+    async fn get_stream_u32(vals: Vec<u32>) -> StreamReader<u32> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_s32(vals: Vec<i32>) -> Result<StreamReader<i32>, String> {
+    async fn get_stream_s32(vals: Vec<i32>) -> StreamReader<i32> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_bool(vals: Vec<bool>) -> Result<StreamReader<bool>, String> {
+    async fn get_stream_bool(vals: Vec<bool>) -> StreamReader<bool> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_u8(vals: Vec<u8>) -> Result<StreamReader<u8>, String> {
+    async fn get_stream_u8(vals: Vec<u8>) -> StreamReader<u8> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_s8(vals: Vec<i8>) -> Result<StreamReader<i8>, String> {
+    async fn get_stream_s8(vals: Vec<i8>) -> StreamReader<i8> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_u16(vals: Vec<u16>) -> Result<StreamReader<u16>, String> {
+    async fn get_stream_u16(vals: Vec<u16>) -> StreamReader<u16> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_s16(vals: Vec<i16>) -> Result<StreamReader<i16>, String> {
+    async fn get_stream_s16(vals: Vec<i16>) -> StreamReader<i16> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_u64(vals: Vec<u64>) -> Result<StreamReader<u64>, String> {
+    async fn get_stream_u64(vals: Vec<u64>) -> StreamReader<u64> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_s64(vals: Vec<i64>) -> Result<StreamReader<i64>, String> {
+    async fn get_stream_s64(vals: Vec<i64>) -> StreamReader<i64> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_f32(vals: Vec<f32>) -> Result<StreamReader<f32>, String> {
+    async fn get_stream_f32(vals: Vec<f32>) -> StreamReader<f32> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_f64(vals: Vec<f64>) -> Result<StreamReader<f64>, String> {
+    async fn get_stream_f64(vals: Vec<f64>) -> StreamReader<f64> {
         stream_values_async(vals)
     }
 
-    // NOTE: stream<char> is not yet supported upstream (stream<u8> can be used instead)
-    // async fn get_stream_char(vals: Vec<char>) -> Result<StreamReader<char>, String> {
-    //     stream_values_async(vals)
-    // }
-
-    async fn get_stream_string(vals: Vec<String>) -> Result<StreamReader<String>, String> {
+    async fn get_stream_string(vals: Vec<String>) -> StreamReader<String> {
         stream_values_async(vals)
     }
 
     async fn get_stream_record(
         vals: Vec<get_stream_async::ExampleRecord>,
-    ) -> Result<StreamReader<get_stream_async::ExampleRecord>, String> {
+    ) -> StreamReader<get_stream_async::ExampleRecord> {
         stream_values_async(vals)
     }
 
     async fn get_stream_variant(
         vals: Vec<get_stream_async::ExampleVariant>,
-    ) -> Result<StreamReader<get_stream_async::ExampleVariant>, String> {
+    ) -> StreamReader<get_stream_async::ExampleVariant> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_tuple(
-        vals: Vec<(u32, i32, String)>,
-    ) -> Result<StreamReader<(u32, i32, String)>, String> {
+    async fn get_stream_tuple(vals: Vec<(u32, i32, String)>) -> StreamReader<(u32, i32, String)> {
         stream_values_async(vals)
     }
 
     async fn get_stream_flags(
         vals: Vec<get_stream_async::ExampleFlags>,
-    ) -> Result<StreamReader<get_stream_async::ExampleFlags>, String> {
+    ) -> StreamReader<get_stream_async::ExampleFlags> {
         stream_values_async(vals)
     }
 
     async fn get_stream_enum(
         vals: Vec<get_stream_async::ExampleEnum>,
-    ) -> Result<StreamReader<get_stream_async::ExampleEnum>, String> {
+    ) -> StreamReader<get_stream_async::ExampleEnum> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_option_string(
-        vals: Vec<Option<String>>,
-    ) -> Result<StreamReader<Option<String>>, String> {
+    async fn get_stream_option_string(vals: Vec<Option<String>>) -> StreamReader<Option<String>> {
         stream_values_async(vals)
     }
 
     async fn get_stream_result_string(
         vals: Vec<Result<String, String>>,
-    ) -> Result<StreamReader<Result<String, String>>, String> {
+    ) -> StreamReader<Result<String, String>> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_list_u8(vals: Vec<Vec<u8>>) -> Result<StreamReader<Vec<u8>>, String> {
+    async fn get_stream_list_u8(vals: Vec<Vec<u8>>) -> StreamReader<Vec<u8>> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_list_string(
-        vals: Vec<Vec<String>>,
-    ) -> Result<StreamReader<Vec<String>>, String> {
+    async fn get_stream_list_string(vals: Vec<Vec<String>>) -> StreamReader<Vec<String>> {
         stream_values_async(vals)
     }
 
     async fn get_stream_list_record(
         vals: Vec<Vec<get_stream_async::ExampleRecord>>,
-    ) -> Result<StreamReader<Vec<get_stream_async::ExampleRecord>>, String> {
+    ) -> StreamReader<Vec<get_stream_async::ExampleRecord>> {
         stream_values_async(vals)
     }
 
-    async fn get_stream_fixed_list_u32(
-        vals: Vec<[u32; 5]>,
-    ) -> Result<StreamReader<[u32; 5]>, String> {
+    async fn get_stream_fixed_list_u32(vals: Vec<[u32; 5]>) -> StreamReader<[u32; 5]> {
         stream_values_async(vals)
     }
-
-    // async fn get_stream_example_resource_own(vals: Vec<u32>) -> Result<StreamReader<ExR>, String> {
-    //     let resources: Vec<ExR> = vals.iter().map(|v| ExR::new(*v)).collect();
-    //     stream_values_async(resources)
-    // }
 
     async fn get_stream_example_resource_own(
         vals: Vec<u32>,
-    ) -> Result<StreamReader<get_stream_async::ExampleGuestResource>, String> {
+    ) -> StreamReader<get_stream_async::ExampleGuestResource> {
         let resources = vals
             .iter()
             .map(|v| get_stream_async::ExampleGuestResource::new(ExR::new(*v)))
@@ -193,21 +175,17 @@ impl get_stream_async::Guest for Component {
         RESOURCE_DISPOSE_COUNT.load(std::sync::atomic::Ordering::Acquire)
     }
 
-    async fn get_stream_example_resource_own_attr(
-        vals: Vec<ExampleResource>,
-    ) -> Result<StreamReader<u32>, String> {
+    async fn get_stream_example_resource_own_attr(vals: Vec<ExampleResource>) -> StreamReader<u32> {
         let (mut tx, rx) = wit_stream::new();
         wit_bindgen::spawn(async move {
             for r in vals.iter() {
                 tx.write(vec![r.get_id()]).await;
             }
         });
-        Ok(rx)
+        rx
     }
 
-    async fn get_stream_stream_string(
-        vals: Vec<String>,
-    ) -> Result<StreamReader<StreamReader<String>>, String> {
+    async fn get_stream_stream_string(vals: Vec<String>) -> StreamReader<StreamReader<String>> {
         let (mut tx, rx) = wit_stream::new();
         wit_bindgen::spawn(async move {
             for v in vals {
@@ -216,16 +194,28 @@ impl get_stream_async::Guest for Component {
                 nested_tx.write(vec![v]).await;
             }
         });
-        Ok(rx)
+        rx
+    }
+
+    async fn get_stream_future_string(
+        vals: Vec<FutureReader<String>>,
+    ) -> StreamReader<FutureReader<String>> {
+        let (mut tx, rx) = wit_stream::new();
+        wit_bindgen::spawn(async move {
+            for v in vals {
+                tx.write_one(v).await;
+            }
+        });
+        rx
     }
 }
 
-fn stream_values_async<T: StreamPayload>(vals: Vec<T>) -> Result<StreamReader<T>, String> {
+fn stream_values_async<T: StreamPayload>(vals: Vec<T>) -> StreamReader<T> {
     let (mut tx, rx) = wit_stream::new();
     wit_bindgen::spawn(async move {
         tx.write_all(vals).await;
     });
-    Ok(rx)
+    rx
 }
 
 // Stub only to ensure this works as a binary

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -59,48 +59,48 @@ interface get-stream-async {
         get-id-async: async func() -> u32;
     }
 
-    get-stream-u32: async func(vals: list<u32>) -> result<stream<u32>, string>;
-    get-stream-s32: async func(vals: list<s32>) -> result<stream<s32>, string>;
+    get-stream-bool: async func(vals: list<bool>) -> stream<bool>;
 
-    get-stream-u8: async func(vals: list<u8>) -> result<stream<u8>, string>;
-    get-stream-s8: async func(vals: list<s8>) -> result<stream<s8>, string>;
+    get-stream-u32: async func(vals: list<u32>) -> stream<u32>;
+    get-stream-s32: async func(vals: list<s32>) -> stream<s32>;
 
-    get-stream-u16: async func(vals: list<u16>) -> result<stream<u16>, string>;
-    get-stream-s16: async func(vals: list<s16>) -> result<stream<s16>, string>;
+    get-stream-u8: async func(vals: list<u8>) -> stream<u8>;
+    get-stream-s8: async func(vals: list<s8>) -> stream<s8>;
 
-    get-stream-u64: async func(vals: list<u64>) -> result<stream<u64>, string>;
-    get-stream-s64: async func(vals: list<s64>) -> result<stream<s64>, string>;
+    get-stream-u16: async func(vals: list<u16>) -> stream<u16>;
+    get-stream-s16: async func(vals: list<s16>) -> stream<s16>;
 
-    get-stream-f32: async func(vals: list<f32>) -> result<stream<f32>, string>;
+    get-stream-u64: async func(vals: list<u64>) -> stream<u64>;
+    get-stream-s64: async func(vals: list<s64>) -> stream<s64>;
 
-    get-stream-f64: async func(vals: list<f64>) -> result<stream<f64>, string>;
+    get-stream-f32: async func(vals: list<f32>) -> stream<f32>;
 
-    get-stream-bool: async func(vals: list<bool>) -> result<stream<bool>, string>;
+    get-stream-f64: async func(vals: list<f64>) -> stream<f64>;
 
     // NOTE: stream<char> is not yet supported upstream (stream<u8> can be used instead)
     //
     // get-stream-char: async func(vals: list<char>) -> result<stream<char>, string>;
 
-    get-stream-string: async func(vals: list<string>) -> result<stream<string>, string>;
+    get-stream-string: async func(vals: list<string>) -> stream<string>;
 
-    get-stream-record: async func(vals: list<example-record>) -> result<stream<example-record>, string>;
+    get-stream-record: async func(vals: list<example-record>) -> stream<example-record>;
 
-    get-stream-variant: async func(vals: list<example-variant>) -> result<stream<example-variant>, string>;
+    get-stream-variant: async func(vals: list<example-variant>) -> stream<example-variant>;
 
-    get-stream-list-u8: async func(vals: list<list<u8>>) -> result<stream<list<u8>>, string>;
-    get-stream-list-string: async func(vals: list<list<string>>) -> result<stream<list<string>>, string>;
-    get-stream-list-record: async func(vals: list<list<example-record>>) -> result<stream<list<example-record>>, string>;
-    get-stream-fixed-list-u32: async func(vals: list<list<u32, 5>>) -> result<stream<list<u32, 5>>, string>;
+    get-stream-list-u8: async func(vals: list<list<u8>>) -> stream<list<u8>>;
+    get-stream-list-string: async func(vals: list<list<string>>) -> stream<list<string>>;
+    get-stream-list-record: async func(vals: list<list<example-record>>) -> stream<list<example-record>>;
+    get-stream-fixed-list-u32: async func(vals: list<list<u32, 5>>) -> stream<list<u32, 5>>;
 
-    get-stream-tuple: async func(vals: list<tuple<u32, s32, string>>) -> result<stream<tuple<u32, s32, string>>, string>;
+    get-stream-tuple: async func(vals: list<tuple<u32, s32, string>>) -> stream<tuple<u32, s32, string>>;
 
-    get-stream-flags: async func(vals: list<example-flags>) -> result<stream<example-flags>, string>;
+    get-stream-flags: async func(vals: list<example-flags>) -> stream<example-flags>;
 
-    get-stream-enum: async func(vals: list<example-enum>) -> result<stream<example-enum>, string>;
+    get-stream-enum: async func(vals: list<example-enum>) -> stream<example-enum>;
 
-    get-stream-option-string: async func(vals: list<option<string>>) -> result<stream<option<string>>, string>;
+    get-stream-option-string: async func(vals: list<option<string>>) -> stream<option<string>>;
 
-    get-stream-result-string: async func(vals: list<result<string, string>>) -> result<stream<result<string, string>>, string>;
+    get-stream-result-string: async func(vals: list<result<string, string>>) -> stream<result<string, string>>;
 
     // NOTE: stream<borrow<t>> is not supoprted
     //
@@ -108,14 +108,89 @@ interface get-stream-async {
     //   vals: list<borrow<example-resource>>
     // ) -> result<stream<borrow<example-resource>>, string>;
 
-    get-stream-example-resource-own: async func(vals: list<u32>) -> result<stream<example-guest-resource>, string>;
+    get-stream-example-resource-own: async func(vals: list<u32>) -> stream<example-guest-resource>;
     get-example-resource-own-disposes: func() -> u32;
 
-    get-stream-example-resource-own-attr: async func(vals: list<example-resource>) -> result<stream<u32>, string>;
+    get-stream-example-resource-own-attr: async func(vals: list<example-resource>) -> stream<u32>;
 
-    get-stream-stream-string: async func(vals: list<string>) -> result<stream<stream<string>>, string>;
+    get-stream-stream-string: async func(vals: list<string>) -> stream<stream<string>>;
 
-    //get-stream-future-string: async func(vals: list<future<string>>) -> result<stream<future<string>>, string>;
+    // The unspooled version should take advantage of host->host optimizations
+    get-stream-future-string: async func(vals: list<future<string>>) -> stream<future<string>>;
+}
+
+
+interface get-future-async {
+    use resources.{example-resource};
+    use example-types.{example-variant, example-enum, example-record, example-flags};
+
+    resource example-guest-resource {
+        constructor(id: u32);
+        get-id: func() -> u32;
+        get-id-async: async func() -> u32;
+    }
+
+    get-future-bool: async func(vals: bool) -> future<bool>;
+
+    get-future-u32: async func(vals: u32) -> future<u32>;
+    get-future-s32: async func(vals: s32) -> future<s32>;
+
+    get-future-u8: async func(vals: u8) -> future<u8>;
+    get-future-s8: async func(vals: s8) -> future<s8>;
+
+    get-future-u16: async func(vals: u16) -> future<u16>;
+    get-future-s16: async func(vals: s16) -> future<s16>;
+
+    get-future-u64: async func(vals: u64) -> future<u64>;
+    get-future-s64: async func(vals: s64) -> future<s64>;
+
+    get-future-f32: async func(vals: f32) -> future<f32>;
+
+    get-future-f64: async func(vals: f64) -> future<f64>;
+
+    // NOTE: future<char> is not yet supported upfuture (future<u8> can be used instead)
+    //
+    // get-future-char: async func(vals: list<char>) -> result<future<char>, string>;
+
+    get-future-string: async func(vals: string) -> future<string>;
+
+    get-future-record: async func(vals: example-record) -> future<example-record>;
+
+    get-future-variant: async func(vals: example-variant) -> future<example-variant>;
+
+    get-future-list-u8: async func(vals: list<u8>) -> future<list<u8>>;
+    get-future-list-string: async func(vals: list<string>) -> future<list<string>>;
+    get-future-list-record: async func(vals: list<example-record>) -> future<list<example-record>>;
+    get-future-fixed-list-u32: async func(vals: list<u32, 5>) -> future<list<u32, 5>>;
+
+    get-future-tuple: async func(vals: tuple<u32, s32, string>) -> future<tuple<u32, s32, string>>;
+
+    get-future-flags: async func(vals: example-flags) -> future<example-flags>;
+
+    get-future-enum: async func(vals: example-enum) -> future<example-enum>;
+
+    get-future-option-string: async func(vals: option<string>) -> future<option<string>>;
+
+    get-future-result-string: async func(vals: result<string, string>) -> future<result<string, string>>;
+
+    // NOTE: future<borrow<t>> is not supoprted
+    //
+    // get-future-example-resource-borrow: async func(
+    //   vals: list<borrow<example-resource>>
+    // ) -> result<future<borrow<example-resource>>, string>;
+
+    get-future-example-resource-own: async func(vals: u32) -> future<example-guest-resource>;
+    get-example-resource-own-disposes: func() -> u32;
+
+    get-future-example-resource-own-attr: async func(vals: example-resource) -> future<u32>;
+
+    get-future-future-string: async func(vals: string) -> future<future<string>>;
+
+    // The unspooled version should take advantage of host->host optimizations
+    get-future-stream-string: async func(vals: stream<string>) -> future<stream<string>>;
+
+    // The spooled version returns a *new* stream that forces transit through the component 
+    get-future-stream-string-spool: async func(vals: list<string>) -> future<stream<string>>;
 }
 
 world async-simple-import {
@@ -142,6 +217,11 @@ world async-simple-return {
 world stream-tx {
   import resources;
   export get-stream-async;
+}
+
+world future-tx {
+  import resources;
+  export get-future-async;
 }
 
 interface sleep-post-return {

--- a/crates/xtask/src/generate/preview2_tests.rs
+++ b/crates/xtask/src/generate/preview2_tests.rs
@@ -25,6 +25,14 @@ const TEST_IGNORE: &[&str] = &[
     "cli_serve_config",
     // TODO: Support these tests
     "cli_multiple_preopens",
+    // NOTE: the tests below are broken because we now check before coercing
+    // numeric inputs to functions
+    //
+    // We should certainly fix these tests, but ensuring that users have
+    // prompt feedback for invalid inputs takes priority.
+    "preview2_ip_name_lookup",
+    "preview1_fd_filestat_set",
+    "preview1_symlink_filestat",
 ];
 
 /// We don't currently support these subsystems, but if someone wants to work on them we

--- a/packages/jco/test/common.js
+++ b/packages/jco/test/common.js
@@ -86,3 +86,18 @@ export function createReadableStreamFromValues(vals) {
         },
     });
 }
+
+/** Check the value of a given future (normally returned from a component) */
+export async function checkFutureValues(args) {
+    const { vals, func, typeName, assertEqFn } = args ?? {};
+    const expectedValues = args.expectedValues ?? [];
+    const eq = assertEqFn ?? assert.equal;
+
+    let future;
+    let res;
+    for (const [idx, v] of vals.entries()) {
+        future = await func(v);
+        res = await future;
+        await eq(res, expectedValues[idx] ?? v, `${typeName} future read is incorrect`);
+    }
+}

--- a/packages/jco/test/p3/future-lifts.js
+++ b/packages/jco/test/p3/future-lifts.js
@@ -1,0 +1,521 @@
+import { join } from "node:path";
+
+import { suite, test, assert, beforeAll, beforeEach, afterAll, expect } from "vitest";
+
+import { setupAsyncTest } from "../helpers.js";
+import {
+    AsyncFunction,
+    LOCAL_TEST_COMPONENTS_DIR,
+    checkFutureValues,
+    createReadableStreamFromValues,
+} from "../common.js";
+import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
+
+suite("future<T> lifts", () => {
+    let esModule, cleanup, instance;
+
+    class ExampleResource {
+        #id;
+        constructor(id) {
+            this.#id = id;
+        }
+        getId() {
+            return this.#id;
+        }
+    }
+
+    beforeAll(async () => {
+        const name = "future-tx";
+        const setupRes = await setupAsyncTest({
+            asyncMode: "jspi",
+            component: {
+                name,
+                path: join(LOCAL_TEST_COMPONENTS_DIR, `${name}.wasm`),
+                skipInstantiation: true,
+            },
+            jco: {
+                transpile: {
+                    extraArgs: {
+                        minify: false,
+                    },
+                },
+            },
+        });
+
+        esModule = setupRes.esModule;
+        cleanup = setupRes.cleanup;
+        //console.log("OUTPUT DIR", setupRes.outputDir);
+    });
+
+    afterAll(async () => {
+        await cleanup();
+    });
+
+    beforeEach(async () => {
+        instance = await esModule.instantiate(undefined, {
+            ...new WASIShim().getImportObject(),
+            "jco:test-components/resources": {
+                ExampleResource,
+            },
+        });
+    });
+
+    test.concurrent("bool", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureBool, AsyncFunction);
+        const vals = [true, false];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureBool,
+            typeName: "bool",
+        });
+    });
+
+    test.concurrent("u8/s8", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureU8, AsyncFunction);
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureS8, AsyncFunction);
+
+        let vals = [0, 1, 255];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureU8,
+            typeName: "u8",
+        });
+
+        let invalidVals = [-1, 256];
+        for (const invalid of invalidVals) {
+            await expect(() => instance["jco:test-components/get-future-async"].getFutureU8(invalid)).rejects.toThrow(
+                /invalid u8 value/,
+            );
+        }
+
+        vals = [-11, -22, -33, -128, 127];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureS8,
+            typeName: "s8",
+        });
+
+        invalidVals = [-129, 128];
+        for (const invalid of invalidVals) {
+            await expect(() => instance["jco:test-components/get-future-async"].getFutureS8(invalid)).rejects.toThrow(
+                /invalid s8 value/,
+            );
+        }
+    });
+
+    test.concurrent("u16/s16", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureU16, AsyncFunction);
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureS16, AsyncFunction);
+
+        let vals = [0, 100, 65535];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureU16,
+            typeName: "u16",
+        });
+
+        vals = [-32_768, 0, 32_767];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureS16,
+            typeName: "s16",
+        });
+    });
+
+    test.concurrent("u32/s32", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureU32, AsyncFunction);
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureS32, AsyncFunction);
+
+        let vals = [11, 22, 33];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureU32,
+            typeName: "u32",
+        });
+
+        vals = [-11, -22, -33];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureS32,
+            typeName: "s32",
+        });
+    });
+
+    test.concurrent("u64/s64", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureU64, AsyncFunction);
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureS64, AsyncFunction);
+
+        let vals = [0n, 100n, 65535n];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureU64,
+            typeName: "u64",
+        });
+
+        let invalidVals = [-1n, 18446744073709551616n];
+        for (const invalid of invalidVals) {
+            await expect(() => instance["jco:test-components/get-future-async"].getFutureU64(invalid)).rejects.toThrow(
+                /invalid u64 value/,
+            );
+        }
+
+        vals = [-32_768n, 0n, 32_767n];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureS64,
+            typeName: "s64",
+        });
+
+        invalidVals = [-9223372036854775809n, 9223372036854775808n];
+        for (const invalid of invalidVals) {
+            await expect(() => instance["jco:test-components/get-future-async"].getFutureS64(invalid)).rejects.toThrow(
+                /invalid s64 value/,
+            );
+        }
+    });
+
+    test.concurrent("f32/f64", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureF64, AsyncFunction);
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureF32, AsyncFunction);
+
+        let vals = [-300.01235, -1.5, -0.0, 0.0, 1.5, 300.01235];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureF32,
+            typeName: "f32",
+            assertEqFn: (value, expected) => {
+                assert.closeTo(value, expected, 0.00001);
+            },
+        });
+
+        vals = [-300.01235, -1.5, -0.0, 0.0, 1.5, -300.01235];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureF64,
+            typeName: "f64",
+            assertEqFn: (value, expected) => {
+                assert.closeTo(value, expected, 0.00001);
+            },
+        });
+    });
+
+    test.concurrent("string", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureString, AsyncFunction);
+
+        let vals = ["hello", "world", "!"];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureString,
+            typeName: "string",
+        });
+    });
+
+    test.concurrent("record", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureRecord, AsyncFunction);
+
+        let vals = [
+            { id: 1, idStr: "one" },
+            { id: 2, idStr: "two" },
+            { id: 3, idStr: "three" },
+        ];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureRecord,
+            typeName: "record",
+            assertEqFn: assert.deepEqual,
+        });
+    });
+
+    test.concurrent("variant", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureVariant, AsyncFunction);
+
+        let vals = [
+            { tag: "maybe-u32", val: 123 },
+            { tag: "maybe-u32", val: null },
+        ];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureVariant,
+            typeName: "variant<maybe-u32>",
+            expectedValues: [
+                // TODO: wit type representation smoothing mismatch,
+                // non-nullable option<t> values are *not* wrapped as objects
+                { tag: "maybe-u32", val: { tag: "some", val: 123 } },
+                { tag: "maybe-u32", val: { tag: "none" } },
+            ],
+            assertEqFn: assert.deepEqual,
+        });
+
+        vals = [{ tag: "float", val: 123.1 }];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureVariant,
+            typeName: "variant<float>",
+            assertEqFn: (value, expected) => {
+                {
+                    assert.equal(value.tag, expected.tag);
+                    assert.closeTo(value.val, expected.val, 0.00001);
+                }
+            },
+        });
+
+        vals = [
+            { tag: "str", val: "string-value" },
+            { tag: "num", val: 1 },
+        ];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureVariant,
+            typeName: "variant<rest>",
+            assertEqFn: assert.deepEqual,
+        });
+    });
+
+    test.concurrent("tuple", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureTuple, AsyncFunction);
+
+        let vals = [
+            [0, 1, "first"],
+            [2, 3, "second"],
+            [3, 4, "third"],
+        ];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureTuple,
+            typeName: "tuple",
+            assertEqFn: assert.deepEqual,
+        });
+    });
+
+    test.concurrent("flags", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureFlags, AsyncFunction);
+
+        let vals = [
+            { first: true, second: false, third: false },
+            { first: false, second: true, third: false },
+            { first: false, second: false, third: true },
+        ];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureFlags,
+            typeName: "tuple",
+            assertEqFn: assert.deepEqual,
+        });
+    });
+
+    test.concurrent("enum", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureEnum, AsyncFunction);
+
+        let vals = ["first", "second", "third"];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureEnum,
+            typeName: "enum",
+            assertEqFn: assert.deepEqual,
+        });
+    });
+
+    test.concurrent("option<string>", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureOptionString, AsyncFunction);
+
+        let vals = ["present string", null];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureOptionString,
+            typeName: "option<string>",
+            expectedValues: [
+                // TODO: wit type representation smoothing mismatch
+                { tag: "some", val: "present string" },
+                { tag: "none" },
+            ],
+            assertEqFn: assert.deepEqual,
+        });
+    });
+
+    test.concurrent("list<u8>", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureListU8, AsyncFunction);
+        let vals = [[0x01, 0x02, 0x03, 0x04, 0x05], new Uint8Array([0x05, 0x04, 0x03, 0x02, 0x01]), []];
+
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureListU8,
+            typeName: "list<u8>",
+            expectedValues: [
+                // TODO: wit type representation smoothing mismatch
+                vals[0],
+                [...vals[1]],
+                [],
+            ],
+            assertEqFn: assert.deepEqual,
+        });
+    });
+
+    // TODO(fix): add tests for optimized UintXArrays (js_array_ty)
+
+    test.concurrent("list<string>", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureListString, AsyncFunction);
+        let vals = [["first", "second", "third"], []];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureListString,
+            typeName: "list<string>",
+            assertEqFn: assert.deepEqual,
+        });
+    });
+
+    test.concurrent("list<u32, 5>", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureFixedListU32, AsyncFunction);
+        let vals = [
+            [1, 2, 3, 4, 5],
+            [0, 0, 0, 0, 0],
+        ];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureFixedListU32,
+            typeName: "list<u32, 5>",
+            assertEqFn: assert.deepEqual,
+        });
+        // TODO: test misuse of fixed length list
+    });
+
+    test.concurrent("list<record>", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureListRecord, AsyncFunction);
+        let vals = [
+            [{ id: 1, idStr: "one" }],
+            [
+                { id: 1, idStr: "one" },
+                { id: 2, idStr: "two" },
+            ],
+            [
+                { id: 1, idStr: "one" },
+                { id: 2, idStr: "two" },
+                { id: 3, idStr: "three" },
+            ],
+            [],
+        ];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureListRecord,
+            typeName: "list<record>",
+            assertEqFn: assert.deepEqual,
+        });
+    });
+
+    test.concurrent("result<string>", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureResultString, AsyncFunction);
+        let vals = [
+            { tag: "ok", val: "present string" },
+            { tag: "err", val: "nope" },
+        ];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureResultString,
+            typeName: "result<string>",
+            assertEqFn: assert.deepEqual,
+        });
+    });
+
+    test.concurrent("example-resource", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureExampleResourceOwn, AsyncFunction);
+        const disposeSymbol = Symbol.dispose || Symbol.for("dispose");
+
+        let vals = [2, 1, 0];
+        const resources = [];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureExampleResourceOwn,
+            typeName: "example-guest-resource",
+            assertEqFn: (resource, expectedResourceId) => {
+                assert.isNotNull(resource);
+                assert.instanceOf(resource, instance["jco:test-components/get-future-async"].ExampleGuestResource);
+                assert.strictEqual(resource.getId(), expectedResourceId);
+                resources.push(resource);
+            },
+        });
+
+        let numDisposed = 0;
+        for (const resource of resources) {
+            assert.strictEqual(resource.getId(), await resource.getIdAsync());
+            assert.doesNotThrow(() => resource[disposeSymbol]());
+            numDisposed += 1;
+            assert.strictEqual(
+                instance["jco:test-components/get-future-async"].getExampleResourceOwnDisposes(),
+                numDisposed,
+            );
+        }
+    });
+
+    test.concurrent("example-resource#get-id", async () => {
+        assert.instanceOf(
+            instance["jco:test-components/get-future-async"].getFutureExampleResourceOwnAttr,
+            AsyncFunction,
+        );
+
+        let vals = [new ExampleResource(2), new ExampleResource(1), new ExampleResource(0)];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureExampleResourceOwnAttr,
+            typeName: "example-resource#get-id (output)",
+            assertEqFn: assert.deepEqual,
+            expectedValues: [2, 1, 0],
+        });
+    });
+
+    test.concurrent("future<string>", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureFutureString, AsyncFunction);
+
+        let vals = ["first", "third", "second"];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureFutureString,
+            assertEqFn: async (v, expected) => {
+                // NOTE: nested Promises are automatically resolved together/collapsed in JS.
+                // by the time this assert eq function runs, the future will have been awaited
+                // and nested inner future will *also* have been resolved.
+                assert.strictEqual(v, expected);
+            },
+        });
+    });
+
+    test.concurrent("future<stream<string>> (spooled)", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureStreamStringSpool, AsyncFunction);
+
+        let vals = [
+            // NOTE: this fn takes a *list* of strings to return, and vals are used as input one at a time
+            ["first", "third", "second"],
+        ];
+        await checkFutureValues({
+            vals,
+            func: instance["jco:test-components/get-future-async"].getFutureStreamStringSpool,
+            assertEqFn: async (nestedStream, expected) => {
+                console.log("nestedStream?", nestedStream);
+                let idx = 0;
+                for await (const value of nestedStream) {
+                    assert.strictEqual(value, expected[idx]);
+                    idx++;
+                }
+            },
+        });
+    });
+
+    // NOTE: when this test runs the host-only read/write optimization should be in place
+    // this component is *not* acting like a spool for the values
+    test.concurrent("future<stream<string>>", async () => {
+        assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureFutureString, AsyncFunction);
+
+        let vals = [["first", "third", "second"]];
+        let resIdx = 0;
+        await checkFutureValues({
+            vals: vals.map(createReadableStreamFromValues),
+            func: instance["jco:test-components/get-future-async"].getFutureStreamString,
+            assertEqFn: async (stream, _expected) => {
+                let elemIdx = 0;
+                for await (const value of stream) {
+                    assert.strictEqual(value, vals[resIdx][elemIdx]);
+                    elemIdx++;
+                }
+                resIdx++;
+            },
+        });
+    });
+});

--- a/packages/preview2-shim/lib/nodejs/filesystem.js
+++ b/packages/preview2-shim/lib/nodejs/filesystem.js
@@ -39,7 +39,7 @@ const symbolDispose = Symbol.dispose || Symbol.for("dispose");
 const isWindows = platform === "win32";
 const isMac = platform === "darwin";
 
-const nsMagnitude = 1_000_000_000_000n;
+const nsMagnitude = 1_000_000_000n;
 function nsToDateTime(ns) {
   const seconds = ns / nsMagnitude;
   const nanoseconds = Number(ns % nsMagnitude);
@@ -328,8 +328,10 @@ class Descriptor {
     if (!pathFlags.symlinkFollow && !lutimesSync) {
       throw new Error("Changing the timestamps of symlinks isn't supported");
     }
+
+    let metadataSetFn = pathFlags.symlinkFollow ? lutimesSync : utimesSync;
     try {
-      (pathFlags.symlinkFollow ? utimesSync : lutimesSync)(fullPath, atime, mtime);
+      metadataSetFn(fullPath, atime / 1000, mtime / 1000);
     } catch (e) {
       throw convertFsError(e);
     }
@@ -814,5 +816,14 @@ function convertFsError(e) {
 }
 
 function timestampToMs(timestamp) {
-  return Number(timestamp.seconds) * 1000 + timestamp.nanoseconds / 1e9;
+  let secondsInMillis = timestamp.seconds * 1000n;
+  if (secondsInMillis > Number.MAX_SAFE_INTEGER) {
+    throw new Error(`cannot represent millisecond amount as Number [${{ nanosInMillis }}]`);
+  }
+  if (timestamp.nanoseconds > Number.MAX_SAFE_INTEGER) {
+    throw new Error(`cannot represent millisecond amount as Number [${{ nanosInMillis }}]`);
+  }
+  let remainderFractionalMillis = timestamp.nanoseconds / 1_000_000;
+  const res = Number(secondsInMillis) + remainderFractionalMillis;
+  return res;
 }


### PR DESCRIPTION
This PR adds support for p3 futures, along with tests for lifts (returning a `future<t>`).

Tests for lowering futures (running a function that *takes* a `future<t>`) will be added shortly after this lands.