### PR TITLE
fix(bindgen): lift numeric p3 lists and streams as typed arrays

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/lift.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lift.rs
@@ -820,7 +820,10 @@ impl LiftIntrinsic {
                     function {lift_flat_list_fn}(meta) {{
                         const {{ elemLiftFn, elemSize32, elemAlign32, knownLen, typedArray }} = meta;
 
-                        const listValue = values => typedArray === undefined ? values : new typedArray(values);
+                        const listValue =
+                          typedArray === undefined
+                            ? values => values
+                            : values => new typedArray(values);
 
                         const readValuesAndReset = (ctx, originalPtr, dataPtr, len) => {{
                             ctx.storagePtr = dataPtr;

--- a/crates/js-component-bindgen/src/intrinsics/lift.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lift.rs
@@ -818,7 +818,9 @@ impl LiftIntrinsic {
 
                 output.push_str(&format!(r#"
                     function {lift_flat_list_fn}(meta) {{
-                        const {{ elemLiftFn, elemSize32, elemAlign32, knownLen }} = meta;
+                        const {{ elemLiftFn, elemSize32, elemAlign32, knownLen, typedArray }} = meta;
+
+                        const listValue = values => typedArray === undefined ? values : new typedArray(values);
 
                         const readValuesAndReset = (ctx, originalPtr, dataPtr, len) => {{
                             ctx.storagePtr = dataPtr;
@@ -832,10 +834,8 @@ impl LiftIntrinsic {
                                 if (rem !== 0) {{ ctx.storagePtr += elemAlign32 - rem; }}
                             }}
                             if (originalPtr !== null) {{ ctx.storagePtr = originalPtr; }}
-                            return [val, ctx];
+                            return [listValue(val), ctx];
                         }};
-
-                        // TODO(fix): special case for u8/u16/etc into appropriate type
 
                         return function {lift_flat_list_fn}Inner(ctx) {{
                             {debug_log_fn}('[{lift_flat_list_fn}()] args', {{ ctx }});
@@ -854,7 +854,7 @@ impl LiftIntrinsic {
                                         // via params.
                                         //
                                         {debug_log_fn}('memory unexpectedly missing while lifting unknown length list', {{ ctx }});
-                                        liftResults = [ctx.params.slice(0, knownLen), ctx];
+                                        liftResults = [listValue(ctx.params.slice(0, knownLen)), ctx];
                                         ctx.params = ctx.params.slice(knownLen);
                                     }} else {{
                                         // in-memory list with unknown length w/ direct params

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -1051,7 +1051,8 @@ impl AsyncStreamIntrinsic {
                                 }}
 
                                 const vs = buffer.read(count);
-                                const res = count === 1 ? vs[0] : vs;
+                                const {{ typedArray }} = this.#elemMeta;
+                                const res = typedArray === undefined || vs.length === 0 ? count === 1 ? vs[0] : vs : new typedArray(vs);
                                 this.#result = null;
                                 resolve(res);
 

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -1334,6 +1334,7 @@ impl<'a> Instantiator<'a, '_> {
                     is_numeric_type_js,
                     is_borrow_js,
                     is_async_value_js,
+                    typed_array_js,
                 ) = match stream_ty.payload {
                     // If there is no payload for the stream, we know the values
                     None => (
@@ -1346,6 +1347,7 @@ impl<'a> Instantiator<'a, '_> {
                         "false".into(),
                         "false".into(),
                         "false".into(),
+                        "undefined",
                     ),
                     // If there is a payload, generate relevant lift/lower and other metadata
                     Some(ty) => (
@@ -1380,6 +1382,7 @@ impl<'a> Instantiator<'a, '_> {
                             "{}",
                             matches!(ty, InterfaceType::Stream(_) | InterfaceType::Future(_))
                         ),
+                        js_typed_array_ctor(&ty).unwrap_or("undefined"),
                     ),
                 };
 
@@ -1396,6 +1399,7 @@ impl<'a> Instantiator<'a, '_> {
                             isNumeric: {is_numeric_type_js},
                             isBorrowed: {is_borrow_js},
                             isAsyncValue: {is_async_value_js},
+                            typedArray: {typed_array_js},
                             flatCount: {flat_count_js},
                             align32: {align_32_js},
                             size32: {size_32_js},
@@ -4953,12 +4957,14 @@ pub fn gen_flat_lift_fn_js_expr(
             let elem_cabi = component_types.canonical_abi(&list_ty.element);
             let elem_align32 = elem_cabi.align32;
             let elem_size32 = elem_cabi.size32;
+            let typed_array = js_typed_array_ctor(&list_ty.element).unwrap_or("undefined");
             format!(
                 "{f}({{
                      elemLiftFn: {lift_fn_expr},
                      elemAlign32: {elem_align32},
                      elemSize32: {elem_size32},
-                 }})"
+                     typedArray: {typed_array},
+                  }})"
             )
         }
 
@@ -5251,6 +5257,22 @@ pub fn gen_flat_lift_fn_js_expr(
             let f = Intrinsic::Lift(LiftIntrinsic::LiftFlatErrorContext).name();
             format!("{f}.bind(null, {table_idx})")
         }
+    }
+}
+
+fn js_typed_array_ctor(ty: &InterfaceType) -> Option<&'static str> {
+    match ty {
+        InterfaceType::U8 => Some("Uint8Array"),
+        InterfaceType::S8 => Some("Int8Array"),
+        InterfaceType::U16 => Some("Uint16Array"),
+        InterfaceType::S16 => Some("Int16Array"),
+        InterfaceType::U32 => Some("Uint32Array"),
+        InterfaceType::S32 => Some("Int32Array"),
+        InterfaceType::U64 => Some("BigUint64Array"),
+        InterfaceType::S64 => Some("BigInt64Array"),
+        InterfaceType::Float32 => Some("Float32Array"),
+        InterfaceType::Float64 => Some("Float64Array"),
+        _ => None,
     }
 }
 

