### PR TITLE
fix(deps): update puppeteer version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -140,17 +140,17 @@ jobs:
           key: weval-bin-${{ steps.weval-meta.outputs.version }}-${{ matrix.os }}
 
       # (no cached weval bin) download weval release
-      - if: ${{ steps.cache-weval-bin.outputs.cache-hit != 'true' && matrix.os == 'ubuntu-latest' }}
+      - if: ${{ steps.cache-weval-bin.outputs.cache-hit != 'true' && startsWith(matrix.os, 'ubuntu') }}
         run: |
           curl -LO https://github.com/bytecodealliance/weval/releases/download/${{ steps.weval-meta.outputs.version }}/weval-${{ steps.weval-meta.outputs.version }}-x86_64-linux.tar.xz
           tar -xvJf weval-${{ steps.weval-meta.outputs.version }}-x86_64-linux.tar.xz
           mv weval-${{ steps.weval-meta.outputs.version }}-x86_64-linux/weval .weval-bin
-      - if: ${{ steps.cache-weval-bin.outputs.cache-hit != 'true' && matrix.os == 'windows-2025' }}
+      - if: ${{ steps.cache-weval-bin.outputs.cache-hit != 'true' && startsWith(matrix.os, 'windows') }}
         run: |
           curl -LO https://github.com/bytecodealliance/weval/releases/download/${{ steps.weval-meta.outputs.version }}/weval-${{ steps.weval-meta.outputs.version }}-x86_64-windows.zip
           unzip weval-${{ steps.weval-meta.outputs.version }}-x86_64-windows.zip
           mv weval-${{ steps.weval-meta.outputs.version }}-x86_64-windows .weval-bin
-      - if: ${{ steps.cache-weval-bin.outputs.cache-hit != 'true' && matrix.os == 'macos-latest' }}
+      - if: ${{ steps.cache-weval-bin.outputs.cache-hit != 'true' && startsWith(matrix.os, 'macos') }}
         run: |
           curl -LO https://github.com/bytecodealliance/weval/releases/download/${{ steps.weval-meta.outputs.version }}/weval-${{ steps.weval-meta.outputs.version }}-aarch64-macos.tar.xz
           tar -xvJf weval-${{ steps.weval-meta.outputs.version }}-aarch64-macos.tar.xz
@@ -198,14 +198,18 @@ jobs:
           if [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.node }}" == "latest" ]]; then
               export EXPECTED_PATH="/Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing";
               if [[ ! -f "$EXPECTED_PATH" ]]; then
+                  echo 'installing fresh macos chrome'
                   rm -rf /Users/runner/.cache/puppeteer/chrome
                   wget https://storage.googleapis.com/chrome-for-testing-public/${PUPPETEER_VERSION}/mac-arm64/chrome-mac-arm64.zip
                   mkdir -p /Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}/
                   unzip chrome-mac-arm64.zip -d /Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}
                   npx puppeteer browsers install chrome@${PUPPETEER_VERSION}
+              else
+                  echo 'using cached macos chrome'
               fi
               echo -e "puppeteer-path=$EXPECTED_PATH" >> $GITHUB_OUTPUT
           else
+              echo 'installing non-macos chrome'
               npx puppeteer browsers install chrome
           fi
 
@@ -238,6 +242,9 @@ jobs:
         env:
           WEVAL_BIN_PATH: ${{ matrix.weval-bin-path }}
         run: |
+          if [ "${{ steps.puppeteer.outputs.puppeteer-path }}" != "" ]; then
+              export PUPPETEER_PATH=${{ steps.puppeteer.outputs.puppeteer-path }}
+          fi
           npm run test -- --maxWorkers 4 --minWorkers 2 --maxConcurrency 2
 
   test-wasi-deno:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,6 +181,19 @@ jobs:
       - name: Install puppeteer
         run: |
           npx puppeteer browsers install chrome
+      - name: Debug
+        run: |
+          brew install tree
+          echo '=> top level app folder'
+          ls '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app'
+          echo '=> root > contents'
+          ls '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS'
+          echo '=> root > contents > macos'
+          ls '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS'
+          ls '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/../'
+          echo '=> frameworks'
+          tree '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64'
+          ls '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/../Frameworks/'
 
       - name: Restore jco build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Install Rust
         run: rustup update stable --no-self-update
