### PR TITLE
refactor(ci): changelog generation

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -182,7 +182,7 @@ jobs:
           git cliff \
             --repository=${{ github.workspace }}/.git \
             --config=${{ steps.project-meta.outputs.project-dir }}/cliff.toml \
-            --unreleased \
+            --latest \
             $OPT_TAG \
             $OPT_TAG_PATTERN \
             --prepend=${{ steps.project-meta.outputs.project-dir }}/CHANGELOG.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -454,43 +454,16 @@ jobs:
           fallback: none
           tool: git-cliff
 
-      # Re-generate the current changelog so we can use it in the GH release announcement
-      #
-      # NOTE: if this workflow is being run due to a tag push, that's an *already committed* release
-      # tag and likely the one corresponding to this release, so we use the latest
-      #
-      - name: Re-generate current changelog
-        id: changelog-regen
-        env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT || secrets.GITHUB_TOKEN }}
-          GITHUB_REPO: ${{ github.repository }}
-        run: |
-          export OPT_START=--unreleased;
-          export OPT_TAG=;
-          if [ "tag" == "${{ github.ref_type }}" ]; then
-            export OPT_START=--current;
-            export OPT_TAG=--tag=${{ needs.meta.outputs.next-release-tag }};
-          fi
-
-          export TAG_PATTERN='^${{ needs.meta.outputs.project }}-v[0-9]+.[0-9]+.[0-9]+$';
-          if [ "true" == "${{ needs.meta.outputs.is-prerelease }}" ]; then
-            export TAG_PATTERN='^${{ needs.meta.outputs.project }}-v[0-9]+.[0-9]+.[0-9]+(-beta|-rc|-alpha)?';
-            export OPT_TAG_PATTERN=--tag-pattern=$TAG_PATTERN;
-          fi
-
-          echo -e "tag-pattern=$TAG_PATTERN" >> $GITHUB_OUTPUT;
-
-          git cliff \
-            --repository=${{ github.workspace }}/.git \
-            --config=${{ needs.meta.outputs.project-dir }}/cliff.toml \
-            $OPT_START \
-            $OPT_TAG \
-            $OPT_TAG_PATTERN \
-            > ${{ needs.meta.outputs.project-dir }}/CHANGELOG.current;
-
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: artifacts
+
+      - name: extract latest changelog section
+        env:
+          OUTPUT_PATH: ${{ needs.meta.outputs.project-dir }}/CHANGELOG.latest
+          CHANGELOG_PATH: ${{ needs.meta.outputs.project-dir }}/CHANGELOG
+        run: |
+          node scripts/extract-latest-changelog-section.mjs
 
       - name: Create GH release
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
@@ -500,7 +473,7 @@ jobs:
           draft: ${{ github.ref_type != 'tag' }}
           tag_name: ${{ needs.meta.outputs.next-release-tag }}
           generate_release_notes: false
-          body_path: ${{ needs.meta.outputs.project-dir }}/CHANGELOG.current
+          body_path: ${{ needs.meta.outputs.project-dir }}/CHANGELOG.newest
           make_latest: ${{ needs.meta.outputs.project == 'jco' && github.ref_type == 'tag' && needs.meta.outputs.is-prerelease == 'false' }}
           files: |
             ./artifacts/*

--- a/scripts/extract-latest-changelog-section.mjs
+++ b/scripts/extract-latest-changelog-section.mjs
@@ -1,0 +1,64 @@
+import * as process from "node:process";
+import * as readline from "node:readline";
+import * as fs from "node:fs/promises";
+import { createReadStream, createWriteStream } from "node:fs";
+
+const REGEX_CHANGELOG_RELEASE_SECTION_HEADING = /^## \[(\d+\.\d+\.\d+(?:-[A-Za-z0-9.-]+)?)\] - (\d{4}-\d{2}-\d{2})$/;
+
+async function fileExists(path) {
+    return fs.stat(path).then(s => s.isFile(), () => false);
+}
+
+async function main() {
+    const changelogPath = process.env.CHANGELOG_PATH;
+    if (!changelogPath) {
+        throw new Error(`invalid path to changelog [${changelogPath}]`);
+    }
+    const changelogPathExists = await fileExists(changelogPath);
+    if (!changelogPathExists) {
+        throw new Error(`missing changelog file @ [${changelogPath}]`);
+    }
+
+    const outputPath = process.env.OUTPUT_PATH;
+    if (!outputPath) {
+        throw new Error(`invalid output path [${outputPath}]`);
+    }
+    process.stderr.write(`[info] reading lines from changelog @ [${changelogPath}]\n`);
+    const lines = readline.createInterface({
+        input: createReadStream(changelogPath),
+        crlfDelay: Infinity,
+    });
+
+    // Read the first line
+    let linesIterator = lines[Symbol.asyncIterator]();
+    let { value: firstLine, done } = await linesIterator.next();
+    if (!firstLine || done) { throw new Error("missing first line/unexpectedly finished iterator (is the changelog file correct?)"); }
+    if (!firstLine.toLowerCase().includes("changelog")) {
+        throw new Error("missing changelog heading on first line, is this file a changelog file?");
+    }
+
+    let outputStream;
+    let sectionsFound = 0;
+    for await (const line of lines) {
+        if (REGEX_CHANGELOG_RELEASE_SECTION_HEADING.test(line)) {
+            sectionsFound++;
+            if (!outputStream) {
+                outputStream = createWriteStream(outputPath);
+            }
+        }
+        if (sectionsFound == 0) {
+            continue;
+        } else if (sectionsFound === 1) {
+            //process.stderr.write(`[info] writing line [${line}]\n`);
+            outputStream.write(`${line}\n`);
+        } else if (sectionsFound === 2) {
+            outputStream.close();
+            process.stderr.write(`[info] wrote lines to output @ [${outputPath}]\n`);
+            break;
+        } else {
+            throw new Error("unexpectedly processing more than one section");
+        }
+    }
+}
+
+await main();


### PR DESCRIPTION
This commit refactors changelog generation, switching from repeatedly generating the changelog with `git-cliff` to generating once during the release PR, then extracting the generated section for reuse later.

This approach has some benefits including enabling maintainers to write custom headers/information into the changelog itself  before a release goes out.

This commit should also fix an issue wherein `[unreleased]` was making it out into GH release notes.