### PR TITLE
fix(bindgen)!: make canon opts optional for func bindgen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -87,6 +87,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,6 +408,40 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -750,6 +809,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +905,7 @@ version = "1.19.0-rc.2"
 dependencies = [
  "anyhow",
  "base64",
+ "bon",
  "heck 0.5.0",
  "log",
  "semver",
@@ -1130,6 +1196,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
 name = "semver"
 version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,6 +1316,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "structopt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ strip = true
 
 [workspace.dependencies]
 anyhow = { version = "1.0.102", default-features = false }
+bon = { version = "3.9.1", default-features = false }
 base64 = { version = "0.22.1", default-features = false }
 cargo_metadata = { version = "0.23.1", default-features = false }
 heck = { version = "0.5.0", default-features = false }

--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -57,7 +57,7 @@ impl bindings::Guest for JsComponentBindgenComponent {
             no_typescript: options.no_typescript.unwrap_or(false),
             instantiation: options.instantiation.map(Into::into),
             map: options.map.map(|map| map.into_iter().collect()),
-            no_nodejs_compat: options.no_nodejs_compat.unwrap_or(false),
+            nodejs_compat_disabled: options.no_nodejs_compat.unwrap_or(false),
             base64_cutoff: options.base64_cutoff.unwrap_or(5000) as usize,
             tla_compat: options
                 .tla_compat
@@ -153,7 +153,7 @@ impl bindings::Guest for JsComponentBindgenComponent {
         let opts = js_component_bindgen::TranspileOpts {
             name: "component".to_string(),
             no_typescript: false,
-            no_nodejs_compat: false,
+            nodejs_compat_disabled: false,
             instantiation: opts.instantiation.map(Into::into),
             map: opts.map.map(|map| map.into_iter().collect()),
             tla_compat: opts.tla_compat.unwrap_or(false),

--- a/crates/js-component-bindgen/Cargo.toml
+++ b/crates/js-component-bindgen/Cargo.toml
@@ -27,6 +27,7 @@ all-features = true
 [dependencies]
 anyhow = { workspace = true }
 base64 = { workspace = true, features = [ "alloc" ] }
+bon = { workspace = true, features = [ "std", "alloc" ] }
 heck = { workspace = true }
 log = { workspace = true }
 semver = { workspace = true }

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -133,6 +133,8 @@ pub struct ResourceTable {
 /// A mapping of type IDs to the resources that they represent
 pub type ResourceMap = BTreeMap<TypeId, ResourceTable>;
 
+#[derive(bon::Builder)]
+#[non_exhaustive]
 pub struct FunctionBindgen<'a> {
     /// Mapping of resources for types that have corresponding definitions locally
     pub resource_map: &'a ResourceMap,
@@ -204,7 +206,10 @@ pub struct FunctionBindgen<'a> {
     pub is_async: bool,
 
     /// Canon opts
-    pub canon_opts: &'a CanonicalOptions,
+    ///
+    /// Note: this is an Option for downstream users that may not process the component completely,
+    /// and do not have access to `CanonicalOptions` for the given function (e.g. in the case of a dummy module)
+    pub canon_opts: Option<&'a CanonicalOptions>,
 
     /// Interface name
     pub iface_name: Option<&'a str>,
@@ -387,6 +392,7 @@ impl FunctionBindgen<'_> {
         let err_handling = self.err.to_js_string();
         let callback_fn_js = self
             .canon_opts
+            .expect("canon opts should be provided")
             .callback
             .as_ref()
             .map(|v| format!("callback_{}", v.as_u32()))
@@ -401,7 +407,11 @@ impl FunctionBindgen<'_> {
         let start_current_task_fn = self.intrinsic(Intrinsic::AsyncTask(
             AsyncTaskIntrinsic::CreateNewCurrentTask,
         ));
-        let component_instance_idx = self.canon_opts.instance.as_u32();
+        let component_instance_idx = self
+            .canon_opts
+            .expect("canon opts should be provided")
+            .instance
+            .as_u32();
 
         uwriteln!(
             self.src,
@@ -1483,7 +1493,7 @@ impl Bindgen for FunctionBindgen<'_> {
 
                 // Save the memory for this task,
                 // which will be used for any subtasks that might be spawned
-                if let Some(mem_idx) = self.canon_opts.memory() {
+                if let Some(mem_idx) = self.canon_opts.expect("missing canon opts").memory() {
                     let idx = mem_idx.as_u32();
                     uwriteln!(self.src, "task.setReturnMemoryIdx({idx});");
                     uwriteln!(self.src, "task.setReturnMemory(memory{idx});");
@@ -1601,7 +1611,11 @@ impl Bindgen for FunctionBindgen<'_> {
                 ));
                 let current_task_get_fn =
                     self.intrinsic(Intrinsic::AsyncTask(AsyncTaskIntrinsic::GetCurrentTask));
-                let component_instance_idx = self.canon_opts.instance.as_u32();
+                let component_instance_idx = self
+                    .canon_opts
+                    .expect("canon opts should be provided")
+                    .instance
+                    .as_u32();
 
                 // At first, use the global current task metadata, in case we are executing from
                 // inside a with-global-current-task wrapper
@@ -1688,6 +1702,7 @@ impl Bindgen for FunctionBindgen<'_> {
                     err_handling = self.err.to_js_string(),
                     callback_fn_js = self
                         .canon_opts
+                        .expect("canon opts should be provided")
                         .callback
                         .as_ref()
                         .map(|v| format!("callback_{}", v.as_u32()))
@@ -1885,6 +1900,11 @@ impl Bindgen for FunctionBindgen<'_> {
                 let get_or_create_async_state_fn = self.intrinsic(Intrinsic::Component(
                     ComponentIntrinsic::GetOrCreateAsyncState,
                 ));
+                let component_idx = self
+                    .canon_opts
+                    .expect("canon opts should be provided")
+                    .instance
+                    .as_u32();
                 let gen_post_return_js =
                     |(post_return_call, ret_stmt): (String, Option<String>)| {
                         format!(
@@ -1896,7 +1916,6 @@ impl Bindgen for FunctionBindgen<'_> {
                         task.exit();
                         {ret_stmt}
                             "#,
-                            component_idx = self.canon_opts.instance.as_u32(),
                             ret_stmt = ret_stmt.unwrap_or_default(),
                         )
                     };
@@ -2702,7 +2721,11 @@ impl Bindgen for FunctionBindgen<'_> {
                     AsyncFutureIntrinsic::NestedFutureSymbol,
                 ));
 
-                let component_idx = self.canon_opts.instance.as_u32();
+                let component_idx = self
+                    .canon_opts
+                    .expect("canon opts should be provided")
+                    .instance
+                    .as_u32();
 
                 let future_arg = operands
                     .first()
@@ -2803,7 +2826,11 @@ impl Bindgen for FunctionBindgen<'_> {
                 //
                 // The realloc fn is saved on the element metadata which is passed through to
                 // stream end and underlying buffer
-                let get_realloc_fn_js = match self.canon_opts.data_model {
+                let get_realloc_fn_js = match self
+                    .canon_opts
+                    .expect("canon opts should be provided")
+                    .data_model
+                {
                     CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions {
                         realloc: Some(realloc_idx),
                         ..
@@ -2983,7 +3010,11 @@ impl Bindgen for FunctionBindgen<'_> {
                         };
 
                     let future_table_idx = future_table_idx_ty.as_u32();
-                    let component_idx = self.canon_opts.instance.as_u32();
+                    let component_idx = self
+                        .canon_opts
+                        .expect("canon opts should be provided")
+                        .instance
+                        .as_u32();
 
                     uwriteln!(
                         self.src,
@@ -3043,7 +3074,11 @@ impl Bindgen for FunctionBindgen<'_> {
                     unreachable!("invalid resource table observed during stream lower");
                 };
 
-                let component_idx = self.canon_opts.instance.as_u32();
+                let component_idx = self
+                    .canon_opts
+                    .expect("canon opts should be provided")
+                    .instance
+                    .as_u32();
                 let stream_table_idx = stream_table_idx_ty.as_u32();
 
                 let (
@@ -3117,7 +3152,11 @@ impl Bindgen for FunctionBindgen<'_> {
                 //
                 // The realloc fn is saved on the element metadata which is passed through to
                 // stream end and underlying buffer
-                let get_realloc_fn_js = match self.canon_opts.data_model {
+                let get_realloc_fn_js = match self
+                    .canon_opts
+                    .expect("canon opts should be provided")
+                    .data_model
+                {
                     CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions {
                         realloc: Some(realloc_idx),
                         ..
@@ -3188,7 +3227,11 @@ impl Bindgen for FunctionBindgen<'_> {
             }
 
             Instruction::StreamLift { payload, ty } => {
-                let component_idx = self.canon_opts.instance.as_u32();
+                let component_idx = self
+                    .canon_opts
+                    .expect("canon opts should be provided")
+                    .instance
+                    .as_u32();
                 let stream_new_from_lift_fn = self.intrinsic(Intrinsic::AsyncStream(
                     AsyncStreamIntrinsic::StreamNewFromLift,
                 ));
@@ -3299,7 +3342,11 @@ impl Bindgen for FunctionBindgen<'_> {
             //
             Instruction::AsyncTaskReturn { name, params } => {
                 let debug_log_fn = self.intrinsic(Intrinsic::DebugLog);
-                let component_instance_idx = self.canon_opts.instance.as_u32();
+                let component_instance_idx = self
+                    .canon_opts
+                    .expect("canon opts should be provided")
+                    .instance
+                    .as_u32();
                 let is_async_js = self.requires_async_porcelain | self.is_async;
                 let async_driver_loop_fn =
                     self.intrinsic(Intrinsic::AsyncTask(AsyncTaskIntrinsic::DriverLoop));

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -3,8 +3,6 @@
 use std::collections::{BTreeSet, HashSet};
 use std::fmt::Write;
 
-use anyhow::{Context as _, Result};
-
 use crate::source::Source;
 use crate::{TranspileOpts, uwrite, uwriteln};
 
@@ -186,7 +184,7 @@ impl Intrinsic {
                     output,
                     "const {var_name} = '{determinism}';",
                     var_name = self.name(),
-                    determinism = args.determinism,
+                    determinism = args.determinism_profile,
                 );
             }
 
@@ -248,7 +246,7 @@ impl Intrinsic {
             }
 
             Intrinsic::Base64Compile => {
-                if !args.nodejs_compat_disabled {
+                if !args.transpile_opts.nodejs_compat_disabled {
                     uwriteln!(
                         output,
                         r#"
@@ -309,7 +307,7 @@ impl Intrinsic {
             ),
 
             Intrinsic::FetchCompile => {
-                if !args.nodejs_compat_disabled {
+                if !args.transpile_opts.nodejs_compat_disabled {
                     output.push_str("
                     const isNode = typeof process !== 'undefined' && process.versions && process.versions.node;
                     let _fs;
@@ -373,7 +371,7 @@ impl Intrinsic {
             ),
 
             Intrinsic::InstantiateCore => {
-                if !args.instantiation {
+                if !args.instantiation_occurred {
                     output.push_str(
                         "
                     const instantiateCore = WebAssembly.instantiate;
@@ -1069,80 +1067,19 @@ impl std::fmt::Display for AsyncDeterminismProfile {
 }
 
 /// Arguments to `render_intrinsics`
+#[derive(bon::Builder)]
 #[non_exhaustive]
 pub struct RenderIntrinsicsArgs<'a> {
     /// List of intrinsics being built for use
     pub(crate) intrinsics: &'a mut BTreeSet<Intrinsic>,
-    /// Whether to use NodeJS compat
-    pub(crate) nodejs_compat_disabled: bool,
     /// Whether instantiation has occurred
-    pub(crate) instantiation: bool,
+    #[builder(default)]
+    pub(crate) instantiation_occurred: bool,
     /// The kind of determinism to use
-    pub(crate) determinism: AsyncDeterminismProfile,
+    #[builder(default)]
+    pub(crate) determinism_profile: AsyncDeterminismProfile,
     /// Options provided when performing transpilation
     pub(crate) transpile_opts: &'a TranspileOpts,
-}
-
-impl<'a> RenderIntrinsicsArgs<'a> {
-    /// Create a builder for rendering intrinsics with `render_intrinsics`
-    pub fn builder() -> RenderIntrinsicsArgsBuilder<'a> {
-        RenderIntrinsicsArgsBuilder::default()
-    }
-}
-
-/// Builder for constructing `RenderIntrinsicsArgs`.
-#[derive(Default)]
-pub struct RenderIntrinsicsArgsBuilder<'a> {
-    nodejs_compat_disabled: Option<bool>,
-    instantiation: Option<bool>,
-    determinism: Option<AsyncDeterminismProfile>,
-    transpile_opts: Option<&'a TranspileOpts>,
-    intrinsics: Option<&'a mut BTreeSet<Intrinsic>>,
-}
-
-impl<'a> RenderIntrinsicsArgsBuilder<'a> {
-    /// Sets whether to use NodeJS compatibility mode.
-    pub fn nodejs_compat_disabled(mut self, disabled: bool) -> Self {
-        self.nodejs_compat_disabled = Some(disabled);
-        self
-    }
-
-    /// Sets whether instantiation has occurred.
-    pub fn instantiation_occurred(mut self, occurred: bool) -> Self {
-        self.instantiation = Some(occurred);
-        self
-    }
-
-    /// Sets the required determinism profile.
-    pub fn determinism_profile(mut self, determinism: AsyncDeterminismProfile) -> Self {
-        self.determinism = Some(determinism);
-        self
-    }
-
-    /// Sets the required determinism profile.
-    pub fn intrinsics(mut self, intrinsics: &'a mut BTreeSet<Intrinsic>) -> Self {
-        self.intrinsics = Some(intrinsics);
-        self
-    }
-
-    /// Sets transpilation options
-    pub fn transpile_options(mut self, opts: &'a TranspileOpts) -> Self {
-        self.transpile_opts = Some(opts);
-        self
-    }
-
-    /// Build the final `RenderIntrinsicsArgs` object
-    pub fn build(self) -> Result<RenderIntrinsicsArgs<'a>> {
-        Ok(RenderIntrinsicsArgs {
-            intrinsics: self.intrinsics.context("missing intrinsic set")?,
-            nodejs_compat_disabled: self.nodejs_compat_disabled.unwrap_or_default(),
-            instantiation: self.instantiation.unwrap_or_default(),
-            determinism: self.determinism.unwrap_or_default(),
-            transpile_opts: self
-                .transpile_opts
-                .context("transpile options must be provided")?,
-        })
-    }
 }
 
 /// Intrinsics that should be rendered as early as possible

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -75,7 +75,7 @@ pub struct TranspileOpts {
     /// component import specifiers to JS import specifiers.
     pub map: Option<HashMap<String, String>>,
     /// Disables compatibility in Node.js without a fetch global.
-    pub no_nodejs_compat: bool,
+    pub nodejs_compat_disabled: bool,
     /// Set the cutoff byte size for base64 inlining core Wasm in instantiation mode
     /// (set to 0 to disable all base64 inlining)
     pub base64_cutoff: usize,
@@ -420,12 +420,10 @@ impl JsBindgen<'_> {
 
         let render_args = RenderIntrinsicsArgs::builder()
             .intrinsics(&mut self.all_intrinsics)
-            .nodejs_compat_disabled(self.opts.no_nodejs_compat)
             .instantiation_occurred(self.opts.instantiation.is_some())
             .determinism_profile(AsyncDeterminismProfile::default())
-            .transpile_options(opts)
-            .build()
-            .expect("failed to build args to render intrinsics");
+            .transpile_opts(opts)
+            .build();
         let js_intrinsics = render_intrinsics(render_args);
 
         if let Some(instantiation) = &self.opts.instantiation {
@@ -4018,7 +4016,7 @@ impl<'a> Instantiator<'a, '_> {
             resolve: self.resolve,
             requires_async_porcelain,
             is_async,
-            canon_opts: opts,
+            canon_opts: Some(opts),
             iface_name,
             asmjs: self.bindgen.opts.asmjs,
         };

--- a/crates/xtask/src/build/jco.rs
+++ b/crates/xtask/src/build/jco.rs
@@ -187,7 +187,7 @@ fn transpile(args: TranspileArgs) -> Result<()> {
         no_typescript: false,
         instantiation: None,
         map: Some(import_map),
-        no_nodejs_compat: false,
+        nodejs_compat_disabled: false,
         base64_cutoff: 5000_usize,
         tla_compat: true,
         valid_lifting_optimization: false,


### PR DESCRIPTION
This commit makes breaking changes to `FunctionBindgen`, making canon_opts optional in cases where the user of the generator

While this breaking change would normally cause a major version bump, since the functionality has actually been broken since 1.11.0 (!) due o missing exported configuration objects, we take this change to use a builder for `FunctionBindgen` itself and introduce non exhaustiveness for related configuration structs as well via `bon`.