--- a/packages/jco/test/common.js
+++ b/packages/jco/test/common.js
@@ -90,6 +90,18 @@ export function createReadableStreamFromValues(vals) {
     });
 }
 
+export function toTypedArray(TypedArray, value) {
+    return value instanceof TypedArray ? value : new TypedArray(value);
+}
+
+export function toTypedArrays(TypedArray, values) {
+    return values.map((value) => toTypedArray(TypedArray, value));
+}
+
+export function toTypedArrayChunks(TypedArray, values) {
+    return values.map((value) => new TypedArray([value]));
+}
+
 /** Check the value of a given future (normally returned from a component) */
 export async function checkFutureValues(args) {
     const { vals, func, typeName, assertEqFn } = args ?? {};

--- a/packages/jco/test/p3/deadlock-regressions.js
+++ b/packages/jco/test/p3/deadlock-regressions.js
@@ -5,7 +5,7 @@ import { suite, test, assert } from "vitest";
 import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
 
 import { setupAsyncTest } from "../helpers.js";
-import { LOCAL_TEST_COMPONENTS_DIR } from "../common.js";
+import { LOCAL_TEST_COMPONENTS_DIR, toTypedArrayChunks } from "../common.js";
 
 suite("async scheduling regressions", () => {
     test("host future can be completed by a guest sibling task", async () => {
@@ -21,7 +21,7 @@ suite("async scheduling regressions", () => {
                             for await (const value of stream) {
                                 values.push(value);
                             }
-                            assert.deepEqual(values, [42]);
+                            assert.deepEqual(values, toTypedArrayChunks(Uint8Array, [42]));
                             return 42;
                         },
                     },
@@ -71,7 +71,7 @@ suite("async scheduling regressions", () => {
         try {
             assert.deepEqual(
                 await instance["jco:test-components/stream-concurrency-test"].readAfterSignal(stream),
-                [42],
+                new Uint8Array([42]),
             );
         } finally {
             await cleanup();

--- a/packages/jco/test/p3/future-lifts.js
+++ b/packages/jco/test/p3/future-lifts.js
@@ -8,6 +8,7 @@ import {
     LOCAL_TEST_COMPONENTS_DIR,
     checkFutureValues,
     createReadableStreamFromValues,
+    toTypedArrays,
 } from "../common.js";
 import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
 
@@ -337,17 +338,10 @@ suite("future<T> lifts", () => {
             vals,
             func: instance["jco:test-components/get-future-async"].getFutureListU8,
             typeName: "list<u8>",
-            expectedValues: [
-                // TODO: wit type representation smoothing mismatch
-                vals[0],
-                [...vals[1]],
-                [],
-            ],
+            expectedValues: toTypedArrays(Uint8Array, vals),
             assertEqFn: assert.deepEqual,
         });
     });
-
-    // TODO(fix): add tests for optimized UintXArrays (js_array_ty)
 
     test.concurrent("list<string>", async () => {
         assert.instanceOf(instance["jco:test-components/get-future-async"].getFutureListString, AsyncFunction);

--- a/packages/jco/test/p3/future-lower.js
+++ b/packages/jco/test/p3/future-lower.js
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { suite, test, assert, beforeAll, afterAll, describe, expect } from "vitest";
 
 import { setupAsyncTest } from "../helpers.js";
-import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR } from "../common.js";
+import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR, toTypedArray } from "../common.js";
 import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
 
 suite("future<T> lowers", () => {
@@ -424,12 +424,10 @@ suite("future<T> lowers", () => {
                     await instance["jco:test-components/future-lower-async"].readFutureValueListU8(Promise.resolve(v)),
                 );
             }
-            assert.deepEqual(returnedVals, [
-                // TODO: wit type representation smoothing mismatch
-                vals[0],
-                [...vals[1]],
-                [],
-            ]);
+            assert.deepEqual(
+                returnedVals,
+                vals.map((value) => toTypedArray(Uint8Array, value)),
+            );
         });
 
         test.concurrent("list<string>", async () => {

--- a/packages/jco/test/p3/stream-lifts.js
+++ b/packages/jco/test/p3/stream-lifts.js
@@ -3,7 +3,13 @@ import { join } from "node:path";
 import { suite, test, assert, beforeAll, afterAll, expect } from "vitest";
 
 import { setupAsyncTest } from "../helpers.js";
-import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR, checkStreamValues } from "../common.js";
+import {
+    AsyncFunction,
+    LOCAL_TEST_COMPONENTS_DIR,
+    checkStreamValues,
+    toTypedArrayChunks,
+    toTypedArrays,
+} from "../common.js";
 import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
 
 suite("stream<T> lifts", () => {
@@ -79,7 +85,13 @@ suite("stream<T> lifts", () => {
 
         let vals = [0, 1, 255];
         let stream = await instance["jco:test-components/get-stream-async"].getStreamU8(vals);
-        await checkStreamValues({ stream, vals, typeName: "u8" });
+        await checkStreamValues({
+            stream,
+            vals,
+            expectedValues: toTypedArrayChunks(Uint8Array, vals),
+            typeName: "u8",
+            assertEqFn: assert.deepEqual,
+        });
 
         let invalidVals = [-1, 256];
         for (const invalid of invalidVals) {
@@ -90,7 +102,13 @@ suite("stream<T> lifts", () => {
 
         vals = [-11, -22, -33, -128, 127];
         stream = await instance["jco:test-components/get-stream-async"].getStreamS8(vals);
-        await checkStreamValues({ stream, vals, typeName: "s8" });
+        await checkStreamValues({
+            stream,
+            vals,
+            expectedValues: toTypedArrayChunks(Int8Array, vals),
+            typeName: "s8",
+            assertEqFn: assert.deepEqual,
+        });
 
         invalidVals = [-129, 128];
         for (const invalid of invalidVals) {
@@ -107,11 +125,23 @@ suite("stream<T> lifts", () => {
 
         let vals = [0, 100, 65535];
         let stream = await instance["jco:test-components/get-stream-async"].getStreamU16(vals);
-        await checkStreamValues({ stream, vals, typeName: "u16" });
+        await checkStreamValues({
+            stream,
+            vals,
+            expectedValues: toTypedArrayChunks(Uint16Array, vals),
+            typeName: "u16",
+            assertEqFn: assert.deepEqual,
+        });
 
         vals = [-32_768, 0, 32_767];
         stream = await instance["jco:test-components/get-stream-async"].getStreamS16(vals);
-        await checkStreamValues({ stream, vals, typeName: "u16" });
+        await checkStreamValues({
+            stream,
+            vals,
+            expectedValues: toTypedArrayChunks(Int16Array, vals),
+            typeName: "s16",
+            assertEqFn: assert.deepEqual,
+        });
     });
 
     test.concurrent("u32/s32", async () => {
@@ -121,11 +151,23 @@ suite("stream<T> lifts", () => {
 
         let vals = [11, 22, 33];
         let stream = await instance["jco:test-components/get-stream-async"].getStreamU32(vals);
-        await checkStreamValues({ stream, vals, typeName: "u32" });
+        await checkStreamValues({
+            stream,
+            vals,
+            expectedValues: toTypedArrayChunks(Uint32Array, vals),
+            typeName: "u32",
+            assertEqFn: assert.deepEqual,
+        });
 
         vals = [-11, -22, -33];
         stream = await instance["jco:test-components/get-stream-async"].getStreamS32(vals);
-        await checkStreamValues({ stream, vals, typeName: "s32" });
+        await checkStreamValues({
+            stream,
+            vals,
+            expectedValues: toTypedArrayChunks(Int32Array, vals),
+            typeName: "s32",
+            assertEqFn: assert.deepEqual,
+        });
     });
 
     test.concurrent("u64/s64", async () => {
@@ -135,7 +177,13 @@ suite("stream<T> lifts", () => {
 
         let vals = [0n, 100n, 65535n];
         let stream = await instance["jco:test-components/get-stream-async"].getStreamU64(vals);
-        await checkStreamValues({ stream, vals, typeName: "u64" });
+        await checkStreamValues({
+            stream,
+            vals,
+            expectedValues: toTypedArrayChunks(BigUint64Array, vals),
+            typeName: "u64",
+            assertEqFn: assert.deepEqual,
+        });
 
         let invalidVals = [-1n, 18446744073709551616n];
         for (const invalid of invalidVals) {
@@ -146,7 +194,13 @@ suite("stream<T> lifts", () => {
 
         vals = [-32_768n, 0n, 32_767n];
         stream = await instance["jco:test-components/get-stream-async"].getStreamS64(vals);
-        await checkStreamValues({ stream, vals, typeName: "s64" });
+        await checkStreamValues({
+            stream,
+            vals,
+            expectedValues: toTypedArrayChunks(BigInt64Array, vals),
+            typeName: "s64",
+            assertEqFn: assert.deepEqual,
+        });
 
         invalidVals = [-9223372036854775809n, 9223372036854775808n];
         for (const invalid of invalidVals) {
@@ -166,10 +220,9 @@ suite("stream<T> lifts", () => {
         await checkStreamValues({
             stream,
             vals,
+            expectedValues: toTypedArrayChunks(Float32Array, vals),
             typeName: "f32",
-            assertEqFn: (value, expected) => {
-                assert.closeTo(value, expected, 0.00001);
-            },
+            assertEqFn: assert.deepEqual,
         });
 
         vals = [-300.01235, -1.5, -0.0, 0.0, 1.5, -300.01235];
@@ -177,10 +230,9 @@ suite("stream<T> lifts", () => {
         await checkStreamValues({
             stream,
             vals,
+            expectedValues: toTypedArrayChunks(Float64Array, vals),
             typeName: "f64",
-            assertEqFn: (value, expected) => {
-                assert.closeTo(value, expected, 0.00001);
-            },
+            assertEqFn: assert.deepEqual,
         });
     });
 
@@ -321,16 +373,9 @@ suite("stream<T> lifts", () => {
             vals,
             typeName: "list<u8>",
             assertEqFn: assert.deepEqual,
-            expectedValues: [
-                // TODO: wit type representation smoothing mismatch
-                vals[0],
-                [...vals[1]],
-                [],
-            ],
+            expectedValues: toTypedArrays(Uint8Array, vals),
         });
     });
-
-    // TODO(fix): add tests for optimized UintXArrays (js_array_ty)
 
     test.concurrent("list<string>", async () => {
         const instance = await getInstance();

--- a/packages/jco/test/p3/stream-lowers.js
+++ b/packages/jco/test/p3/stream-lowers.js
@@ -4,7 +4,13 @@ import { ReadableStream } from "node:stream/web";
 import { suite, test, assert, beforeAll, afterAll, describe } from "vitest";
 
 import { setupAsyncTest } from "../helpers.js";
-import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR, createReadableStreamFromValues } from "../common.js";
+import {
+    AsyncFunction,
+    LOCAL_TEST_COMPONENTS_DIR,
+    createReadableStreamFromValues,
+    toTypedArray,
+    toTypedArrays,
+} from "../common.js";
 import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
 
 suite("stream<T> lowers", () => {
@@ -171,13 +177,13 @@ suite("stream<T> lowers", () => {
             let returnedVals = await instance["jco:test-components/stream-lower-async"].readStreamValuesU8(
                 createReadableStreamFromValues(vals),
             );
-            assert.deepEqual(returnedVals, vals);
+            assert.deepEqual(returnedVals, toTypedArray(Uint8Array, vals));
 
             vals = [-128, 0, 1, 127];
             returnedVals = await instance["jco:test-components/stream-lower-async"].readStreamValuesS8(
                 createReadableStreamFromValues(vals),
             );
-            assert.deepEqual(returnedVals, vals);
+            assert.deepEqual(returnedVals, toTypedArray(Int8Array, vals));
         });
 
         test.concurrent("u16/s16", async () => {
@@ -189,13 +195,13 @@ suite("stream<T> lowers", () => {
             let returnedVals = await instance["jco:test-components/stream-lower-async"].readStreamValuesU16(
                 createReadableStreamFromValues(vals),
             );
-            assert.deepEqual(returnedVals, vals);
+            assert.deepEqual(returnedVals, toTypedArray(Uint16Array, vals));
 
             vals = [-32_768, 0, 32_767];
             returnedVals = await instance["jco:test-components/stream-lower-async"].readStreamValuesS16(
                 createReadableStreamFromValues(vals),
             );
-            assert.deepEqual(returnedVals, vals);
+            assert.deepEqual(returnedVals, toTypedArray(Int16Array, vals));
         });
 
         test.concurrent("u32/s32", async () => {
@@ -207,13 +213,13 @@ suite("stream<T> lowers", () => {
             let returnedVals = await instance["jco:test-components/stream-lower-async"].readStreamValuesU32(
                 createReadableStreamFromValues(vals),
             );
-            assert.deepEqual(returnedVals, vals);
+            assert.deepEqual(returnedVals, toTypedArray(Uint32Array, vals));
 
             vals = [-32, 90001, 3200000];
             returnedVals = await instance["jco:test-components/stream-lower-async"].readStreamValuesS32(
                 createReadableStreamFromValues(vals),
             );
-            assert.deepEqual(returnedVals, vals);
+            assert.deepEqual(returnedVals, toTypedArray(Int32Array, vals));
         });
 
         test.concurrent("u64/s64", async () => {
@@ -225,13 +231,13 @@ suite("stream<T> lowers", () => {
             let returnedVals = await instance["jco:test-components/stream-lower-async"].readStreamValuesU64(
                 createReadableStreamFromValues(vals),
             );
-            assert.deepEqual(returnedVals, vals);
+            assert.deepEqual(returnedVals, toTypedArray(BigUint64Array, vals));
 
             vals = [-32_768n, 0n, 32_767n];
             returnedVals = await instance["jco:test-components/stream-lower-async"].readStreamValuesS64(
                 createReadableStreamFromValues(vals),
             );
-            assert.deepEqual(returnedVals, vals);
+            assert.deepEqual(returnedVals, toTypedArray(BigInt64Array, vals));
         });
 
         test.concurrent("f32/f64", async () => {
@@ -244,12 +250,14 @@ suite("stream<T> lowers", () => {
                 createReadableStreamFromValues(vals),
             );
             vals.entries().forEach(([idx, v]) => assert.closeTo(v, returnedVals[idx], 0.01));
+            assert.instanceOf(returnedVals, Float32Array);
 
             vals = [-60000.01235, -1.5, -0.0, 0.0, 1.5, -60000.01235];
             returnedVals = await instance["jco:test-components/stream-lower-async"].readStreamValuesF32(
                 createReadableStreamFromValues(vals),
             );
             vals.entries().forEach(([idx, v]) => assert.closeTo(v, returnedVals[idx], 0.01));
+            assert.instanceOf(returnedVals, Float32Array);
         });
 
         test.concurrent("string", async () => {
@@ -395,12 +403,7 @@ suite("stream<T> lowers", () => {
             let returnedVals = await instance["jco:test-components/stream-lower-async"].readStreamValuesListU8(
                 createReadableStreamFromValues(vals),
             );
-            assert.deepEqual(returnedVals, [
-                // TODO: wit type representation smoothing mismatch
-                vals[0],
-                [...vals[1]],
-                [],
-            ]);
+            assert.deepEqual(returnedVals, toTypedArrays(Uint8Array, vals));
         });
 
         test.concurrent("list<string>", async () => {
@@ -499,7 +502,7 @@ suite("stream<T> lowers", () => {
             const returnedVals = await instance[
                 "jco:test-components/stream-lower-async"
             ].readStreamValuesExampleResourceOwnAttr(createReadableStreamFromValues(vals));
-            assert.deepEqual(returnedVals, [2, 1, 0]);
+            assert.deepEqual(returnedVals, toTypedArray(Uint32Array, [2, 1, 0]));
         });
 
         test.concurrent("stream<string>", async () => {


### PR DESCRIPTION
Change p3 flat list lifts and numeric stream reads to use the JS typed-array representation.