### PR TITLE
fix(bindgen): avoid assuming WebAssembly global is present

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -336,7 +336,7 @@ impl AsyncTaskIntrinsic {
                 uwriteln!(
                     output,
                     r#"
-                      const {var_name} = new WebAssembly.Global({{ value: 'i32', mutable: true }}, 0);
+                      const {var_name} = globalThis.WebAssembly ? new globalThis.WebAssembly.Global({{ value: 'i32', mutable: true }}, 0) : false;
                     "#
                 );
             }


### PR DESCRIPTION
For some downstream consumers of `js-component-bindgen` which use `wizer` (like `componentize-js`), the `WebAssembly` global is not present. This PR removes adds a check for the global before use