### PR TITLE
Update `use jco` directive to `use components`

### DIFF
--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -416,7 +416,7 @@ impl JsBindgen<'_> {
         }
 
         // Render the telemery directive
-        uwriteln!(output, r#""use jco";"#);
+        uwriteln!(output, r#""use components";"#);
 
         let js_intrinsics = render_intrinsics(RenderIntrinsicsArgs {
             intrinsics: &mut self.all_intrinsics,

--- a/packages/jco/test/codegen.js
+++ b/packages/jco/test/codegen.js
@@ -209,7 +209,7 @@ suite("Directive Prologue", () => {
         const component = await readFile(join(COMPONENT_FIXTURES_DIR, "adder.component.wasm"));
         const { files } = await transpile(component, { name: "adder" });
         const bindingsSource = new TextDecoder().decode(files["adder.js"]);
-        assert.isOk(bindingsSource.includes('"use jco";'));
+        assert.isOk(bindingsSource.includes('"use components";'));
     });
 });
 


### PR DESCRIPTION
This is a small change to the `use jco` directive intended to be used for telemetry to make this less tool-specific and instead leave open the opportunity for other projects to use this as well which may not be using jco specifically.