### PR TITLE
fix(bindgen): allow external crates to use intrinsic renderer

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -3,6 +3,8 @@
 use std::collections::{BTreeSet, HashSet};
 use std::fmt::Write;
 
+use anyhow::{Context as _, Result};
+
 use crate::source::Source;
 use crate::{TranspileOpts, uwrite, uwriteln};
 
@@ -246,7 +248,7 @@ impl Intrinsic {
             }
 
             Intrinsic::Base64Compile => {
-                if !args.no_nodejs_compat {
+                if !args.nodejs_compat_disabled {
                     uwriteln!(
                         output,
                         r#"
@@ -307,7 +309,7 @@ impl Intrinsic {
             ),
 
             Intrinsic::FetchCompile => {
-                if !args.no_nodejs_compat {
+                if !args.nodejs_compat_disabled {
                     output.push_str("
                     const isNode = typeof process !== 'undefined' && process.versions && process.versions.node;
                     let _fs;
@@ -1043,7 +1045,7 @@ impl Intrinsic {
 
 /// Profile for determinism to be used by async implementation
 #[derive(Debug, Default, PartialEq, Eq)]
-pub(crate) enum AsyncDeterminismProfile {
+pub enum AsyncDeterminismProfile {
     /// Allow random ordering non-determinism
     #[default]
     Random,
@@ -1067,17 +1069,80 @@ impl std::fmt::Display for AsyncDeterminismProfile {
 }
 
 /// Arguments to `render_intrinsics`
+#[non_exhaustive]
 pub struct RenderIntrinsicsArgs<'a> {
     /// List of intrinsics being built for use
     pub(crate) intrinsics: &'a mut BTreeSet<Intrinsic>,
     /// Whether to use NodeJS compat
-    pub(crate) no_nodejs_compat: bool,
+    pub(crate) nodejs_compat_disabled: bool,
     /// Whether instantiation has occurred
     pub(crate) instantiation: bool,
     /// The kind of determinism to use
     pub(crate) determinism: AsyncDeterminismProfile,
     /// Options provided when performing transpilation
     pub(crate) transpile_opts: &'a TranspileOpts,
+}
+
+impl<'a> RenderIntrinsicsArgs<'a> {
+    /// Create a builder for rendering intrinsics with `render_intrinsics`
+    pub fn builder() -> RenderIntrinsicsArgsBuilder<'a> {
+        RenderIntrinsicsArgsBuilder::default()
+    }
+}
+
+/// Builder for constructing `RenderIntrinsicsArgs`.
+#[derive(Default)]
+pub struct RenderIntrinsicsArgsBuilder<'a> {
+    nodejs_compat_disabled: Option<bool>,
+    instantiation: Option<bool>,
+    determinism: Option<AsyncDeterminismProfile>,
+    transpile_opts: Option<&'a TranspileOpts>,
+    intrinsics: Option<&'a mut BTreeSet<Intrinsic>>,
+}
+
+impl<'a> RenderIntrinsicsArgsBuilder<'a> {
+    /// Sets whether to use NodeJS compatibility mode.
+    pub fn nodejs_compat_disabled(mut self, disabled: bool) -> Self {
+        self.nodejs_compat_disabled = Some(disabled);
+        self
+    }
+
+    /// Sets whether instantiation has occurred.
+    pub fn instantiation_occurred(mut self, occurred: bool) -> Self {
+        self.instantiation = Some(occurred);
+        self
+    }
+
+    /// Sets the required determinism profile.
+    pub fn determinism_profile(mut self, determinism: AsyncDeterminismProfile) -> Self {
+        self.determinism = Some(determinism);
+        self
+    }
+
+    /// Sets the required determinism profile.
+    pub fn intrinsics(mut self, intrinsics: &'a mut BTreeSet<Intrinsic>) -> Self {
+        self.intrinsics = Some(intrinsics);
+        self
+    }
+
+    /// Sets transpilation options
+    pub fn transpile_options(mut self, opts: &'a TranspileOpts) -> Self {
+        self.transpile_opts = Some(opts);
+        self
+    }
+
+    /// Build the final `RenderIntrinsicsArgs` object
+    pub fn build(self) -> Result<RenderIntrinsicsArgs<'a>> {
+        Ok(RenderIntrinsicsArgs {
+            intrinsics: self.intrinsics.context("missing intrinsic set")?,
+            nodejs_compat_disabled: self.nodejs_compat_disabled.unwrap_or_default(),
+            instantiation: self.instantiation.unwrap_or_default(),
+            determinism: self.determinism.unwrap_or_default(),
+            transpile_opts: self
+                .transpile_opts
+                .context("transpile options must be provided")?,
+        })
+    }
 }
 
 /// Intrinsics that should be rendered as early as possible

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -418,13 +418,15 @@ impl JsBindgen<'_> {
         // Render the telemery directive
         uwriteln!(output, r#""use components";"#);
 
-        let js_intrinsics = render_intrinsics(RenderIntrinsicsArgs {
-            intrinsics: &mut self.all_intrinsics,
-            no_nodejs_compat: self.opts.no_nodejs_compat,
-            instantiation: self.opts.instantiation.is_some(),
-            determinism: AsyncDeterminismProfile::default(),
-            transpile_opts: opts,
-        });
+        let render_args = RenderIntrinsicsArgs::builder()
+            .intrinsics(&mut self.all_intrinsics)
+            .nodejs_compat_disabled(self.opts.no_nodejs_compat)
+            .instantiation_occurred(self.opts.instantiation.is_some())
+            .determinism_profile(AsyncDeterminismProfile::default())
+            .transpile_options(opts)
+            .build()
+            .expect("failed to build args to render intrinsics");
+        let js_intrinsics = render_intrinsics(render_args);
 
         if let Some(instantiation) = &self.opts.instantiation {
             uwrite!(


### PR DESCRIPTION
This commit adds changes to expose `AsyncDeterminismProfile` and fields of `RenderIntrinsicArgs` so it can be used by downstream users of `render_intrinsics` via  `builder()` method.