### PR TITLE
fix(p3): use async lower result pointer from params trail

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -2073,6 +2073,7 @@ impl AsyncTaskIntrinsic {
                             isManualAsync,
                             paramLiftFns,
                             resultLowerFns,
+                            hasResultPointer,
                             funcTypeIsAsync,
                             metadata,
                             memoryIdx,
@@ -2105,6 +2106,10 @@ impl AsyncTaskIntrinsic {
 
                         // If there is an existing task, this should be part of a subtask
                         const memory = getMemoryFn();
+                        // Canonical ABI lower appends result storage as a trailing
+                        // param when async lower has any flat result, or sync lower
+                        // has more than one flat result.
+                        const resultPtr = hasResultPointer ? params[params.length - 1] : undefined;
                         const subtask = task.createSubtask({{
                            componentIdx,
                            parentTask: task,
@@ -2116,7 +2121,7 @@ impl AsyncTaskIntrinsic {
                                memory,
                                realloc: getReallocFn?.(),
                                getReallocFn,
-                               resultPtr: params[0],
+                               resultPtr,
                                lowers: resultLowerFns,
                                stringEncoding,
                            }}
@@ -2271,6 +2276,7 @@ impl AsyncTaskIntrinsic {
                             isManualAsync,
                             paramLiftFns,
                             resultLowerFns,
+                            hasResultPointer,
                             funcTypeIsAsync,
                             metadata,
                             memoryIdx,
@@ -2345,6 +2351,10 @@ impl AsyncTaskIntrinsic {
 
                         // If there is an existing task, this should be part of a subtask
                         const memory = getMemoryFn();
+                        // Canonical ABI lower appends result storage as a trailing
+                        // param when async lower has any flat result, or sync lower
+                        // has more than one flat result.
+                        const resultPtr = hasResultPointer ? params[params.length - 1] : undefined;
                         const subtask = task.createSubtask({{
                            componentIdx,
                            parentTask: task,
@@ -2356,7 +2366,7 @@ impl AsyncTaskIntrinsic {
                                memory,
                                realloc: getReallocFn?.(),
                                getReallocFn,
-                               resultPtr: params[0],
+                               resultPtr,
                                lowers: resultLowerFns,
                                stringEncoding,
                            }}

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -58,6 +58,8 @@ use crate::{
 /// Size of flat parameters that can be sent, for example via the `task.return`
 /// intrinsic, when returning from an async func
 const MAX_FLAT_PARAMS: usize = 16;
+/// Maximum direct flat results for sync canonical lowering.
+const MAX_FLAT_RESULTS: usize = 1;
 
 #[derive(Debug, Default, Clone)]
 pub struct TranspileOpts {
@@ -2174,6 +2176,12 @@ impl<'a> Instantiator<'a, '_> {
                 let result_types = &self.types.index(func_ty.results).types;
                 let result_lower_fns_js =
                     gen_flat_lower_fn_list_js_expr(self, result_types.iter().as_slice(), &None);
+                let result_flat_count = result_types.iter().try_fold(0usize, |count, ty| {
+                    self.types
+                        .canonical_abi(ty)
+                        .flat_count
+                        .map(|flat_count| count + usize::from(flat_count))
+                });
 
                 let get_callback_fn_js = canon_opts
                     .callback
@@ -2210,6 +2218,14 @@ impl<'a> Instantiator<'a, '_> {
 
                 // Build the lower import call that will wrap the actual trampoline
                 let func_ty_async = func_ty.async_;
+                let max_direct_results = if is_async || func_ty_async {
+                    0
+                } else {
+                    MAX_FLAT_RESULTS
+                };
+                let has_result_pointer = result_flat_count
+                    .map(|count| count > max_direct_results)
+                    .unwrap_or(true);
                 let call = format!(
                     r#"{lower_import_intrinsic}.bind(
                         null,
@@ -2220,6 +2236,7 @@ impl<'a> Instantiator<'a, '_> {
                             isManualAsync: _trampoline{i}.manuallyAsync,
                             paramLiftFns: {param_lift_fns_js},
                             resultLowerFns: {result_lower_fns_js},
+                            hasResultPointer: {has_result_pointer},
                             funcTypeIsAsync: {func_ty_async},
                             getCallbackFn: {get_callback_fn_js},
                             getPostReturnFn: {get_post_return_fn_js},

--- a/crates/test-components/src/bin/async_lower_result_pointer.rs
+++ b/crates/test-components/src/bin/async_lower_result_pointer.rs
@@ -1,0 +1,25 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "async-lower-result-pointer",
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::local_run_async;
+use bindings::jco::test_components::async_lower_result_pointer_host;
+use bindings::jco::test_components::sync_lower_result_pointer_host;
+
+struct Component;
+
+impl local_run_async::Guest for Component {
+    async fn run() {
+        let sync_result = sync_lower_result_pointer_host::add_pair(1, 2, 3, 4, 5);
+        assert_eq!(sync_result, (15, 120));
+
+        let result = async_lower_result_pointer_host::add_five(1, 2, 3, 4, 5).await;
+        assert_eq!(result, Ok(15));
+    }
+}
+
+fn main() {}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -16,6 +16,14 @@ interface async-add-s32 {
     add: async func(a: s32, b: s32) -> result<s32, string>;
 }
 
+interface async-lower-result-pointer-host {
+    add-five: async func(a: u32, b: u32, c: u32, d: u32, e: u32) -> result<u32, string>;
+}
+
+interface sync-lower-result-pointer-host {
+    add-pair: func(a: u32, b: u32, c: u32, d: u32, e: u32) -> tuple<u32, u32>;
+}
+
 interface resources {
     resource example-resource {
         constructor(id: u32);
@@ -233,6 +241,12 @@ world async-error-context {
 
 world async-flat-param-adder {
   export async-add-s32;
+}
+
+world async-lower-result-pointer {
+  import async-lower-result-pointer-host;
+  import sync-lower-result-pointer-host;
+  export local-run-async;
 }
 
 world async-simple-return {

--- a/packages/jco/test/p3/async.js
+++ b/packages/jco/test/p3/async.js
@@ -36,6 +36,37 @@ suite("Async (WASI P3)", () => {
         await cleanup();
     });
 
+    test("lowered imports use trailing result pointer", async () => {
+        const { instance, cleanup } = await setupAsyncTest({
+            asyncMode: "jspi",
+            component: {
+                path: join(LOCAL_TEST_COMPONENTS_DIR, "async-lower-result-pointer.wasm"),
+                imports: {
+                    ...new WASIShim().getImportObject(),
+                    "jco:test-components/async-lower-result-pointer-host": {
+                        addFive: async (a, b, c, d, e) => a + b + c + d + e,
+                    },
+                    "jco:test-components/sync-lower-result-pointer-host": {
+                        addPair: (a, b, c, d, e) => [a + b + c + d + e, a * b * c * d * e],
+                    },
+                },
+            },
+            jco: {
+                transpile: {
+                    extraArgs: {
+                        minify: false,
+                    },
+                },
+            },
+        });
+
+        try {
+            await instance["jco:test-components/local-run-async"].run();
+        } finally {
+            await cleanup();
+        }
+    });
+
     // https://bytecodealliance.zulipchat.com/#narrow/channel/206238-general/topic/Should.20StringLift.20be.20emitted.20for.20async.20return.20values.3F/with/561133720
     test("simple async returns", async () => {
         const { instance, cleanup } = await setupAsyncTest({


### PR DESCRIPTION
Async canonical lower appends a result pointer to flat params when flat_results is non-empty. The async task metadata was treating the first raw param as the result pointer, which corrupts params for async imports that have both params and results.

The relevant spec snippet can be found here: 
https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#flattening