### PR TITLE
fix(bindgen): fix result rejection lowering and stream drop propagation

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -3155,7 +3155,7 @@ impl Bindgen for FunctionBindgen<'_> {
                                 size32: {payload_size32_js},
                                 // TODO(feat): facilitate non utf8 string encoding for lowered streams
                                 stringEncoding: 'utf8',
-                                geReallocFn: {get_realloc_fn_js},
+                                getReallocFn: {get_realloc_fn_js},
                             }},
                         }});
 

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -1482,6 +1482,7 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
             &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::InternalFutureClass),
             &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::IsFutureLowerableObject),
             &Intrinsic::SymbolResourceRep,
+            &Intrinsic::GetErrorPayload,
             &Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState),
             &Intrinsic::AsyncFuture(AsyncFutureIntrinsic::GenFutureHostInjectFn),
             &Intrinsic::Lower(LowerIntrinsic::LowerFlatU32),

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
@@ -1366,6 +1366,7 @@ impl AsyncFutureIntrinsic {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let gen_host_inject_fn = self.name();
                 let nested_future_symbol = Self::NestedFutureSymbol.name();
+                let get_error_payload = Intrinsic::GetErrorPayload.name();
 
                 uwriteln!(
                     output,
@@ -1389,9 +1390,19 @@ impl AsyncFutureIntrinsic {
                                   return () => {{ throw new Error('cannot inject write: host must write to future before closing'); }}
                               }}
 
+                              let value;
                               try {{
-                                  const value = await promise;
+                                  value = await promise;
+                              }} catch (err) {{
+                                  const elemMeta = hostWriteEnd.getElemMeta();
+                                  if (!elemMeta.payloadTypeName?.startsWith('Result(')) {{
+                                      {debug_log_fn}("failed to inject host write", err);
+                                      throw new Error("cannot inject write: promise failed");
+                                  }}
+                                  value = {{ tag: 'err', val: {get_error_payload}(err) }};
+                              }}
 
+                              try {{
                                   // If we've read a nested promise from the outside,
                                   // we must convert the value that we get back into a future,
                                   // because we are not at the lowest level yet.

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -542,6 +542,10 @@ impl AsyncStreamIntrinsic {
                                 if (!buffer) {{ throw new TypeError('missing/invalid buffer'); }}
                                 if (!onCopyFn) {{ throw new TypeError("missing/invalid onCopy handler"); }}
                                 if (!onCopyDoneFn) {{ throw new TypeError("missing/invalid onCopyDone handler"); }}
+                                if (this.isDropped()) {{
+                                    onCopyDoneFn({stream_end_class}.CopyResult.DROPPED);
+                                    return;
+                                }}
 
                                 if (!this.#pendingBufferMeta.buffer) {{
                                     this.setPendingBufferMeta({{ componentIdx, buffer, onCopyFn, onCopyDoneFn }});
@@ -708,7 +712,8 @@ impl AsyncStreamIntrinsic {
                                      this.#pendingBufferMeta.onCopyDoneFn = null;
                                      f({stream_end_class}.CopyResult.DROPPED);
                                  }}
-                                 return;
+                                 this.setCopyState({stream_end_class}.CopyState.DONE);
+                                 return {stream_end_class}.CopyResult.DROPPED;
                              }}
 
                              const {{ buffer, onCopyFn, onCopyDoneFn }} = this.setupCopy({{
@@ -1331,6 +1336,7 @@ impl AsyncStreamIntrinsic {
                                 writeFn: async (v) => {{
                                     await streamEnd.write(v);
                                 }},
+                                dropFn: () => streamEnd.drop(),
                             }});
                         }}
                     }}
@@ -1409,7 +1415,7 @@ impl AsyncStreamIntrinsic {
                         }}
 
                         [{symbol_dispose}]() {{
-                            this.#dropFn();
+                            this.#dropFn?.();
                         }}
 
                     }}

--- a/packages/jco/test/p3/future-lower.js
+++ b/packages/jco/test/p3/future-lower.js
@@ -407,10 +407,16 @@ suite("future<T> lowers", () => {
             // and when passed through a Promise, they throw.
             vals = [{ tag: "err", val: "nope" }];
             for (const v of vals) {
-                expect(
+                await expect(
                     instance["jco:test-components/future-lower-async"].readFutureValueResultString(Promise.resolve(v)),
                 ).rejects.toThrow(v.val);
             }
+
+            await expect(
+                instance["jco:test-components/future-lower-async"].readFutureValueResultString(
+                    Promise.reject("rejected result payload"),
+                ),
+            ).rejects.toThrow("rejected result payload");
         });
 
         test.concurrent("list<u8>", async () => {

--- a/packages/jco/test/p3/stream-lifts.js
+++ b/packages/jco/test/p3/stream-lifts.js
@@ -118,6 +118,16 @@ suite("stream<T> lifts", () => {
         }
     });
 
+    test.concurrent("returned stream dispose drops the stream end", async () => {
+        const instance = await getInstance();
+        const dispose = Symbol.dispose || Symbol.for("dispose");
+        const stream = await instance["jco:test-components/get-stream-async"].getStreamU8([1, 2, 3]);
+
+        assert.isFunction(stream[dispose]);
+        assert.doesNotThrow(() => stream[dispose]());
+        assert.deepEqual(await stream.next(), { value: undefined, done: true });
+    });
+
     test.concurrent("u16/s16", async () => {
         const instance = await getInstance();
         assert.instanceOf(instance["jco:test-components/get-stream-async"].getStreamU16, AsyncFunction);


### PR DESCRIPTION
This patch contains a few fixes:
- fix typo in realloc callback
- rejected `future<result<>>` are converted to `result.err`
- write to a dropped stream should return `DROPPED`
- forward shim dispose to canonical stream end