-      - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2.7.8
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:
           shared-key: jco-${{ hashFiles('Cargo.lock') }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -194,10 +194,13 @@ jobs:
         id: puppeteer
         env:
           PUPPETEER_VERSION: "148.0.7778.97"
+          OS_LINUX: ${{ startsWith(matrix.os, 'ubuntu') }}
+          OS_MACOS: ${{ startsWith(matrix.os, 'macos') }}
+          OS_WINDOWS: ${{ startsWith(matrix.os, 'windows') }}
         run: |
-          if [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.node }}" == "latest" ]]; then
+          if [ "$OS_MACOS" = "true" && "${{ matrix.node }}" = "latest" ]; then
               export EXPECTED_PATH="/Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing";
-              if [[ ! -f "$EXPECTED_PATH" ]]; then
+              if [ ! -f "$EXPECTED_PATH" ]; then
                   echo 'installing fresh macos chrome'
                   rm -rf /Users/runner/.cache/puppeteer/chrome
                   wget https://storage.googleapis.com/chrome-for-testing-public/${PUPPETEER_VERSION}/mac-arm64/chrome-mac-arm64.zip
@@ -210,6 +213,22 @@ jobs:
               echo -e "puppeteer-path=$EXPECTED_PATH" >> $GITHUB_OUTPUT
           else
               echo 'installing non-macos chrome'
+              if [ "$OS_LINUX" = "true" ]; then
+                  if [ ! -f "$HOME/.cache/puppeteer/chrome/linux-${PUPPETEER_VERSION}/chrome-linux64/chrome" ]; then
+                      rm -rf $HOME/.cache/puppeteer/chrome;
+                  fi
+              elif [ "$OS_WINDOWS" = "true" ]; then
+                  if [ ! -f "$HOME/.cache/puppeteer/chrome/win64-${PUPPETEER_VERSION}/chrome-win/chrome.exe" ]; then
+                      rm -rf $HOME/.cache/puppeteer/chrome;
+                  fi
+              elif [ "$OS_MACOS" = "true" ]; then
+                  if [ ! -f "$HOME/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" ]; then
+                      rm -rf $HOME/.cache/puppeteer/chrome;
+                  fi
+              else
+                  echo -e "ERROR: unexpected OS";
+                  exit 1;
+              fi
               npx puppeteer browsers install chrome
           fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -178,22 +178,25 @@ jobs:
           key: puppeteer-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('packages/jco/package.json') }}
           path: |
             /home/runner/.cache/puppeteer
+            /Users/runner/.cache/puppeteer
+
+      # NOTE: on macos-latest w/ latest node (26.x), installing puppeteer via npx does not
+      # properly place the framework (dynamic lib) bits, so we perform a manual download of a set version instead.
       - name: Install puppeteer
+        id: puppeteer
+        env:
+          PUPPETEER_VERSION: "148.0.7778.97"
         run: |
-          npx puppeteer browsers install chrome
-      - name: Debug
-        run: |
-          brew install tree
-          echo '=> top level app folder'
-          ls '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app'
-          echo '=> root > contents'
-          ls '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS'
-          echo '=> root > contents > macos'
-          ls '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS'
-          ls '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/../'
-          echo '=> frameworks'
-          tree '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64'
-          ls '/Users/runner/.cache/puppeteer/chrome/mac_arm-148.0.7778.97/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/../Frameworks/'
+          if [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.node }}" == "latest" ]]; then
+              rm -rf /Users/runner/.cache/puppeteer/chrome
+              wget https://storage.googleapis.com/chrome-for-testing-public/${PUPPETEER_VERSION}/mac-arm64/chrome-mac-arm64.zip
+              mkdir -p /Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}/
+              unzip chrome-mac-arm64.zip -d /Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}
+              npx puppeteer browsers install chrome@${PUPPETEER_VERSION}
+              echo -e "puppeteer-path=/Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" >> $GITHUB_OUTPUT
+          else
+              npx puppeteer browsers install chrome
+          fi
 
       - name: Restore jco build
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -213,6 +216,9 @@ jobs:
         if: matrix.node == '18.x' || matrix.node == '20.x' || matrix.ndoe == '22.x'
         working-directory: packages/jco
         run: |
+          if [ "${{ steps.puppeteer.outputs.puppeteer-path }}" != "" ]; then
+              export PUPPETEER_PATH=${{ steps.puppeteer.outputs.puppeteer-path }}
+          fi
           npm run test:lts -- --maxWorkers 4 --minWorkers 2 --maxConcurrency 2
 
       - name: Test Latest Node.js

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -188,12 +188,15 @@ jobs:
           PUPPETEER_VERSION: "148.0.7778.97"
         run: |
           if [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.node }}" == "latest" ]]; then
