### PR TITLE
fix(bindgen): generating types error

### DIFF
--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -69,6 +69,7 @@ impl bindings::Guest for JsComponentBindgenComponent {
             import_bindings: options.import_bindings.map(Into::into),
             guest: options.guest.unwrap_or(false),
             async_mode: options.async_mode.map(Into::into),
+            strict: options.strict.unwrap_or(false),
         };
 
         let js_component_bindgen::Transpiled {
@@ -163,6 +164,7 @@ impl bindings::Guest for JsComponentBindgenComponent {
             import_bindings: None,
             guest: opts.guest.unwrap_or(false),
             async_mode: opts.async_mode.map(Into::into),
+            strict: opts.strict.unwrap_or(false),
         };
 
         let files = js_component_bindgen::generate_types(&name, resolve, world, opts)

--- a/crates/js-component-bindgen-component/wit/js-component-bindgen.wit
+++ b/crates/js-component-bindgen-component/wit/js-component-bindgen.wit
@@ -69,6 +69,9 @@ world js-component-bindgen {
     /// Configure whether to use `async` imports or exports with
     /// JavaScript Promise Integration (JSPI).
     async-mode: option<async-mode>,
+
+    /// Configure whether to generate code that includes strict type checks
+    strict: option<bool>,
   }
 
   record async-imports-exports {
@@ -103,18 +106,28 @@ world js-component-bindgen {
   record type-generation-options {
     /// wit to generate typing from
     wit: wit,
+
     /// world to generate typing for
     %world: option<string>,
+
     tla-compat: option<bool>,
+
     instantiation: option<instantiation-mode>,
+
     %map: option<maps>,
+
     /// Features that should be enabled as part of feature gating
     features: option<enabled-feature-set>,
+
     /// Whether to generate module declarations like `declare module "local:package/foo" {...`.
     guest: option<bool>,
+
     /// Configure whether to use `async` imports or exports with
     /// JavaScript Promise Integration (JSPI).
     async-mode: option<async-mode>,
+
+    /// Configure whether to generate code that includes strict type checks
+    strict: option<bool>,
   }
 
   enum export-type {

--- a/crates/js-component-bindgen/src/intrinsics/component.rs
+++ b/crates/js-component-bindgen/src/intrinsics/component.rs
@@ -734,7 +734,6 @@ impl ComponentIntrinsic {
                                 if (!table) {{ throw new Error(`missing/invalid table [${{tableIdx}}] while getting future end`); }}
                                 futureEnd = table.get(futureEndHandle);
                             }} else {{
-                                console.log("args?", args);
                                 throw new TypeError("must specify either waitable idx or handle to retrieve future");
                             }}
 

--- a/crates/js-component-bindgen/src/intrinsics/component.rs
+++ b/crates/js-component-bindgen/src/intrinsics/component.rs
@@ -2,10 +2,10 @@
 
 use std::fmt::Write as _;
 
-use crate::intrinsics::Intrinsic;
 use crate::intrinsics::p3::async_future::AsyncFutureIntrinsic;
 use crate::intrinsics::p3::async_stream::AsyncStreamIntrinsic;
 use crate::intrinsics::p3::waitable::WaitableIntrinsic;
+use crate::intrinsics::{Intrinsic, RenderIntrinsicsArgs};
 use crate::source::Source;
 use crate::uwriteln;
 
@@ -81,7 +81,7 @@ impl ComponentIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, _render_args: &RenderIntrinsicsArgs<'_>) {
         match self {
             Self::GlobalAsyncStateMap => {
                 let var_name = Self::GlobalAsyncStateMap.name();

--- a/crates/js-component-bindgen/src/intrinsics/conversion.rs
+++ b/crates/js-component-bindgen/src/intrinsics/conversion.rs
@@ -2,7 +2,7 @@
 
 use std::fmt::Write;
 
-use crate::intrinsics::Intrinsic;
+use crate::intrinsics::{Intrinsic, RenderIntrinsicsArgs};
 use crate::source::Source;
 use crate::uwriteln;
 
@@ -100,7 +100,7 @@ impl ConversionIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, render_args: &RenderIntrinsicsArgs) {
         match self {
             Self::I32ToF32 => output.push_str(
                 "
@@ -125,13 +125,19 @@ impl ConversionIntrinsic {
             "),
 
             Self::ToBigInt64 => {
-                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                let strict_checks = if render_args.transpile_opts.strict {
+                    let require_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                    format!("{require_valid_numeric_primitive_fn}('s64', converted);")
+                } else {
+                    "".into()
+                };
+
                 uwriteln!(
                     output,
                     r#"
                       function toInt64(val) {{
                           const converted = BigInt(val)
-                          {ensure_valid_numeric_primitive_fn}('s64', converted);
+                          {strict_checks}
                           return BigInt.asIntN(64, converted);
                       }}
                     "#
@@ -139,13 +145,19 @@ impl ConversionIntrinsic {
             },
 
             Self::ToBigUint64 => {
-                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                let strict_checks = if render_args.transpile_opts.strict {
+                    let require_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                    format!("{require_valid_numeric_primitive_fn}('u64', converted);")
+                } else {
+                    "".into()
+                };
+
                 uwriteln!(
                     output,
                     r#"
                       function toUint64(val) {{
                           const converted = BigInt(val)
-                          {ensure_valid_numeric_primitive_fn}('u64', converted);
+                          {strict_checks}
                           return BigInt.asUintN(64, converted);
                       }}
                     "#
@@ -153,12 +165,18 @@ impl ConversionIntrinsic {
             },
 
             Self::ToInt16 => {
-                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                let strict_checks = if render_args.transpile_opts.strict {
+                    let require_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                    format!("{require_valid_numeric_primitive_fn}('s16', val);")
+                } else {
+                    "".into()
+                };
+
                 uwriteln!(
                     output,
                     r#"
                       function toInt16(val) {{
-                          {ensure_valid_numeric_primitive_fn}('s16', val);
+                          {strict_checks}
                           val >>>= 0;
                           val %= 2 ** 16;
                           if (val >= 2 ** 15) {{
@@ -171,12 +189,18 @@ impl ConversionIntrinsic {
             },
 
             Self::ToUint16 => {
-                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                let strict_checks = if render_args.transpile_opts.strict {
+                    let require_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                    format!("{require_valid_numeric_primitive_fn}('u16', val);")
+                } else {
+                    "".into()
+                };
+
                 uwriteln!(
                     output,
                     r#"
                       function toUint16(val) {{
-                          {ensure_valid_numeric_primitive_fn}('u16', val);
+                          {strict_checks}
                           val >>>= 0;
                           val %= 2 ** 16;
                           return val;
@@ -186,12 +210,18 @@ impl ConversionIntrinsic {
             },
 
             Self::ToInt32 => {
-                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                let strict_checks = if render_args.transpile_opts.strict {
+                    let require_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                    format!("{require_valid_numeric_primitive_fn}('s32', val);")
+                } else {
+                    "".into()
+                };
+
                 uwriteln!(
                     output,
                     r#"
                       function toInt32(val) {{
-                          {ensure_valid_numeric_primitive_fn}('s32', val);
+                          {strict_checks}
                           return val >> 0;
                       }}
                     "#
@@ -199,12 +229,18 @@ impl ConversionIntrinsic {
             },
 
             Self::ToInt8 => {
-                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                let strict_checks = if render_args.transpile_opts.strict {
+                    let require_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                    format!("{require_valid_numeric_primitive_fn}('s8', val);")
+                } else {
+                    "".into()
+                };
+
                 uwriteln!(
                     output,
                     r#"
                       function toInt8(val) {{
-                          {ensure_valid_numeric_primitive_fn}('s8', val);
+                          {strict_checks}
                           val >>>= 0;
                           val %= 2 ** 8;
                           if (val >= 2 ** 7) {{
@@ -238,12 +274,18 @@ impl ConversionIntrinsic {
 
 
             Self::ToUint32 => {
-                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                let strict_checks = if render_args.transpile_opts.strict {
+                    let require_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                    format!("{require_valid_numeric_primitive_fn}('u32', val);")
+                } else {
+                    "".into()
+                };
+
                 uwriteln!(
                     output,
                     r#"
                       function toUint32(val) {{
-                          {ensure_valid_numeric_primitive_fn}('u32', val);
+                          {strict_checks}
                           return val >>> 0;
                       }}
                     "#
@@ -251,12 +293,18 @@ impl ConversionIntrinsic {
             },
 
             Self::ToUint8 => {
-                let ensure_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                let strict_checks = if render_args.transpile_opts.strict {
+                    let require_valid_numeric_primitive_fn = Self::RequireValidNumericPrimitive.name();
+                    format!("{require_valid_numeric_primitive_fn}('u8', val);")
+                } else {
+                    "".into()
+                };
+
                 uwriteln!(
                     output,
                     r#"
                       function toUint8(val) {{
-                          {ensure_valid_numeric_primitive_fn}('u8', val);
+                          {strict_checks}
                           val >>>= 0;
                           val %= 2 ** 8;
                           return val;

--- a/crates/js-component-bindgen/src/intrinsics/js_helper.rs
+++ b/crates/js-component-bindgen/src/intrinsics/js_helper.rs
@@ -1,6 +1,9 @@
 //! Intrinsics that represent helpers that should be used from JS code
 
-use crate::{intrinsics::Intrinsic, source::Source};
+use crate::{
+    intrinsics::{Intrinsic, RenderIntrinsicsArgs},
+    source::Source,
+};
 
 /// This enum contains intrinsics that function as JS helpers
 ///
@@ -35,7 +38,7 @@ impl JsHelperIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, _args: &RenderIntrinsicsArgs) {
         match self {
             Self::EmptyFunc => output.push_str("
                 const emptyFunc = () => {};

--- a/crates/js-component-bindgen/src/intrinsics/lift.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lift.rs
@@ -1,12 +1,12 @@
 //! Intrinsics that represent helpers that enable Lift integration
 use std::fmt::Write;
 
-use crate::intrinsics::Intrinsic;
 use crate::intrinsics::component::ComponentIntrinsic;
 use crate::intrinsics::p3::async_future::AsyncFutureIntrinsic;
 use crate::intrinsics::p3::async_stream::AsyncStreamIntrinsic;
 use crate::intrinsics::p3::error_context::ErrCtxIntrinsic;
 use crate::intrinsics::string::StringIntrinsic;
+use crate::intrinsics::{Intrinsic, RenderIntrinsicsArgs};
 use crate::source::Source;
 use crate::uwriteln;
 
@@ -249,7 +249,7 @@ impl LiftIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, _render_args: &RenderIntrinsicsArgs<'_>) {
         match self {
             Self::LiftFlatBool => {
                 let debug_log_fn = Intrinsic::DebugLog.name();

--- a/crates/js-component-bindgen/src/intrinsics/lower.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lower.rs
@@ -1,9 +1,9 @@
 //! Intrinsics that represent helpers that enable Lower integration
 
-use crate::intrinsics::Intrinsic;
 use crate::intrinsics::component::ComponentIntrinsic;
 use crate::intrinsics::p3::{async_stream::AsyncStreamIntrinsic, error_context::ErrCtxIntrinsic};
 use crate::intrinsics::string::StringIntrinsic;
+use crate::intrinsics::{Intrinsic, RenderIntrinsicsArgs};
 use crate::source::Source;
 
 use super::conversion::ConversionIntrinsic;
@@ -245,7 +245,7 @@ impl LowerIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, _render_args: &RenderIntrinsicsArgs<'_>) {
         match self {
             Self::LowerFlatBool => {
                 let debug_log_fn = Intrinsic::DebugLog.name();

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeSet, HashSet};
 use std::fmt::Write;
 
 use crate::source::Source;
-use crate::{uwrite, uwriteln};
+use crate::{TranspileOpts, uwrite, uwriteln};
 
 pub(crate) mod conversion;
 use conversion::ConversionIntrinsic;
@@ -165,19 +165,19 @@ pub enum Intrinsic {
 impl Intrinsic {
     pub fn render(&self, output: &mut Source, args: &RenderIntrinsicsArgs) {
         match self {
-            Intrinsic::JsHelper(i) => i.render(output),
-            Intrinsic::Conversion(i) => i.render(output),
-            Intrinsic::String(i) => i.render(output),
-            Intrinsic::ErrCtx(i) => i.render(output),
-            Intrinsic::Resource(i) => i.render(output),
-            Intrinsic::AsyncTask(i) => i.render(output),
+            Intrinsic::JsHelper(i) => i.render(output, args),
+            Intrinsic::Conversion(i) => i.render(output, args),
+            Intrinsic::String(i) => i.render(output, args),
+            Intrinsic::ErrCtx(i) => i.render(output, args),
+            Intrinsic::Resource(i) => i.render(output, args),
+            Intrinsic::AsyncTask(i) => i.render(output, args),
             Intrinsic::Waitable(i) => i.render(output, args),
-            Intrinsic::Lift(i) => i.render(output),
-            Intrinsic::Lower(i) => i.render(output),
-            Intrinsic::AsyncStream(i) => i.render(output),
-            Intrinsic::AsyncFuture(i) => i.render(output),
-            Intrinsic::Component(i) => i.render(output),
-            Intrinsic::Host(i) => i.render(output),
+            Intrinsic::Lift(i) => i.render(output, args),
+            Intrinsic::Lower(i) => i.render(output, args),
+            Intrinsic::AsyncStream(i) => i.render(output, args),
+            Intrinsic::AsyncFuture(i) => i.render(output, args),
+            Intrinsic::Component(i) => i.render(output, args),
+            Intrinsic::Host(i) => i.render(output, args),
 
             Intrinsic::GlobalAsyncDeterminism => {
                 output.push_str(&format!(
@@ -1041,6 +1041,8 @@ pub struct RenderIntrinsicsArgs<'a> {
     pub(crate) instantiation: bool,
     /// The kind of determinism to use
     pub(crate) determinism: AsyncDeterminismProfile,
+    /// Options provided when performing transpilation
+    pub(crate) transpile_opts: &'a TranspileOpts,
 }
 
 /// Intrinsics that should be rendered as early as possible

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
@@ -1312,10 +1312,6 @@ impl AsyncFutureIntrinsic {
                             ctx,
                             params,
                         }});
-                        console.log('[{future_transfer_fn}()] args', {{
-                            ctx,
-                            params,
-                        }});
                     }}
                     "#
                 ));

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
@@ -2,8 +2,8 @@
 
 use std::fmt::Write;
 
-use crate::intrinsics::Intrinsic;
 use crate::intrinsics::component::ComponentIntrinsic;
+use crate::intrinsics::{Intrinsic, RenderIntrinsicsArgs};
 use crate::source::Source;
 use crate::uwriteln;
 
@@ -252,7 +252,7 @@ impl AsyncFutureIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, _render_args: &RenderIntrinsicsArgs<'_>) {
         match self {
             Self::GlobalFutureMap => {
                 let global_future_map = Self::GlobalFutureMap.name();

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -1,7 +1,7 @@
 //! Intrinsics that represent helpers that enable Stream integration
 
 use crate::{
-    intrinsics::{Intrinsic, component::ComponentIntrinsic},
+    intrinsics::{Intrinsic, RenderIntrinsicsArgs, component::ComponentIntrinsic},
     source::Source,
 };
 
@@ -266,7 +266,7 @@ impl AsyncStreamIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, _render_args: &RenderIntrinsicsArgs<'_>) {
         match self {
             Self::StreamEndClass => {
                 let debug_log_fn = Intrinsic::DebugLog.name();

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -1,9 +1,9 @@
 //! Intrinsics that represent helpers that implement async tasks
 
-use crate::intrinsics::Intrinsic;
 use crate::intrinsics::component::ComponentIntrinsic;
 use crate::intrinsics::conversion::ConversionIntrinsic;
 use crate::intrinsics::p3::waitable::WaitableIntrinsic;
+use crate::intrinsics::{Intrinsic, RenderIntrinsicsArgs};
 use crate::source::Source;
 
 /// This enum contains intrinsics that implement async tasks
@@ -326,7 +326,7 @@ impl AsyncTaskIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, _render_args: &RenderIntrinsicsArgs<'_>) {
         match self {
             Self::CurrentTaskMayBlock => {
                 output.push_str(&format!(

--- a/crates/js-component-bindgen/src/intrinsics/p3/error_context.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/error_context.rs
@@ -1,7 +1,7 @@
 //! Intrinsics that represent helpers that implement error contexts
 
-use crate::intrinsics::Intrinsic;
 use crate::intrinsics::component::ComponentIntrinsic;
+use crate::intrinsics::{Intrinsic, RenderIntrinsicsArgs};
 use crate::source::Source;
 
 /// This enum contains intrinsics that implement error contexts
@@ -212,7 +212,7 @@ impl ErrCtxIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, _render_args: &RenderIntrinsicsArgs<'_>) {
         match self {
             Self::ComponentGlobalTable => {
                 let name = Self::ComponentGlobalTable.name();

--- a/crates/js-component-bindgen/src/intrinsics/p3/host.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/host.rs
@@ -1,8 +1,8 @@
 //! Intrinsics that represent helpers that implement async calls
 
-use crate::intrinsics::Intrinsic;
 use crate::intrinsics::component::ComponentIntrinsic;
 use crate::intrinsics::p3::async_task::AsyncTaskIntrinsic;
+use crate::intrinsics::{Intrinsic, RenderIntrinsicsArgs};
 use crate::source::Source;
 
 /// This enum contains intrinsics that implement async calls
@@ -102,7 +102,7 @@ impl HostIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, _render_args: &RenderIntrinsicsArgs<'_>) {
         match self {
             // PrepareCall is called before an async-lowered import (from the host or another component)
             // is called from inside a component.

--- a/crates/js-component-bindgen/src/intrinsics/p3/waitable.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/waitable.rs
@@ -146,7 +146,7 @@ impl WaitableIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source, _args: &RenderIntrinsicsArgs<'_>) {
+    pub fn render(&self, output: &mut Source, _render_args: &RenderIntrinsicsArgs<'_>) {
         match self {
             Self::WaitableSetClass => {
                 let debug_log_fn = Intrinsic::DebugLog.name();

--- a/crates/js-component-bindgen/src/intrinsics/resource.rs
+++ b/crates/js-component-bindgen/src/intrinsics/resource.rs
@@ -1,6 +1,6 @@
 //! Intrinsics that represent helpers that deal with Component Model resources
 
-use crate::intrinsics::Intrinsic;
+use crate::intrinsics::{Intrinsic, RenderIntrinsicsArgs};
 use crate::source::Source;
 
 /// This enum contains intrinsics for supporting Component Model resources
@@ -104,7 +104,7 @@ impl ResourceIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, _render_args: &RenderIntrinsicsArgs<'_>) {
         match self {
             Self::CurResourceBorrows => output.push_str(
                 "

--- a/crates/js-component-bindgen/src/intrinsics/string.rs
+++ b/crates/js-component-bindgen/src/intrinsics/string.rs
@@ -1,6 +1,7 @@
 //! Intrinsics that represent helpers that manipulate strings
 use std::fmt::Write;
 
+use crate::intrinsics::RenderIntrinsicsArgs;
 use crate::uwriteln;
 use crate::{intrinsics::Intrinsic, source::Source};
 
@@ -66,7 +67,7 @@ impl StringIntrinsic {
     }
 
     /// Render an intrinsic to a string
-    pub fn render(&self, output: &mut Source) {
+    pub fn render(&self, output: &mut Source, _render_args: &RenderIntrinsicsArgs<'_>) {
         let name = self.name();
         match self {
             Self::Utf16Decoder => uwriteln!(output, "const {name} = new TextDecoder('utf-16');"),

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -100,6 +100,8 @@ pub struct TranspileOpts {
     /// Configure whether to use `async` imports or exports with
     /// JavaScript Promise Integration (JSPI).
     pub async_mode: Option<AsyncMode>,
+    /// Configure whether to generate code that includes strict type checks
+    pub strict: bool,
 }
 
 #[derive(Default, Clone, Debug)]
@@ -421,6 +423,7 @@ impl JsBindgen<'_> {
             no_nodejs_compat: self.opts.no_nodejs_compat,
             instantiation: self.opts.instantiation.is_some(),
             determinism: AsyncDeterminismProfile::default(),
+            transpile_opts: opts,
         });
 
         if let Some(instantiation) = &self.opts.instantiation {

--- a/crates/xtask/src/build/jco.rs
+++ b/crates/xtask/src/build/jco.rs
@@ -197,6 +197,7 @@ fn transpile(args: TranspileArgs) -> Result<()> {
         import_bindings: Some(BindingsMode::Js),
         guest: false,
         async_mode: None,
+        strict: true,
     };
 
     let transpiled = js_component_bindgen::transpile(&adapted_component, opts)?;

--- a/packages/jco/src/cmd/transpile.d.ts
+++ b/packages/jco/src/cmd/transpile.d.ts
@@ -17,6 +17,7 @@ export function guestTypes(witPath: any, opts: any): Promise<void>;
  *   outDir?: string,
  *   features?: string[] | 'all',
  *   guest?: bool,
+ *   strict?: bool,
  * }} opts
  * @returns {Promise<{ [filename: string]: Uint8Array }>}
  */
@@ -33,6 +34,7 @@ export function typesComponent(
         outDir?: string;
         features?: string[] | "all";
         guest?: boolean;
+        strict?: boolean;
     },
 ): Promise<{
     [filename: string]: Uint8Array;

--- a/packages/jco/src/cmd/transpile.js
+++ b/packages/jco/src/cmd/transpile.js
@@ -153,9 +153,8 @@ export async function transpileComponent(component, opts = {}) {
     // Let's define `instantiation` from `--instantiation` if it's present.
     if (opts.instantiation) {
         instantiation = { tag: opts.instantiation };
-    }
-    // Otherwise, if `--js` is present, an `instantiate` function is required.
-    else if (opts.js) {
+    } else if (opts.js) {
+        // Otherwise, if `--js` is present, an `instantiate` function is required.
         instantiation = { tag: "async" };
     }
 
@@ -200,6 +199,7 @@ export async function transpileComponent(component, opts = {}) {
         noNamespacedExports: opts.namespacedExports === false,
         multiMemory: opts.multiMemory === true,
         idlImports: opts.experimentalIdlImports === true,
+        strict: opts.strict === true,
     });
 
     let outDir = (opts.outDir ?? "").replace(/\\/g, "/");

--- a/packages/jco/src/cmd/types.d.ts
+++ b/packages/jco/src/cmd/types.d.ts
@@ -13,6 +13,7 @@ export function guestTypes(witPath: any, opts: any): Promise<void>;
  *   outDir?: string,
  *   features?: string[] | 'all',
  *   guest?: bool,
+ *   strict?: bool,
  * }} opts
  * @returns {Promise<{ [filename: string]: Uint8Array }>}
  */
@@ -29,6 +30,7 @@ export function typesComponent(
         outDir?: string;
         features?: string[] | "all";
         guest?: boolean;
+        strict?: boolean;
     },
 ): Promise<{
     [filename: string]: Uint8Array;

--- a/packages/jco/src/cmd/types.js
+++ b/packages/jco/src/cmd/types.js
@@ -140,6 +140,7 @@ export async function typesComponent(witPath, opts) {
             world: opts.worldName,
             features,
             guest: opts.guest ?? false,
+            strict: opts.strict === true,
             asyncMode: asyncModeObj,
         }).map(([name, file]) => [`${outDir}${name}`, file]);
     } catch (err) {

--- a/packages/jco/src/jco.js
+++ b/packages/jco/src/jco.js
@@ -25,7 +25,7 @@ program
     )
     .usage("<command> [options]")
     .enablePositionalOptions()
-    .version("1.16.1");
+    .version("1.17.7");
 
 function myParseInt(value) {
     return parseInt(value, 10);

--- a/packages/jco/src/jco.js
+++ b/packages/jco/src/jco.js
@@ -128,6 +128,7 @@ program
     .option("-q, --quiet", "disable output summary")
     .option("--no-namespaced-exports", "disable namespaced exports for typescript compatibility")
     .option("--multi-memory", "optimized output for Wasm multi-memory")
+    .option("--strict", "generate bindings with strict type checking")
     .allowExcessArguments(true)
     .action(asyncAction(transpile));
 
@@ -164,6 +165,7 @@ program
     .option("--feature <feature>", "enable one specific WIT feature (repeatable)", collectOptions, [])
     .option("--all-features", "enable all features")
     .option("--wasm-opt-bin <path-to-wasm-opt>', 'wasm-opt binary path (default: 'binaryen/bin/wasm-opt')")
+    .option("--strict", "generate bindings with strict type checking")
     .action(asyncAction(types));
 
 program
@@ -186,6 +188,7 @@ program
             .choices(["sync", "jspi"])
             .preset("sync"),
     )
+    .option("--strict", "generate bindings with strict type checking")
     .action(asyncAction(guestTypes));
 
 program

--- a/packages/jco/test/codegen.js
+++ b/packages/jco/test/codegen.js
@@ -3,7 +3,8 @@ import { createServer } from "node:http";
 import { resolve, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 
-import { componentNew, componentEmbed, transpile, preview1AdapterCommandPath } from "@bytecodealliance/jco";
+import { componentNew, componentEmbed, preview1AdapterCommandPath } from "@bytecodealliance/jco";
+import { transpile } from "../src/api.js";
 import { HTTPServer } from "@bytecodealliance/preview2-shim/http";
 
 import { suite, test, assert, describe } from "vitest";
@@ -226,5 +227,31 @@ suite("codegen determinism", () => {
         ]);
         assert.deepEqual(streamTx[0].files, streamTx[1].files);
         assert.deepEqual(streamRx[0].files, streamRx[1].files);
+    });
+});
+
+// see: https://github.com/bytecodealliance/jco/issues/1400
+suite("--strict", () => {
+    test("does not add checks when disabled", async () => {
+        const component = await readFile(join(COMPONENT_FIXTURES_DIR, "adder.component.wasm"));
+        const { files } = await transpile(component, { name: "adder" });
+        const bindingsSource = new TextDecoder().decode(files["adder.js"]);
+        assert.isFalse(
+            bindingsSource.includes("_requireValidNumericPrimitive('u32', val)"),
+            "numeric primitive check shoudl not be included",
+        );
+    });
+
+    test("adds checks when enabled", async () => {
+        const component = await readFile(join(COMPONENT_FIXTURES_DIR, "adder.component.wasm"));
+        const { files } = await transpile(component, { name: "adder", strict: true });
+        const bindingsSource = new TextDecoder().decode(files["adder.js"]);
+        // Somewhat brittle, but we're looking for a *specific* call in the body of `toUint32(val)` below:
+        assert.isOk(
+            bindingsSource.includes(
+                "_requireValidNumericPrimitive('u32', val)",
+                "numeric primitive check should be included",
+            ),
+        );
     });
 });

--- a/packages/jco/test/fixtures/wits/issue-1400/component.wit
+++ b/packages/jco/test/fixtures/wits/issue-1400/component.wit
@@ -1,0 +1,9 @@
+package example:math@0.1.0;
+
+interface calculator {
+  add: func(a: s32, b: s32) -> s32;
+}
+
+world math {
+  export calculator;
+}

--- a/packages/jco/test/helpers.js
+++ b/packages/jco/test/helpers.js
@@ -232,6 +232,7 @@ export async function setupAsyncTest(args) {
         instantiation: "async",
         asyncMode,
         wasiShim: true,
+        strict: true,
         outDir: moduleOutputDir,
         ...(jco?.transpile?.extraArgs || {}),
     };

--- a/packages/jco/test/p3/future-lifts.js
+++ b/packages/jco/test/p3/future-lifts.js
@@ -488,7 +488,6 @@ suite("future<T> lifts", () => {
             vals,
             func: instance["jco:test-components/get-future-async"].getFutureStreamStringSpool,
             assertEqFn: async (nestedStream, expected) => {
-                console.log("nestedStream?", nestedStream);
                 let idx = 0;
                 for await (const value of nestedStream) {
                     assert.strictEqual(value, expected[idx]);


### PR DESCRIPTION
Some new strictness regarding `u32`s that are being coerced was introduced that broke users because it *required* a newer version of `preview2-shim` that fixed some old buggy code.

In order to fix that breakage, this PR:
- adds a `--strict` option to relevant generation
- updates bindgen checks to use the strictness setting
- adds a test to ensure strict code is not included at all when disabled (which is the default)

This removes the strictness-by-default unless people opt into it, and in a future breaking version change we'll set `--strict` to be the default.

Resolves #1400