### PR TITLE
fix(bindgen): register p3 global table-map intrinsics before per-table assignments

### DIFF
--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -806,40 +806,55 @@ impl<'a> Instantiator<'a, '_> {
             }
         }
 
-        // Set up global stream map, which is used by intrinsics like stream.transfer
-        let global_stream_table_map =
-            Intrinsic::AsyncStream(AsyncStreamIntrinsic::GlobalStreamTableMap).name();
-        let rep_table_class = Intrinsic::RepTableClass.name();
-        for (table_idx, component_idx) in self.stream_tables.iter() {
-            self.src.js.push_str(&format!(
-                "{global_stream_table_map}[{}] = {{ componentIdx: {}, table: new {rep_table_class}() }};\n",
-                table_idx.as_u32(),
-                component_idx.as_u32(),
+        // Set up global stream map, which is used by intrinsics like stream.transfer.
+        // Register the intrinsic so the `const STREAM_TABLES = {};` declaration
+        // is emitted before these per-table assignments — without that, the
+        // generated module references an undeclared identifier and fails to
+        // load (ReferenceError: STREAM_TABLES is not defined).
+        if !self.stream_tables.is_empty() {
+            let global_stream_table_map = self.bindgen.intrinsic(Intrinsic::AsyncStream(
+                AsyncStreamIntrinsic::GlobalStreamTableMap,
             ));
+            let rep_table_class = Intrinsic::RepTableClass.name();
+            for (table_idx, component_idx) in self.stream_tables.iter() {
+                self.src.js.push_str(&format!(
+                    "{global_stream_table_map}[{}] = {{ componentIdx: {}, table: new {rep_table_class}() }};\n",
+                    table_idx.as_u32(),
+                    component_idx.as_u32(),
+                ));
+            }
         }
 
-        // Set up global future map, which is used by intrinsics like future.transfer
-        let global_future_table_map =
-            Intrinsic::AsyncFuture(AsyncFutureIntrinsic::GlobalFutureTableMap).name();
-        let rep_table_class = Intrinsic::RepTableClass.name();
-        for (table_idx, component_idx) in self.future_tables.iter() {
-            self.src.js.push_str(&format!(
-                "{global_future_table_map}[{}] = {{ componentIdx: {}, table: new {rep_table_class}() }};\n",
-                table_idx.as_u32(),
-                component_idx.as_u32(),
+        // Set up global future map, which is used by intrinsics like future.transfer.
+        // Same registration fix as above for FUTURE_TABLES.
+        if !self.future_tables.is_empty() {
+            let global_future_table_map = self.bindgen.intrinsic(Intrinsic::AsyncFuture(
+                AsyncFutureIntrinsic::GlobalFutureTableMap,
             ));
+            let rep_table_class = Intrinsic::RepTableClass.name();
+            for (table_idx, component_idx) in self.future_tables.iter() {
+                self.src.js.push_str(&format!(
+                    "{global_future_table_map}[{}] = {{ componentIdx: {}, table: new {rep_table_class}() }};\n",
+                    table_idx.as_u32(),
+                    component_idx.as_u32(),
+                ));
+            }
         }
 
-        // Set up global error context map, which is used by intrinsics like err_ctx.transfer
-        let global_err_ctx_table_map =
-            Intrinsic::ErrCtx(ErrCtxIntrinsic::GlobalErrCtxTableMap).name();
-        let rep_table_class = Intrinsic::RepTableClass.name();
-        for (table_idx, component_idx) in self.err_ctx_tables.iter() {
-            self.src.js.push_str(&format!(
-                "{global_err_ctx_table_map}[{}] = {{ componentIdx: {}, table: new {rep_table_class}() }};\n",
-                table_idx.as_u32(),
-                component_idx.as_u32(),
-            ));
+        // Set up global error context map, which is used by intrinsics like err_ctx.transfer.
+        // Same registration fix as above for ERR_CTX_TABLES.
+        if !self.err_ctx_tables.is_empty() {
+            let global_err_ctx_table_map = self
+                .bindgen
+                .intrinsic(Intrinsic::ErrCtx(ErrCtxIntrinsic::GlobalErrCtxTableMap));
+            let rep_table_class = Intrinsic::RepTableClass.name();
+            for (table_idx, component_idx) in self.err_ctx_tables.iter() {
+                self.src.js.push_str(&format!(
+                    "{global_err_ctx_table_map}[{}] = {{ componentIdx: {}, table: new {rep_table_class}() }};\n",
+                    table_idx.as_u32(),
+                    component_idx.as_u32(),
+                ));
+            }
         }
 
         // Process global initializers


### PR DESCRIPTION
## Problem

When `Instantiator::instantiate` (`crates/js-component-bindgen/src/transpile_bindgen.rs`, ~line 808) emits the per-table assignment lines:

```js
STREAM_TABLES[0]    = { componentIdx: 0, table: new RepTable() };
FUTURE_TABLES[0]    = { componentIdx: 0, table: new RepTable() };
ERR_CTX_TABLES[0]   = { componentIdx: 0, table: new RepTable() };
```

…it gets the identifier strings by calling `Intrinsic::AsyncStream(AsyncStreamIntrinsic::GlobalStreamTableMap).name()` directly. That bypasses `Bindgen::intrinsic()`, which is the method responsible for inserting the intrinsic into `all_intrinsics`. As a result, the render branches in `intrinsics/p3/async_stream.rs`, `intrinsics/p3/async_future.rs`, and `intrinsics/p3/error_context.rs` that emit:

```js
const STREAM_TABLES = {};
const FUTURE_TABLES = {};
const ERR_CTX_TABLES = {};
```

…never run. The transpiled module then references undeclared identifiers and fails at module-evaluation time:

```
ReferenceError: STREAM_TABLES is not defined
    at <entry>.js:4554:1
```

This happens for any wasip3-async component with stream/future/err-ctx tables — i.e., effectively every real async-component output.

## Reproducer

```sh
npx jco transpile <any-wasip3-async-component>.wasm \
    --async-mode jspi \
    -o out/
node --input-type=module -e "await import('./out/<name>.js')"
```

For instance, with `ghcr.io/actpkg/time:0.2.0` (or any component built using `wit_bindgen` + `--async-spawn` exporting an interface that uses `stream<…>`):

```sh
oras pull ghcr.io/actpkg/time:0.2.0
npx jco transpile component_time.wasm --async-mode jspi -o out/
# Inspect out/component_time.js around line 4500 — `STREAM_TABLES[0] = …`
# appears without any preceding declaration.
```

## Fix

Route the name lookups through `self.bindgen.intrinsic(…)` so the intrinsic gets registered and its `render` branch emits the corresponding declaration. Guard each block on `is_empty()` so we don't insert intrinsics nobody uses.

Three identical blocks fixed — stream, future, and err-ctx table maps. The fix is purely additive (no semantic change for components that don't have these tables) and uses the canonical `self.bindgen.intrinsic(…)` idiom already used elsewhere in the same file.

## Testing

- `cargo build -p js-component-bindgen` — clean.
- Verified end-to-end against `ghcr.io/actpkg/time:0.2.0` (wasip3-async `act:tools/tool-provider`): transpiled output now loads successfully under both Chrome 148 (JSPI default) and Firefox Nightly 152 (JSPI default).
- Existing test suite (`cargo test`) — not run on this branch yet; CI on this PR will cover it.

## Related

A second wasip3-async bindgen bug — `_liftFlatRecord` mis-decoding the *flat-fields* form of async task-return — will be reported as a separate issue with reproducer. That fix is more involved and benefits from upstream design discussion before code.