### PR TITLE
fix(bindgen): use builder for TranspileOpts

### DIFF
--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -52,26 +52,28 @@ struct JsComponentBindgenComponent;
 impl bindings::Guest for JsComponentBindgenComponent {
     fn generate(component: Vec<u8>, options: GenerateOptions) -> Result<Transpiled, String> {
         let component = wat::parse_bytes(&component).map_err(|e| format!("{e}"))?;
-        let opts = js_component_bindgen::TranspileOpts {
-            name: options.name,
-            no_typescript: options.no_typescript.unwrap_or(false),
-            instantiation: options.instantiation.map(Into::into),
-            map: options.map.map(|map| map.into_iter().collect()),
-            nodejs_compat_disabled: options.no_nodejs_compat.unwrap_or(false),
-            base64_cutoff: options.base64_cutoff.unwrap_or(5000) as usize,
-            tla_compat: options
-                .tla_compat
-                .unwrap_or(options.compat.unwrap_or(false)),
-            valid_lifting_optimization: options.valid_lifting_optimization.unwrap_or(false),
-            tracing: options.tracing.unwrap_or(false),
-            no_namespaced_exports: options.no_namespaced_exports.unwrap_or(false),
-            multi_memory: options.multi_memory.unwrap_or(false),
-            import_bindings: options.import_bindings.map(Into::into),
-            guest: options.guest.unwrap_or(false),
-            async_mode: options.async_mode.map(Into::into),
-            strict: options.strict.unwrap_or(false),
-            asmjs: options.asmjs.unwrap_or(false),
-        };
+        let opts = js_component_bindgen::TranspileOpts::builder()
+            .name(options.name)
+            .no_typescript(options.no_typescript.unwrap_or(false))
+            .maybe_instantiation_mode(options.instantiation.map(Into::into))
+            .maybe_map(options.map.map(|map| map.into_iter().collect()))
+            .nodejs_compat_disabled(options.no_nodejs_compat.unwrap_or(false))
+            .base64_cutoff(options.base64_cutoff.unwrap_or(5000) as usize)
+            .tla_compat(
+                options
+                    .tla_compat
+                    .unwrap_or(options.compat.unwrap_or(false)),
+            )
+            .valid_lifting_optimization(options.valid_lifting_optimization.unwrap_or(false))
+            .tracing(options.tracing.unwrap_or(false))
+            .no_namespaced_exports(options.no_namespaced_exports.unwrap_or(false))
+            .multi_memory(options.multi_memory.unwrap_or(false))
+            .maybe_import_bindings(options.import_bindings.map(Into::into))
+            .guest(options.guest.unwrap_or(false))
+            .maybe_async_mode(options.async_mode.map(Into::into))
+            .strict(options.strict.unwrap_or(false))
+            .asmjs(options.asmjs.unwrap_or(false))
+            .build();
 
         let js_component_bindgen::Transpiled {
             files,
@@ -150,24 +152,23 @@ impl bindings::Guest for JsComponentBindgenComponent {
             .select_world(&[ids], world_string.as_deref())
             .map_err(|e| e.to_string())?;
 
-        let opts = js_component_bindgen::TranspileOpts {
-            name: "component".to_string(),
-            no_typescript: false,
-            nodejs_compat_disabled: false,
-            instantiation: opts.instantiation.map(Into::into),
-            map: opts.map.map(|map| map.into_iter().collect()),
-            tla_compat: opts.tla_compat.unwrap_or(false),
-            valid_lifting_optimization: false,
-            base64_cutoff: 0,
-            tracing: false,
-            no_namespaced_exports: false,
-            multi_memory: false,
-            import_bindings: None,
-            guest: opts.guest.unwrap_or(false),
-            async_mode: opts.async_mode.map(Into::into),
-            strict: opts.strict.unwrap_or(false),
-            asmjs: false,
-        };
+        let opts = js_component_bindgen::TranspileOpts::builder()
+            .name("component".into())
+            .no_typescript(false)
+            .nodejs_compat_disabled(false)
+            .maybe_instantiation_mode(opts.instantiation.map(Into::into))
+            .maybe_map(opts.map.map(|map| map.into_iter().collect()))
+            .tla_compat(opts.tla_compat.unwrap_or(false))
+            .valid_lifting_optimization(false)
+            .base64_cutoff(0)
+            .tracing(false)
+            .no_namespaced_exports(false)
+            .multi_memory(false)
+            .guest(opts.guest.unwrap_or(false))
+            .maybe_async_mode(opts.async_mode.map(Into::into))
+            .strict(opts.strict.unwrap_or(false))
+            .asmjs(false)
+            .build();
 
         let files = js_component_bindgen::generate_types(&name, resolve, world, opts)
             .with_context(|| format!("generating types for [{}]", &name))

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -59,15 +59,16 @@ use crate::{
 /// intrinsic, when returning from an async func
 const MAX_FLAT_PARAMS: usize = 16;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, bon::Builder)]
 pub struct TranspileOpts {
     pub name: String,
     /// Disables generation of `*.d.ts` files and instead only generates `*.js`
     /// source files.
+    #[builder(default)]
     pub no_typescript: bool,
     /// Provide a custom JS instantiation API for the component instead
     /// of the direct importable native ESM output.
-    pub instantiation: Option<InstantiationMode>,
+    pub instantiation_mode: Option<InstantiationMode>,
     /// Configure how import bindings are provided, as high-level JS bindings,
     /// or as hybrid optimized bindings.
     pub import_bindings: Option<BindingsMode>,
@@ -75,36 +76,47 @@ pub struct TranspileOpts {
     /// component import specifiers to JS import specifiers.
     pub map: Option<HashMap<String, String>>,
     /// Disables compatibility in Node.js without a fetch global.
+    #[builder(default)]
     pub nodejs_compat_disabled: bool,
     /// Set the cutoff byte size for base64 inlining core Wasm in instantiation mode
     /// (set to 0 to disable all base64 inlining)
+    #[builder(default)]
     pub base64_cutoff: usize,
     /// Enables compatibility for JS environments without top-level await support
     /// via an async $init promise export to wait for instead.
+    #[builder(default)]
     pub tla_compat: bool,
     /// Disable verification of component Wasm data structures when
     /// lifting as a production optimization
+    #[builder(default)]
     pub valid_lifting_optimization: bool,
     /// Whether or not to emit `tracing` calls on function entry/exit.
+    #[builder(default)]
     pub tracing: bool,
     /// Whether to generate namespaced exports like `foo as "local:package/foo"`.
     /// These exports can break typescript builds.
+    #[builder(default)]
     pub no_namespaced_exports: bool,
     /// Whether to output core Wasm utilizing multi-memory or to polyfill
     /// this handling.
+    #[builder(default)]
     pub multi_memory: bool,
     /// Whether to generate types for a guest module using module declarations.
+    #[builder(default)]
     pub guest: bool,
     /// Configure whether to use `async` imports or exports with
     /// JavaScript Promise Integration (JSPI).
     pub async_mode: Option<AsyncMode>,
     /// Configure whether to generate code that includes strict type checks
+    #[builder(default)]
     pub strict: bool,
     /// Whether the core module(s) to be wrapped were actually transpiled from Wasm to JS (asm.js) and thus need shimming for i64
+    #[builder(default)]
     pub asmjs: bool,
 }
 
 #[derive(Default, Clone, Debug)]
+#[non_exhaustive]
 pub enum AsyncMode {
     #[default]
     Sync,
@@ -115,6 +127,7 @@ pub enum AsyncMode {
 }
 
 #[derive(Default, Clone, Debug)]
+#[non_exhaustive]
 pub enum InstantiationMode {
     #[default]
     Async,
@@ -138,6 +151,7 @@ enum CallType {
 }
 
 #[derive(Default, Clone, Debug)]
+#[non_exhaustive]
 pub enum BindingsMode {
     Hybrid,
     #[default]
@@ -371,7 +385,7 @@ impl JsBindgen<'_> {
         }
 
         // adds a default implementation of `getCoreModule`
-        if matches!(self.opts.instantiation, Some(InstantiationMode::Async)) {
+        if matches!(self.opts.instantiation_mode, Some(InstantiationMode::Async)) {
             uwriteln!(
                 compilation_promises,
                 "if (!getCoreModule) getCoreModule = (name) => {}(new URL(`./${{name}}`, import.meta.url));",
@@ -384,7 +398,7 @@ impl JsBindgen<'_> {
         for i in 0..self.core_module_cnt {
             let local_name = format!("module{i}");
             let mut name_idx = core_file_name(name, i as u32);
-            if self.opts.instantiation.is_some() {
+            if self.opts.instantiation_mode.is_some() {
                 uwriteln!(
                     compilation_promises,
                     "const {local_name} = getCoreModule('{name_idx}');"
@@ -420,13 +434,13 @@ impl JsBindgen<'_> {
 
         let render_args = RenderIntrinsicsArgs::builder()
             .intrinsics(&mut self.all_intrinsics)
-            .instantiation_occurred(self.opts.instantiation.is_some())
+            .instantiation_occurred(self.opts.instantiation_mode.is_some())
             .determinism_profile(AsyncDeterminismProfile::default())
             .transpile_opts(opts)
             .build();
         let js_intrinsics = render_intrinsics(render_args);
 
-        if let Some(instantiation) = &self.opts.instantiation {
+        if let Some(instantiation) = &self.opts.instantiation_mode {
             uwrite!(
                 output,
                 "\
@@ -447,7 +461,7 @@ impl JsBindgen<'_> {
         }
 
         // Render all imports
-        let imports_object = if self.opts.instantiation.is_some() {
+        let imports_object = if self.opts.instantiation_mode.is_some() {
             Some("imports")
         } else {
             None
@@ -456,11 +470,11 @@ impl JsBindgen<'_> {
             .render_imports(&mut output, imports_object, &mut self.local_names);
 
         // Create instantiation code
-        if self.opts.instantiation.is_some() {
+        if self.opts.instantiation_mode.is_some() {
             uwrite!(&mut self.src.js, "{}", &core_exported_funcs as &str);
             self.esm_bindgen.render_exports(
                 &mut self.src.js,
-                self.opts.instantiation.is_some(),
+                self.opts.instantiation_mode.is_some(),
                 &mut self.local_names,
                 opts,
             );
@@ -499,7 +513,7 @@ impl JsBindgen<'_> {
             );
         } else {
             let (maybe_init_export, maybe_init) =
-                if self.opts.tla_compat && opts.instantiation.is_none() {
+                if self.opts.tla_compat && opts.instantiation_mode.is_none() {
                     uwriteln!(self.src.js_init, "_initialized = true;");
                     (
                         "\
@@ -562,7 +576,7 @@ impl JsBindgen<'_> {
 
             self.esm_bindgen.render_exports(
                 &mut output,
-                self.opts.instantiation.is_some(),
+                self.opts.instantiation_mode.is_some(),
                 &mut self.local_names,
                 opts,
             );
@@ -789,7 +803,7 @@ impl<'a> Instantiator<'a, '_> {
             assert_eq!(i, *index);
         }
 
-        if let Some(InstantiationMode::Async) = self.bindgen.opts.instantiation {
+        if let Some(InstantiationMode::Async) = self.bindgen.opts.instantiation_mode {
             // To avoid uncaught promise rejection errors, we attach an intermediate
             // Promise.all with a rejection handler, if there are multiple promises.
             if self.modules.len() > 1 {
@@ -909,7 +923,7 @@ impl<'a> Instantiator<'a, '_> {
             self.trampoline(i, trampoline);
         }
 
-        if self.bindgen.opts.instantiation.is_some() {
+        if self.bindgen.opts.instantiation_mode.is_some() {
             let js_init = mem::take(&mut self.src.js_init);
             self.src.js.push_str(&js_init);
         }
@@ -2863,7 +2877,7 @@ impl<'a> Instantiator<'a, '_> {
         let instantiate = self.bindgen.intrinsic(Intrinsic::InstantiateCore);
         uwriteln!(self.src.js, "let exports{iu32};");
 
-        match self.bindgen.opts.instantiation {
+        match self.bindgen.opts.instantiation_mode {
             Some(InstantiationMode::Async) | None => {
                 uwriteln!(
                     self.src.js_init,
@@ -3961,7 +3975,7 @@ impl<'a> Instantiator<'a, '_> {
         // If TLA compat was enabled, ensure that it was initialized
         if self.bindgen.opts.tla_compat
             && matches!(abi, AbiVariant::GuestExport)
-            && self.bindgen.opts.instantiation.is_none()
+            && self.bindgen.opts.instantiation_mode.is_none()
         {
             let throw_uninitialized = self.bindgen.intrinsic(Intrinsic::ThrowUninitialized);
             uwrite!(

--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -176,7 +176,7 @@ pub fn ts_bindgen(
                                 name,
                                 *id,
                                 files,
-                                opts.instantiation.is_some(),
+                                opts.instantiation_mode.is_some(),
                             );
                         }
 
@@ -262,7 +262,7 @@ pub fn ts_bindgen(
                 name.as_ref(),
                 import_interfaces,
                 files,
-                opts.instantiation.is_some(),
+                opts.instantiation_mode.is_some(),
             );
         }
     }
@@ -311,7 +311,7 @@ pub fn ts_bindgen(
                     continue;
                 }
 
-                let instantiation = opts.instantiation.is_some();
+                let instantiation = opts.instantiation_mode.is_some();
                 bindgen.export_interface(resolve, export_name, *id, files, instantiation);
                 // Also export the interface name as a type alias
                 let alt_export_name = iface_name.to_lower_camel_case();
@@ -323,7 +323,13 @@ pub fn ts_bindgen(
         }
     }
     if !funcs.is_empty() {
-        bindgen.export_funcs(resolve, id, &funcs, files, opts.instantiation.is_none());
+        bindgen.export_funcs(
+            resolve,
+            id,
+            &funcs,
+            files,
+            opts.instantiation_mode.is_none(),
+        );
     }
 
     let camel = world.name.to_upper_camel_case();
@@ -334,7 +340,7 @@ pub fn ts_bindgen(
     // With the current representation of a "world" this is an import object
     // per-imported-interface where the type of that field is defined by the
     // interface bindgen.
-    if opts.instantiation.is_some() {
+    if opts.instantiation_mode.is_some() {
         uwriteln!(bindgen.src, "export interface ImportObject {{");
         bindgen.src.push_str(&bindgen.import_object);
         uwriteln!(bindgen.src, "}}");
@@ -342,7 +348,7 @@ pub fn ts_bindgen(
 
     // Generate a type definition for the export object from instantiating
     // the component.
-    if opts.instantiation.is_some() {
+    if opts.instantiation_mode.is_some() {
         uwriteln!(bindgen.src, "export interface {camel} {{",);
         bindgen.src.push_str(&bindgen.export_object);
         uwriteln!(bindgen.src, "}}");
@@ -350,7 +356,7 @@ pub fn ts_bindgen(
         bindgen.src.push_str(&bindgen.export_object);
     }
 
-    if opts.tla_compat && opts.instantiation.is_none() {
+    if opts.tla_compat && opts.instantiation_mode.is_none() {
         uwriteln!(
             bindgen.src,
             "
@@ -361,7 +367,7 @@ pub fn ts_bindgen(
     // Generate the TypeScript definition of the `instantiate` function
     // which is the main workhorse of the generated bindings.
     if opts.asmjs {
-        if let Some(mode) = &opts.instantiation {
+        if let Some(mode) = &opts.instantiation_mode {
             uwriteln!(
                 bindgen.src,
                 "
@@ -387,7 +393,7 @@ pub fn ts_bindgen(
             );
         }
     } else {
-        match opts.instantiation {
+        match opts.instantiation_mode {
             Some(InstantiationMode::Async) => {
                 uwriteln!(
                 bindgen.src,

--- a/crates/xtask/src/build/jco.rs
+++ b/crates/xtask/src/build/jco.rs
@@ -182,25 +182,23 @@ fn transpile(args: TranspileArgs) -> Result<()> {
             "@bytecodealliance/preview2-shim/sockets#*".into(),
         ),
     ]);
-    let opts = js_component_bindgen::TranspileOpts {
-        name,
-        no_typescript: false,
-        instantiation: None,
-        map: Some(import_map),
-        nodejs_compat_disabled: false,
-        base64_cutoff: 5000_usize,
-        tla_compat: true,
-        valid_lifting_optimization: false,
-        tracing: false,
-        no_namespaced_exports: true,
-        multi_memory: true,
-        import_bindings: Some(BindingsMode::Js),
-        guest: false,
-        async_mode: None,
+    let opts = js_component_bindgen::TranspileOpts::builder()
+        .name(name)
+        .no_typescript(false)
+        .map(import_map)
+        .nodejs_compat_disabled(false)
+        .base64_cutoff(5000_usize)
+        .tla_compat(true)
+        .valid_lifting_optimization(false)
+        .tracing(false)
+        .no_namespaced_exports(true)
+        .multi_memory(true)
+        .import_bindings(BindingsMode::Js)
+        .guest(false)
         // TODO(breaking): strict by default
-        strict: false,
-        asmjs: false,
-    };
+        .strict(false)
+        .asmjs(false)
+        .build();
 
     let transpiled = js_component_bindgen::transpile(&adapted_component, opts)?;
 

--- a/crates/xtask/src/generate/wasi_types.rs
+++ b/crates/xtask/src/generate/wasi_types.rs
@@ -48,12 +48,11 @@ fn process_wasi_types(wasi: WasiTypes<'_>) -> Result<()> {
 
         let world = resolve.select_world(&[*package], Some(world_name))?;
 
-        let opts = js_component_bindgen::TranspileOpts {
-            name: "component".to_string(),
-            import_bindings: Some(BindingsMode::Js),
-            no_namespaced_exports: true,
-            ..Default::default()
-        };
+        let opts = js_component_bindgen::TranspileOpts::builder()
+            .name("component".into())
+            .import_bindings(BindingsMode::Js)
+            .no_namespaced_exports(true)
+            .build();
 
         let files = generate_types(&name, resolve, world, opts)?;
 


### PR DESCRIPTION
This commit introduces yet another breaking change into an already-broken API -- `TranspileOpts` -- to ensure that it can be used a bit more easily going forward.

Since `TranspileOpts` is used in other parts of the codebase, namely `transpile(..)`, it was very disruptive to make it non exhaustive, so it will be left with `pub` members to avoid unnecessary disruption of downstream consumers.