### PR TITLE
fix(bindgen): return state-only handle when async-lowered import resolves eagerly

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -2163,11 +2163,6 @@ impl AsyncTaskIntrinsic {
 
                         // NOTE: at this point we know that we are working with an async lowered import
 
-                        const subtaskState = subtask.getStateNumber();
-                        if (subtaskState < 0 || subtaskState > 2**5) {{
-                            throw new Error('invalid subtask state, out of valid range');
-                        }}
-
                         subtask.setOnProgressFn(() => {{
                             subtask.setPendingEvent(() => {{
                                 if (subtask.isResolved()) {{ subtask.deliverResolve(); }}
@@ -2222,6 +2217,24 @@ impl AsyncTaskIntrinsic {
                         }}
 
                         if (requiresManualAsyncResult) {{ return manualAsyncResult.promise; }}
+
+                        const subtaskState = subtask.getStateNumber();
+                        if (subtaskState < 0 || subtaskState >= 2**4) {{
+                            throw new Error('invalid subtask state, out of valid range');
+                        }}
+
+                        // An async-lowered import whose callee resolved synchronously returns
+                        // [Subtask.State.RETURNED] only an no subtask handle is exposed.
+                        if (subtask.isReturned()) {{
+                            if (!subtask.resolveDelivered()) {{
+                                subtask.deliverResolve();
+                            }}
+                            const removed = cstate.handles.remove(subtask.waitableRep());
+                            if (removed !== subtask) {{
+                                throw new Error('subtask handle cleanup removed unexpected entry');
+                            }}
+                            return subtaskState;
+                        }}
 
                         return Number(subtask.waitableRep()) << 4 | subtaskState;
                     }}
@@ -2398,7 +2411,7 @@ impl AsyncTaskIntrinsic {
                         // NOTE: at this point we know that we are working with an async lowered import
 
                         const subtaskState = subtask.getStateNumber();
-                        if (subtaskState < 0 || subtaskState > 2**5) {{
+                        if (subtaskState < 0 || subtaskState >= 2**4) {{
                             throw new Error('invalid subtask state, out of valid range');
                         }}
 


### PR DESCRIPTION
Per CanonicalABI.md an async-lowered import whose callee resolves synchronously returns `Subtask.State.RETURNED` state only and no subtask handle is packed into the result.

Separateley The CanonicalABI.md packs state into 4 bits so the check bounds are adjusted.

This the relevant spec section:

> In the async case, if the callee already called on_resolve, then the RETURNED code is eagerly returned to the core wasm caller without needing to add a Subtask to the current component instance's handles table.

```python
    if subtask.resolved():
      assert(flat_results == [])
      subtask.deliver_resolve()
      return [Subtask.State.RETURNED]
    else:
      subtaski = thread.task.inst.handles.add(subtask)
      def on_progress():
        def subtask_event():
          if subtask.resolved():
            subtask.deliver_resolve()
          return (EventCode.SUBTASK, subtaski, subtask.state)
        subtask.set_pending_event(subtask_event)
      assert(0 < subtaski <= Table.MAX_LENGTH < 2**28)
      assert(0 <= subtask.state < 2**4)
      return [subtask.state | (subtaski << 4)]
```