### PR TITLE
fix(p3-shim): align socket behavior with WASI tests

### DIFF
--- a/packages/preview3-shim/lib/nodejs/sockets/address.js
+++ b/packages/preview3-shim/lib/nodejs/sockets/address.js
@@ -1,4 +1,5 @@
 // Adapted from preview2-shim/lib/io/worker-sockets.js
+import { networkInterfaces } from "node:os";
 
 // TODO(tandr): switch to generated types
 export const IP_ADDRESS_FAMILY = {
@@ -47,7 +48,7 @@ export const ipv4ToTuple = (ipv4) => {
 
 export const isMulticastIpAddress = ({ tag, val: { address } }) =>
   (tag === "ipv4" && address[0] >= 0xe0 && address[0] <= 0xef) ||
-  (tag === "ipv6" && address[0] === 0xff);
+  (tag === "ipv6" && (address[0] & 0xff00) === 0xff00);
 
 export const isIpv4MappedAddress = ({ tag, val: { address } }) =>
   tag === "ipv6" &&
@@ -65,6 +66,19 @@ export const isBroadcastIpAddress = ({ tag, val: { address } }) =>
 
 export const isUnicastIpAddress = (a) =>
   !isMulticastIpAddress(a) && !isBroadcastIpAddress(a) && !isWildcardIpAddress(a);
+
+export const isLoopbackIpAddress = ({ tag, val: { address } }) =>
+  (tag === "ipv4" && address[0] === 127) ||
+  (tag === "ipv6" && address.slice(0, 7).every((segment) => segment === 0) && address[7] === 1);
+
+export const ipAddressConflict = (a, b) =>
+  a.tag === b.tag &&
+  Number(a.val.port) !== 0 &&
+  Number(b.val.port) !== 0 &&
+  Number(a.val.port) === Number(b.val.port) &&
+  (isWildcardIpAddress(a) ||
+    isWildcardIpAddress(b) ||
+    a.val.address.every((segment, idx) => segment === b.val.address[idx]));
 
 /**
  * Serialize a socket‐address to text.
@@ -106,4 +120,28 @@ export const makeIpAddress = (family, host, port) => {
   return family === "ipv4"
     ? { tag: "ipv4", val: base }
     : { tag: "ipv6", val: { ...base, flowInfo: 0, scopeId: 0 } };
+};
+
+/**
+ * Determine whether an IP address can be used as a local bind address.
+ * @param {{tag:'ipv4'|'ipv6',val:{address:number[]}}} ipAddress
+ * @returns {boolean}
+ */
+export const isBindableIpAddress = (ipAddress) => {
+  if (isWildcardIpAddress(ipAddress)) {
+    return true;
+  }
+
+  const expectedFamily = ipAddress.tag === "ipv4" ? "IPv4" : "IPv6";
+  const expectedAddress = ipAddress.val.address;
+  return Object.values(networkInterfaces())
+    .flat()
+    .some((iface) => {
+      if (iface?.family !== expectedFamily) {
+        return false;
+      }
+      const ifaceAddress =
+        ipAddress.tag === "ipv4" ? ipv4ToTuple(iface.address) : ipv6ToTuple(iface.address);
+      return expectedAddress.every((segment, idx) => segment === ifaceAddress[idx]);
+    });
 };

--- a/packages/preview3-shim/lib/nodejs/sockets/address.js
+++ b/packages/preview3-shim/lib/nodejs/sockets/address.js
@@ -73,9 +73,8 @@ export const isLoopbackIpAddress = ({ tag, val: { address } }) =>
 
 export const ipAddressConflict = (a, b) =>
   a.tag === b.tag &&
-  Number(a.val.port) !== 0 &&
-  Number(b.val.port) !== 0 &&
   Number(a.val.port) === Number(b.val.port) &&
+  Number(a.val.port) !== 0 &&
   (isWildcardIpAddress(a) ||
     isWildcardIpAddress(b) ||
     a.val.address.every((segment, idx) => segment === b.val.address[idx]));

--- a/packages/preview3-shim/lib/nodejs/sockets/error.js
+++ b/packages/preview3-shim/lib/nodejs/sockets/error.js
@@ -109,6 +109,9 @@ export class SocketError extends Error {
       if (tag === "other") {
         val = err.code;
       }
+    } else if (err && typeof err.message === "string" && ERROR_MAP[err.message]) {
+      tag = ERROR_MAP[err.message];
+      message = err.message;
     } else {
       tag = "other";
       message = err?.message;

--- a/packages/preview3-shim/lib/nodejs/sockets/tcp.js
+++ b/packages/preview3-shim/lib/nodejs/sockets/tcp.js
@@ -8,6 +8,7 @@ import {
   isUnicastIpAddress,
   isMulticastIpAddress,
   isIpv4MappedAddress,
+  isBindableIpAddress,
   IP_ADDRESS_FAMILY,
 } from "./address.js";
 
@@ -77,11 +78,8 @@ export class TcpSocket {
     keepAliveInterval: 1_000_000_000n,
     keepAliveCount: 10,
     hopLimit: 1,
-
-    // For sendBufferSize and receiveBufferSize we can at least
-    // use the system defaults, but still we can't support setting them.
-    receiveBufferSize: undefined,
-    sendBufferSize: undefined,
+    receiveBufferSize: 65_536n,
+    sendBufferSize: 65_536n,
   };
 
   /**
@@ -150,6 +148,9 @@ export class TcpSocket {
 
     if (!this.#isValidLocalAddress(localAddress)) {
       throw new SocketError("invalid-argument");
+    }
+    if (!isBindableIpAddress(localAddress)) {
+      throw new SocketError("address-not-bindable");
     }
     try {
       worker().runSync({
@@ -224,10 +225,12 @@ export class TcpSocket {
     }
     try {
       // Convert incoming connections from worker to TcpSocket instances
+      const listener = this;
       const transform = new TransformStream({
         transform({ family, socketId }, controller) {
           const socket = TcpSocket._create(token(), family, socketId);
           socket.#state = STATE.CONNECTED;
+          socket.#options = { ...listener.#options };
           controller.enqueue(socket);
         },
       });
@@ -422,7 +425,11 @@ export class TcpSocket {
       throw new SocketError("invalid-argument");
     }
 
-    if (this.#state === STATE.CONNECTING || this.#state === STATE.CONNECTED) {
+    if (
+      this.#state === STATE.CONNECTING ||
+      this.#state === STATE.CONNECTED ||
+      this.#state === STATE.LISTENING
+    ) {
       throw new SocketError("not-supported");
     }
 
@@ -518,6 +525,7 @@ export class TcpSocket {
     }
 
     if (value === this.#options.keepAliveIdleTime || !this.#options.keepAliveEnabled) {
+      this.#options.keepAliveIdleTime = value;
       return;
     }
 
@@ -744,7 +752,7 @@ export class TcpSocket {
   #isValidLocalAddress(localAddress) {
     return (
       this.#family === localAddress.tag &&
-      isUnicastIpAddress(localAddress) &&
+      (isUnicastIpAddress(localAddress) || isWildcardIpAddress(localAddress)) &&
       !isIpv4MappedAddress(localAddress)
     );
   }

--- a/packages/preview3-shim/lib/nodejs/sockets/udp.js
+++ b/packages/preview3-shim/lib/nodejs/sockets/udp.js
@@ -1,6 +1,12 @@
 import { ResourceWorker } from "../workers/resource-worker.js";
 import { SocketError } from "./error.js";
-import { isWildcardIpAddress, isUnicastIpAddress, IP_ADDRESS_FAMILY } from "./address.js";
+import {
+  isWildcardIpAddress,
+  isUnicastIpAddress,
+  isIpv4MappedAddress,
+  isBindableIpAddress,
+  IP_ADDRESS_FAMILY,
+} from "./address.js";
 
 let WORKER = null;
 function worker() {
@@ -55,8 +61,8 @@ export class UdpSocket {
   #remote = null;
   #options = {
     hopLimit: 1,
-    receiveBufferSize: undefined,
-    sendBufferSize: undefined,
+    receiveBufferSize: 65_536n,
+    sendBufferSize: 65_536n,
   };
 
   /**
@@ -123,8 +129,15 @@ export class UdpSocket {
     if (this.#state !== STATE.UNBOUND) {
       throw new SocketError("invalid-state");
     }
-    if (localAddress.tag !== this.#family) {
+    if (
+      localAddress.tag !== this.#family ||
+      (!isUnicastIpAddress(localAddress) && !isWildcardIpAddress(localAddress)) ||
+      isIpv4MappedAddress(localAddress)
+    ) {
       throw new SocketError("invalid-argument");
+    }
+    if (!isBindableIpAddress(localAddress)) {
+      throw new SocketError("address-not-bindable");
     }
 
     try {
@@ -153,14 +166,12 @@ export class UdpSocket {
    * @throws {SocketError} for other errors, payload.tag maps the system error
    */
   connect(remoteAddress) {
-    if (this.#state === STATE.CONNECTED) {
-      throw new SocketError("invalid-state");
-    }
     if (
       remoteAddress.tag !== this.#family ||
       remoteAddress.val.port === 0 ||
       isWildcardIpAddress(remoteAddress) ||
-      !isUnicastIpAddress(remoteAddress)
+      !isUnicastIpAddress(remoteAddress) ||
+      isIpv4MappedAddress(remoteAddress)
     ) {
       throw new SocketError("invalid-argument");
     }
@@ -221,7 +232,7 @@ export class UdpSocket {
    * @throws {SocketError} for other errors, payload.tag maps the system error
    */
   async send(data, remoteAddress = null) {
-    if (this.#state === STATE.UNBOUND || this.#state === STATE.CLOSED) {
+    if (this.#state === STATE.CLOSED) {
       throw new SocketError("invalid-state");
     }
 
@@ -230,7 +241,14 @@ export class UdpSocket {
     }
 
     const addr = remoteAddress ?? this.#remote;
-    if (!addr || addr.val.port === 0 || addr.tag !== this.#family) {
+    if (
+      !addr ||
+      addr.val.port === 0 ||
+      addr.tag !== this.#family ||
+      isWildcardIpAddress(addr) ||
+      isIpv4MappedAddress(addr) ||
+      !isUnicastIpAddress(addr)
+    ) {
       throw new SocketError("invalid-argument");
     }
 
@@ -244,6 +262,7 @@ export class UdpSocket {
       throw new SocketError("invalid-argument");
     }
 
+    const wasUnbound = this.#state === STATE.UNBOUND;
     try {
       await worker().run(
         {
@@ -254,6 +273,9 @@ export class UdpSocket {
         },
         [data.buffer],
       );
+      if (wasUnbound) {
+        this.#state = STATE.BOUND;
+      }
     } catch (e) {
       throw SocketError.from(e);
     }
@@ -280,7 +302,7 @@ export class UdpSocket {
         op: "udp-receive",
         socketId: this.#socketId,
       });
-      return { data: new Uint8Array(data), addr: remoteAddress };
+      return [new Uint8Array(data), remoteAddress];
     } catch (e) {
       throw SocketError.from(e);
     }
@@ -372,6 +394,10 @@ export class UdpSocket {
     }
 
     this.#options.hopLimit = value;
+    if (this.#state === STATE.UNBOUND) {
+      return;
+    }
+
     try {
       worker().runSync({
         op: "udp-set-unicast-hop-limit",

--- a/packages/preview3-shim/lib/nodejs/workers/tcp-worker.js
+++ b/packages/preview3-shim/lib/nodejs/workers/tcp-worker.js
@@ -4,7 +4,7 @@ import { pipeline } from "stream/promises";
 import { once } from "node:events";
 
 import { Router } from "../workers/resource-worker.js";
-import { serializeIpAddress, makeIpAddress } from "../sockets/address.js";
+import { serializeIpAddress, makeIpAddress, ipAddressConflict } from "../sockets/address.js";
 import { SocketError } from "../sockets/error.js";
 
 import process from "node:process";
@@ -12,9 +12,8 @@ const { TCP, constants: TCPConstants } = process.binding("tcp_wrap");
 
 // Socket instances stored by ID
 const sockets = new Map();
-// Unique IDs for sockets and servers
+// Unique IDs for sockets
 let NEXT_SOCKET_ID = 0n;
-let NEXT_SERVER_ID = 0n;
 
 // Handle worker messages
 Router()
@@ -48,6 +47,7 @@ function handleTcpCreate({ family }) {
     tcp: null,
     server: null,
     backlog: 128,
+    localAddress: null,
   });
 
   return { socketId };
@@ -60,6 +60,17 @@ async function handleTcpBind({ socketId, localAddress }) {
   const port = localAddress.val.port;
 
   const { handle, family } = socket;
+
+  const hasConflict = [...sockets].some(
+    ([id, { localAddress: boundAddress }]) =>
+      id !== socketId && boundAddress && ipAddressConflict(boundAddress, localAddress),
+  );
+
+  if (hasConflict) {
+    const err = new Error("EADDRINUSE");
+    err.code = "EADDRINUSE";
+    throw err;
+  }
 
   await new Promise((resolve, reject) => {
     let code;
@@ -75,6 +86,13 @@ async function handleTcpBind({ socketId, localAddress }) {
       resolve();
     }
   });
+
+  const out = {};
+  const code = handle.getsockname(out);
+  if (code !== 0) {
+    throw SocketError.from(-code);
+  }
+  socket.localAddress = makeIpAddress(out.family.toLowerCase(), out.address, out.port);
 }
 
 // Connect a socket to remote address
@@ -119,9 +137,21 @@ async function handleTcpListen({ socketId, stream }) {
 
   await Promise.race([onListening, onError]);
 
+  const addr = server.address();
+  if (addr && typeof addr === "object") {
+    socket.localAddress = makeIpAddress(family, addr.address, addr.port);
+  }
+
   server.on("connection", (conn) => {
-    const id = NEXT_SERVER_ID++;
-    sockets.set(id, { handle: conn._handle, family, backlog, tcp: conn });
+    const id = NEXT_SOCKET_ID++;
+    sockets.set(id, {
+      handle: conn._handle,
+      family,
+      backlog,
+      tcp: conn,
+      server: null,
+      localAddress: makeIpAddress(family, conn.localAddress, conn.localPort),
+    });
     writer.write({ family, socketId: id });
   });
 

--- a/packages/preview3-shim/lib/nodejs/workers/udp-worker.js
+++ b/packages/preview3-shim/lib/nodejs/workers/udp-worker.js
@@ -101,15 +101,15 @@ async function handleConnect({ socketId, remoteAddress }) {
     isLoopbackIpAddress(socket.connected) &&
     isLoopbackIpAddress(remoteAddress);
 
-  if (preserveLocalAddress) {
-    const localAddress = socket.localAddress;
+  if (socket.connected) {
+    const localAddress = preserveLocalAddress ? socket.localAddress : null;
     await new Promise((resolve) => socket.udp.close(resolve));
     socket.udp = createSocket(socket);
-    await handleBind({ socketId, localAddress });
-  } else if (socket.connected) {
-    await new Promise((resolve) => socket.udp.close(resolve));
-    socket.udp = createSocket(socket);
-    socket.localAddress = null;
+    if (localAddress) {
+      await handleBind({ socketId, localAddress });
+    } else {
+      socket.localAddress = null;
+    }
   }
 
   const addr = serializeIpAddress(remoteAddress);
@@ -134,17 +134,13 @@ async function handleSend({ socketId, data, remoteAddress }) {
   const isConnected = socket.connected != null;
 
   await new Promise((resolve, reject) => {
-    try {
-      if (isConnected) {
-        socket.udp.send(data, (err) => (err ? reject(err) : resolve()));
-      } else {
-        const addr = serializeIpAddress(remoteAddress);
-        const port = remoteAddress.val.port;
+    if (isConnected) {
+      socket.udp.send(data, (err) => (err ? reject(err) : resolve()));
+    } else {
+      const addr = serializeIpAddress(remoteAddress);
+      const port = remoteAddress.val.port;
 
-        socket.udp.send(data, port, addr, (err) => (err ? reject(err) : resolve()));
-      }
-    } catch (err) {
-      reject(err);
+      socket.udp.send(data, port, addr, (err) => (err ? reject(err) : resolve()));
     }
   });
 

--- a/packages/preview3-shim/lib/nodejs/workers/udp-worker.js
+++ b/packages/preview3-shim/lib/nodejs/workers/udp-worker.js
@@ -1,7 +1,12 @@
 import { once } from "node:events";
 
 import { Router } from "../workers/resource-worker.js";
-import { serializeIpAddress, makeIpAddress } from "../sockets/address.js";
+import {
+  serializeIpAddress,
+  makeIpAddress,
+  ipAddressConflict,
+  isLoopbackIpAddress,
+} from "../sockets/address.js";
 
 import dgram from "node:dgram";
 
@@ -33,8 +38,21 @@ Router()
 
 function handleCreate({ family }) {
   const socketId = NEXT_SOCKET_ID++;
-  const type = family === "ipv6" ? "udp6" : "udp4";
-  const ipv6Only = family === "ipv6";
+  const socket = {
+    family,
+    connected: null,
+    localAddress: null,
+    receiveQueue: [],
+  };
+  socket.udp = createSocket(socket);
+  sockets.set(socketId, socket);
+
+  return { socketId };
+}
+
+function createSocket(socket) {
+  const type = socket.family === "ipv6" ? "udp6" : "udp4";
+  const ipv6Only = socket.family === "ipv6";
   const udp = dgram.createSocket({
     type,
     ipv6Only,
@@ -42,14 +60,24 @@ function handleCreate({ family }) {
     lookup: noLookup,
   });
 
+  udp.on("message", (msg, rinfo) => socket.receiveQueue.push({ msg, rinfo }));
   udp.on("error", () => {});
-  sockets.set(socketId, { udp, family, connected: null });
-
-  return { socketId };
+  return udp;
 }
 
 async function handleBind({ socketId, localAddress }) {
   const socket = sockets.get(socketId);
+  const hasConflict = [...sockets].some(
+    ([id, { localAddress: boundAddress }]) =>
+      id !== socketId && boundAddress && ipAddressConflict(boundAddress, localAddress),
+  );
+
+  if (hasConflict) {
+    const err = new Error("EADDRINUSE");
+    err.code = "EADDRINUSE";
+    throw err;
+  }
+
   const addr = serializeIpAddress(localAddress);
   const port = localAddress.val.port;
 
@@ -61,14 +89,37 @@ async function handleBind({ socketId, localAddress }) {
   socket.udp.bind(port, addr);
 
   await Promise.race([onListening, onError]);
+  const boundAddr = socket.udp.address();
+  socket.localAddress = makeIpAddress(socket.family, boundAddr.address, boundAddr.port);
 }
 
-function handleConnect({ socketId, remoteAddress }) {
+async function handleConnect({ socketId, remoteAddress }) {
   const socket = sockets.get(socketId);
+  const preserveLocalAddress =
+    socket.connected &&
+    socket.localAddress &&
+    isLoopbackIpAddress(socket.connected) &&
+    isLoopbackIpAddress(remoteAddress);
+
+  if (preserveLocalAddress) {
+    const localAddress = socket.localAddress;
+    await new Promise((resolve) => socket.udp.close(resolve));
+    socket.udp = createSocket(socket);
+    await handleBind({ socketId, localAddress });
+  } else if (socket.connected) {
+    await new Promise((resolve) => socket.udp.close(resolve));
+    socket.udp = createSocket(socket);
+    socket.localAddress = null;
+  }
+
   const addr = serializeIpAddress(remoteAddress);
   const port = remoteAddress.val.port;
 
-  socket.udp.connect(port, addr);
+  await new Promise((resolve, reject) => {
+    socket.udp.connect(port, addr, (err) => (err ? reject(err) : resolve()));
+  });
+  const boundAddr = socket.udp.address();
+  socket.localAddress = makeIpAddress(socket.family, boundAddr.address, boundAddr.port);
   socket.connected = remoteAddress;
 }
 
@@ -83,34 +134,40 @@ async function handleSend({ socketId, data, remoteAddress }) {
   const isConnected = socket.connected != null;
 
   await new Promise((resolve, reject) => {
-    if (isConnected) {
-      socket.udp.send(data, (err) => (err ? reject(err) : resolve()));
-    } else {
-      const addr = serializeIpAddress(remoteAddress);
-      const port = remoteAddress.val.port;
+    try {
+      if (isConnected) {
+        socket.udp.send(data, (err) => (err ? reject(err) : resolve()));
+      } else {
+        const addr = serializeIpAddress(remoteAddress);
+        const port = remoteAddress.val.port;
 
-      socket.udp.send(data, port, addr, (err) => (err ? reject(err) : resolve()));
+        socket.udp.send(data, port, addr, (err) => (err ? reject(err) : resolve()));
+      }
+    } catch (err) {
+      reject(err);
     }
   });
+
+  const boundAddr = socket.udp.address();
+  socket.localAddress = makeIpAddress(socket.family, boundAddr.address, boundAddr.port);
 }
 
 async function handleReceive({ socketId }) {
   const socket = sockets.get(socketId);
-
-  const [event, payload] = await Promise.race([
-    once(socket.udp, "message").then(([msg, rinfo]) => ["message", { msg, rinfo }]),
-    once(socket.udp, "error").then(([err]) => {
-      throw err;
-    }),
-  ]);
-
-  if (event === "message") {
-    const { msg, rinfo } = payload;
-    return {
-      data: msg,
-      remoteAddress: makeIpAddress(socket.family, rinfo.address, rinfo.port),
-    };
+  if (socket.receiveQueue.length === 0) {
+    await Promise.race([
+      once(socket.udp, "message"),
+      once(socket.udp, "error").then(([err]) => {
+        throw err;
+      }),
+    ]);
   }
+
+  const { msg, rinfo } = socket.receiveQueue.shift();
+  return {
+    data: msg,
+    remoteAddress: makeIpAddress(socket.family, rinfo.address, rinfo.port),
+  };
 }
 
 function handleGetLocal({ socketId }) {

--- a/packages/preview3-shim/test/tcp.test.js
+++ b/packages/preview3-shim/test/tcp.test.js
@@ -128,7 +128,7 @@ describe("TCP Socket Listen", () => {
     client.listen();
 
     expect(() => client.setListenBacklogSize(1000n)).toThrow(
-      expect.objectContaining({ payload: { tag: "invalid-state" } }),
+      expect.objectContaining({ payload: { tag: "not-supported" } }),
     );
   });
 

--- a/packages/preview3-shim/test/udp.test.js
+++ b/packages/preview3-shim/test/udp.test.js
@@ -66,10 +66,10 @@ describe("UDP Socket Bind", () => {
     );
   });
 
-  test("throws on send before bind", async () => {
+  test("throws on send without a remote address", async () => {
     const sock = await createIpv4Socket();
     await expect(sock.send(new Uint8Array([1, 2, 3]))).rejects.toSatisfy(
-      (err) => err.payload.tag === "invalid-state",
+      (err) => err.payload.tag === "invalid-argument",
     );
   });
 });
@@ -103,11 +103,25 @@ describe("UDP Send/Receive without connect", () => {
     const msg = new TextEncoder().encode("hello");
     await sock.send(msg, makeIpAddress("ipv4", "127.0.0.1", port));
 
-    const { data, addr } = await recvPromise;
+    const [data, addr] = await recvPromise;
 
     expect(data).toStrictEqual(new Uint8Array(Buffer.from("pong")));
     expect(addr.tag).toBe(IP_ADDRESS_FAMILY.IPV4);
     expect(addr.val.port).toBe(port);
+
+    sock[Symbol.dispose]();
+  });
+
+  test("send with explicit address binds an unbound socket", async () => {
+    const sock = createIpv4Socket();
+
+    await expect(
+      sock.send(new TextEncoder().encode("hello"), makeIpAddress("ipv4", "127.0.0.1", port)),
+    ).resolves.toBeUndefined();
+
+    const local = sock.getLocalAddress();
+    expect(local.tag).toBe(IP_ADDRESS_FAMILY.IPV4);
+    expect(local.val.port).toBeGreaterThan(0);
 
     sock[Symbol.dispose]();
   });
@@ -121,12 +135,36 @@ describe("UDP Send/Receive without connect", () => {
     const msg = new TextEncoder().encode("ping");
     await sock.send(msg);
 
-    const { data, addr } = await recvPromise;
+    const [data, addr] = await recvPromise;
     expect(data).toStrictEqual(new Uint8Array(Buffer.from("pong")));
     expect(addr.tag).toBe(IP_ADDRESS_FAMILY.IPV4);
     expect(addr.val.port).toBe(port);
 
     sock[Symbol.dispose]();
+  });
+
+  test("returns queued datagrams", async () => {
+    const server = createIpv4Socket();
+    server.bind(makeIpAddress("ipv4", "127.0.0.1", 0));
+    const serverAddress = server.getLocalAddress();
+    const client = createIpv4Socket();
+    client.bind(makeIpAddress("ipv4", "0.0.0.0", 0));
+    client.connect(serverAddress);
+    const clientAddress = client.getLocalAddress();
+
+    await client.send(new Uint8Array(0));
+    await client.send(new TextEncoder().encode("Hello, world!"), serverAddress);
+
+    const first = await server.receive();
+    expect(first[0]).toStrictEqual(new Uint8Array(0));
+    expect(first[1]).toStrictEqual(clientAddress);
+
+    const second = await server.receive();
+    expect(second[0]).toStrictEqual(new TextEncoder().encode("Hello, world!"));
+    expect(second[1]).toStrictEqual(clientAddress);
+
+    server[Symbol.dispose]();
+    client[Symbol.dispose]();
   });
 
   test("disconnect allows send with explicit address", async () => {


### PR DESCRIPTION
The fixes are driven by wasi upstream tests: allow wildcard binds, reject non-bindable addresses, and detect local bind conflicts for tcp and udp sockets.