-              rm -rf /Users/runner/.cache/puppeteer/chrome
-              wget https://storage.googleapis.com/chrome-for-testing-public/${PUPPETEER_VERSION}/mac-arm64/chrome-mac-arm64.zip
-              mkdir -p /Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}/
-              unzip chrome-mac-arm64.zip -d /Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}
-              npx puppeteer browsers install chrome@${PUPPETEER_VERSION}
-              echo -e "puppeteer-path=/Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing" >> $GITHUB_OUTPUT
+              export EXPECTED_PATH="/Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing";
+              if [[ ! -f "$EXPECTED_PATH" ]]; then
+                  rm -rf /Users/runner/.cache/puppeteer/chrome
+                  wget https://storage.googleapis.com/chrome-for-testing-public/${PUPPETEER_VERSION}/mac-arm64/chrome-mac-arm64.zip
+                  mkdir -p /Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}/
+                  unzip chrome-mac-arm64.zip -d /Users/runner/.cache/puppeteer/chrome/mac_arm-${PUPPETEER_VERSION}
+                  npx puppeteer browsers install chrome@${PUPPETEER_VERSION}
+              fi
+              echo -e "puppeteer-path=$EXPECTED_PATH" >> $GITHUB_OUTPUT
           else
               npx puppeteer browsers install chrome
           fi

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,7 +189,10 @@ jobs:
             /Users/runner/.cache/puppeteer
 
       # NOTE: on macos-latest w/ latest node (26.x), installing puppeteer via npx does not
-      # properly place the framework (dynamic lib) bits, so we perform a manual download of a set version instead.
+      # properly place the framework (dynamic lib) files, so we perform a manual download
+      # of a set version instead.
+      #
+      # TODO: revert to simple `npx puppeteer browsers install chrome` once this problem is fixed upstream
       - name: Install puppeteer
         id: puppeteer
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,14 @@ jobs:
         with:
           shared-key: jco-${{ hashFiles('Cargo.lock') }}
 
+      - name: Enable sccache
+        uses: mozilla-actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696 # v0.0.10
+
+      - name: Setup sccache
+        run: |
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+
       - name: Cache npm install
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3240,18 +3240,18 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.10.6",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.6.tgz",
-      "integrity": "sha512-pHUn6ZRt39bP3698HFQlu2ZHCkS/lPcpv7fVQcGBSzNNygw171UXAKrCUhy+TEMw4lEttOKDgNpb04hwUAJeiQ==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.4.1",
+        "debug": "^4.4.3",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.7.2",
-        "tar-fs": "^3.1.0",
+        "semver": "^7.7.4",
+        "tar-fs": "^3.1.1",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -4191,11 +4191,19 @@
       }
     },
     "node_modules/b4a": {
-      "version": "1.6.7",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.6.7.tgz",
-      "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -4203,24 +4211,32 @@
       "license": "MIT"
     },
     "node_modules/bare-events": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.6.1.tgz",
-      "integrity": "sha512-AuTJkq9XmE6Vk0FJVNq5QxETrSA/vKHarWVBG5l/JbdCL1prJemiyJqUS0jrlXO0MftuPq4m3YVYhoNc5+aE/g==",
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
     },
     "node_modules/bare-fs": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.2.0.tgz",
-      "integrity": "sha512-oRfrw7gwwBVAWx9S5zPMo2iiOjxyiZE12DmblmMQREgcogbNO0AFaZ+QBxxkEXiPspcpvO/Qtqn8LabUx4uYXg==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-events": "^2.5.4",
         "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4"
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
       },
       "engines": {
         "bare": ">=1.16.0"
@@ -4235,12 +4251,11 @@
       }
     },
     "node_modules/bare-os": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
-      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "bare": ">=1.14.0"
       }
@@ -4251,32 +4266,45 @@
       "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
         "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-      "integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "streamx": "^2.21.0"
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
       },
       "peerDependencies": {
+        "bare-abort-controller": "*",
         "bare-buffer": "*",
         "bare-events": "*"
       },
       "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
         "bare-buffer": {
           "optional": true
         },
         "bare-events": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -4300,9 +4328,9 @@
       "license": "MIT"
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4606,9 +4634,9 @@
       }
     },
     "node_modules/chromium-bidi": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-7.3.1.tgz",
