### PR TITLE
fix(ci): detect jspi support in nodejs

### DIFF
--- a/packages/jco/test/vitest.ts
+++ b/packages/jco/test/vitest.ts
@@ -6,6 +6,7 @@ const DEFAULT_TIMEOUT_MS = 1000 * 60 * 1; // 60s
 const CI_DEFAULT_TIMEOUT_MS = 1000 * 60 * 3; // 1m
 
 const REPORTERS = process.env.GITHUB_ACTIONS ? ["verbose", "github-actions"] : ["verbose"];
+const JSPI_EXEC_ARGV = "Suspending" in WebAssembly ? [] : ["--experimental-wasm-jspi"];
 
 export default defineConfig({
     test: {
@@ -29,7 +30,7 @@ export default defineConfig({
         pool: "forks",
         poolOptions: {
             forks: {
-                execArgv: ["--experimental-wasm-jspi", "--stack-trace-limit=100"],
+                execArgv: [...JSPI_EXEC_ARGV, "--stack-trace-limit=100"],
             },
         },
     },


### PR DESCRIPTION
It looks like `jspi` option is gone in node 26. This makes CI fail with:

```
/Users/runner/hostedtoolcache/node/26.0.0/arm64/bin/node: bad option: --experimental-wasm-jspi
```

This patch tries to detect if `jspi` support is already there and skips experimental flag it that's the case.

https://github.com/WebAssembly/js-promise-integration/blob/main/proposals/js-promise-integration/Overview.md#specification