-      "integrity": "sha512-i+BMGluhZZc4Jic9L1aHJBTfaopxmCqQxGklyMcqFx4fvF3nI4BJ3bCe1ad474nvYRIo/ZN/VrdA4eOaRZua4Q==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-14.0.0.tgz",
+      "integrity": "sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5039,9 +5067,9 @@
       "license": "ISC"
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1475386",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1475386.tgz",
-      "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -5251,6 +5279,8 @@
     },
     "node_modules/estraverse": {
       "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -5269,6 +5299,8 @@
     },
     "node_modules/esutils": {
       "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -5287,6 +5319,16 @@
         "split": "0.3",
         "stream-combiner": "~0.0.4",
         "through": "~2.3.1"
+      }
+    },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
       }
     },
     "node_modules/execa": {
@@ -6725,9 +6767,9 @@
       }
     },
     "node_modules/netmask": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-      "integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7402,9 +7444,9 @@
       }
     },
     "node_modules/pump": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-      "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7413,19 +7455,19 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.16.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.16.2.tgz",
-      "integrity": "sha512-eNjKzwjITM4Lvho6iHb+VQamadUBgc8TsjAApsKi5N8DXipxAaAZWssBOFsrIOLo4eYWYj0Qk5gmr4wBSqzJWw==",
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.1.tgz",
+      "integrity": "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.6",
-        "chromium-bidi": "7.3.1",
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1475386",
-        "puppeteer-core": "24.16.2",
-        "typed-query-selector": "^2.12.0"
+        "devtools-protocol": "0.0.1608973",
+        "puppeteer-core": "24.43.1",
+        "typed-query-selector": "^2.12.2"
       },
       "bin": {
         "puppeteer": "lib/cjs/puppeteer/node/cli.js"
@@ -7435,18 +7477,19 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.16.2",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.16.2.tgz",
-      "integrity": "sha512-areKSSQzpoHa5nCk3uD/o504yjrW5ws0N6jZfdFZ3a4H+Q7NBgvuDydjN5P87jN4Rj+eIpLcK3ELOThTtYuuxg==",
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.10.6",
-        "chromium-bidi": "7.3.1",
-        "debug": "^4.4.1",
-        "devtools-protocol": "0.0.1475386",
-        "typed-query-selector": "^2.12.0",
-        "ws": "^8.18.3"
+        "@puppeteer/browsers": "2.13.2",
+        "chromium-bidi": "14.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
+        "webdriver-bidi-protocol": "0.4.1",
+        "ws": "^8.20.0"
       },
       "engines": {
         "node": ">=18"
@@ -7671,9 +7714,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -7916,17 +7959,15 @@
       }
     },
     "node_modules/streamx": {
-      "version": "2.22.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.1.tgz",
-      "integrity": "sha512-znKXEBxfatz2GBNK02kRnCXjV+AA4kjZIUxeWSr3UGirZMJfTE9uiwKHobnbgxWyL/JWro8tTq+vOqAK1/qbSA==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "events-universal": "^1.0.0",
         "fast-fifo": "^1.3.2",
         "text-decoder": "^1.1.0"
-      },
-      "optionalDependencies": {
-        "bare-events": "^2.2.0"
       }
     },
     "node_modules/string_decoder": {
@@ -8125,9 +8166,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.0.tgz",
-      "integrity": "sha512-5Mty5y/sOF1YWj1J6GiBodjlDc05CUR8PKXrsnFAiSG0xA+GHeWLovaZPYUDXkH/1iKRf2+M5+OrRgzC7O9b7w==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8140,13 +8181,14 @@
       }
     },
     "node_modules/tar-fs/node_modules/tar-stream": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-      "integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
         "fast-fifo": "^1.2.0",
         "streamx": "^2.15.0"
       }
@@ -8167,6 +8209,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
       }
     },
     "node_modules/terminate": {
@@ -8203,9 +8255,9 @@
       "license": "MIT"
     },
     "node_modules/text-decoder": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-      "integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -8373,9 +8425,9 @@
       }
     },
     "node_modules/typed-query-selector": {
-      "version": "2.12.0",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.0.tgz",
-      "integrity": "sha512-SbklCd1F0EiZOyPiW192rrHZzZ5sBijB6xM+cpmrwDqObvdtunOHHIk9fCGsoK5JVIYXoyEp4iEdE3upFH3PAg==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -8720,6 +8772,13 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.1.tgz",
+      "integrity": "sha512-ARrjNjtWRRs2w4Tk7nqrf2gBI0QXWuOmMCx2hU+1jUt6d00MjMxURrhxhGbrsoiZKJrhTSTzbIrc554iKI10qw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-book-library-wasm": {
       "resolved": "examples/components/webidl-book-library",
       "link": true
@@ -8896,9 +8955,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9048,7 +9107,7 @@
         "conventional-changelog-conventionalcommits": "^9.1.0",
         "mime": "^4.0.7",
         "oxfmt": "^0.28.0",
-        "puppeteer": "^24.16.2",
+        "puppeteer": "^24.43.1",
         "semver": "^7.7.1",
         "smol-toml": "^1.4.2",
         "typescript": "^5.9.2",
@@ -9673,7 +9732,7 @@
         "@bytecodealliance/componentize-js": "0.20.0",
         "@bytecodealliance/jco": "1.15.2",
         "mime": "^4.0.7",
-        "puppeteer": "^24.16.2"
+        "puppeteer": "^24.43.1"
       }
     },
     "packages/preview2-shim/node_modules/@bytecodealliance/componentize-js": {

--- a/packages/jco/package.json
+++ b/packages/jco/package.json
@@ -89,7 +89,7 @@
         "conventional-changelog-conventionalcommits": "^9.1.0",
         "mime": "^4.0.7",
         "oxfmt": "^0.28.0",
-        "puppeteer": "^24.16.2",
+        "puppeteer": "^24.43.1",
         "semver": "^7.7.1",
         "smol-toml": "^1.4.2",
         "typescript": "^5.9.2",

--- a/packages/jco/test/browser.js
+++ b/packages/jco/test/browser.js
@@ -75,7 +75,9 @@ suite("Browser", () => {
             },
         );
 
-        browser = await puppeteer.launch();
+        browser = await puppeteer.launch({
+            executablePath: env.PUPPETEER_PATH,
+        });
     });
 
     afterAll(async function () {

--- a/packages/jco/test/jspi.browser.js
+++ b/packages/jco/test/jspi.browser.js
@@ -1,4 +1,5 @@
 import { resolve } from "node:path";
+import { env } from "node:process";
 import { mkdir, rm, symlink } from "node:fs/promises";
 
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -97,6 +98,7 @@ suite(`Async`, async () => {
 
         // Start a browser to visit the test server
         const browser = await puppeteer.launch({
+            executablePath: env.PUPPETEER_PATH,
             args: [
                 "--enable-experimental-webassembly-jspi",
                 "--flag-switches-begin",

--- a/packages/preview2-shim/package.json
+++ b/packages/preview2-shim/package.json
@@ -60,6 +60,6 @@
     "@bytecodealliance/componentize-js": "0.20.0",
     "@bytecodealliance/jco": "1.15.2",
     "mime": "^4.0.7",
-    "puppeteer": "^24.16.2"
+    "puppeteer": "^24.43.1"
   }
 }

--- a/packages/preview2-shim/test/common.js
+++ b/packages/preview2-shim/test/common.js
@@ -214,6 +214,7 @@ export async function startTestServer(args) {
 
   // Launch a puppeteer instance
   const browser = await puppeteer.launch({
+    executablePath: env.PUPPETEER_PATH,
     args: [
       ...(env.TEST_PUPPETEER_LAUNCH_ARGS ?? "").split(","),
       "--enable-experimental-webassembly-jspi",


### PR DESCRIPTION
Tests are currently failing with the following error:

```
dlopen /Users/runner/.cache/puppeteer/chrome/mac_arm-139.0.7258.68/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/../Frameworks/Google Chrome for Testing Framework.framework/Versions/139.0.7258.68/Google Chrome for Testing Framework: dlopen(/Users/runner/.cache/puppeteer/chrome/mac_arm-139.0.7258.68/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/../Frameworks/Google Chrome for Testing Framework.framework/Versions/139.0.7258.68/Google Chrome for Testing Framework, 0x0105): tried: '/Users/runner/.cache/puppeteer/chrome/mac_arm-139.0.7258.68/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/../Frameworks/Google Chrome for Testing Framework.framework/Versions/139.0.7258.68/Google Chrome for Testing Framework' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/Users/runner/.cache/puppeteer/chrome/mac_arm-139.0.7258.68/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/../Frameworks/Google Chrome for Testing Framework.framework/Versions/139.0.7258.68/Google Chrome for Testing Framework' (no such file), '/Users/runner/.cache/puppeteer/chrome/mac_arm-139.0.7258.68/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/../Frameworks/Google Chrome for Testing Framework.framework/Versions/139.0.7258.68/Google Chrome for Testing Framework' (no such file).
```

We run the puppeteer install right before the run (and load values from cache as well), so it's not completely clear why this happens, *but* updating puppeteer to a later version and also likely fixing the hash of the cache should fix the issue if it's not something deeper.