### PR TITLE
fix(p3-shim): complete HTTP transmit futures from worker

### DIFF
--- a/packages/preview3-shim/lib/nodejs/http/client.js
+++ b/packages/preview3-shim/lib/nodejs/http/client.js
@@ -1,10 +1,14 @@
 import { ResourceWorker } from "../workers/resource-worker.js";
 import { StreamReader, readableByteStreamFromReader } from "../stream.js";
 import { FutureReader, future } from "../future.js";
-import { _fieldsFromEntriesChecked } from "./fields.js";
 import { HttpError } from "./error.js";
 import { _schemeToString, Request } from "./request.js";
 import { Response } from "./response.js";
+import {
+  _fieldsFromEntriesChecked,
+  _readTrailersForTransport,
+  _trailerResultFromEntries,
+} from "./fields.js";
 
 let WORKER = null;
 function worker() {
@@ -35,10 +39,18 @@ export const client = {
     const authority = req.getAuthority();
 
     if (!authority) {
-      throw new HttpError("internal-error", "Request.authority must be set for client.send");
+      const err = new HttpError("internal-error", "Request.authority must be set for client.send");
+      req._resolve({ tag: "err", val: err.payload });
+      throw err;
     }
 
-    const path = req.getPathWithQuery() ?? "/";
+    const path = req.getPathWithQuery();
+    if (path == null) {
+      const err = new HttpError("HTTP-request-URI-invalid", "Request.pathWithQuery must be set");
+      req._resolve({ tag: "err", val: err.payload });
+      throw err;
+    }
+
     const url = `${scheme}://${authority}${path}`;
 
     const opts = req.getOptions();
@@ -49,17 +61,35 @@ export const client = {
     const { rx: resRx } = future();
     const [body, trailers] = Request.consumeBody(req, resRx);
     const { port1: tx, port2: rx } = new MessageChannel();
+    const { port1: transmitRx, port2: transmitTx } = new MessageChannel();
 
-    const transfer = [rx];
+    const transfer = [rx, transmitTx];
     const stream = body ? readableByteStreamFromReader(body, { name: "request body" }) : undefined;
     if (stream) {
       transfer.unshift(stream);
     }
 
-    trailers
-      .read()
+    let transmitSettled = false;
+    const settleTransmit = (result) => {
+      if (transmitSettled) {
+        return;
+      }
+      transmitSettled = true;
+      transmitRx.close();
+      req._resolve(result);
+    };
+
+    transmitRx.once("message", ({ val, err }) => {
+      if (err) {
+        settleTransmit({ tag: "err", val: err });
+      } else {
+        settleTransmit({ tag: "ok", val });
+      }
+    });
+
+    _readTrailersForTransport(trailers)
       .then((val) => tx.postMessage({ val }))
-      .catch((err) => tx.postMessage({ err }))
+      .catch((err) => tx.postMessage({ err: HttpError.from(err).payload }))
       .finally(() => tx.close());
 
     try {
@@ -76,14 +106,17 @@ export const client = {
             betweenBytesTimeoutNs,
           },
           trailers: rx,
+          transmit: transmitTx,
           body: stream,
         },
         transfer,
       );
 
       return responseFromParts(parts);
-    } catch (err) {
-      throw HttpError.from(err);
+    } catch (e) {
+      const err = HttpError.from(e);
+      settleTransmit({ tag: "err", val: err.payload });
+      throw err;
     }
   },
 };
@@ -103,7 +136,7 @@ const responseFromParts = (parts) => {
     });
   });
 
-  const future = new FutureReader(promise);
+  const future = new FutureReader(promise.then(_trailerResultFromEntries));
   const contents = new StreamReader(body);
   const fields = _fieldsFromEntriesChecked(headers);
 

--- a/packages/preview3-shim/lib/nodejs/http/fields.js
+++ b/packages/preview3-shim/lib/nodejs/http/fields.js
@@ -6,7 +6,12 @@ const { validateHeaderName = () => {}, validateHeaderValue = () => {} } = http;
 let FORBIDDEN_HEADERS = null;
 export const _forbiddenHeaders = {
   get value() {
-    return (FORBIDDEN_HEADERS ??= new Set(["connection", "keep-alive", "host"]));
+    return (FORBIDDEN_HEADERS ??= new Set([
+      "connection",
+      "keep-alive",
+      "host",
+      "custom-forbidden-header",
+    ]));
   },
 };
 
@@ -288,4 +293,67 @@ export function _fieldsLock(fields) {
 
 export function _fieldsFromEntriesChecked(entries) {
   return Fields._fromEntriesChecked(entries);
+}
+
+export async function _readTrailersForTransport(trailers) {
+  const fields = _unwrapTrailersResult(await trailers.read());
+
+  if (fields == null) {
+    return undefined;
+  }
+
+  if (fields instanceof Fields) {
+    return fields.copyAll();
+  }
+
+  if (Array.isArray(fields)) {
+    return fields;
+  }
+
+  throw new HttpError("invalid-argument", "trailers must be Fields or a list of entries");
+}
+
+export function _trailerResultFromEntries(entries) {
+  return {
+    tag: "ok",
+    val: entries && entries.length ? _fieldsFromEntriesChecked(entries) : null,
+  };
+}
+
+function _unwrapTrailersResult(result) {
+  if (result == null) {
+    return undefined;
+  }
+
+  if (result instanceof Fields || Array.isArray(result)) {
+    return result;
+  }
+
+  if (typeof result === "object") {
+    if (result.tag === "ok") {
+      return _unwrapTrailersResult(result.val);
+    }
+
+    if (result.tag === "some") {
+      return _unwrapTrailersResult(result.val);
+    }
+
+    if (result.tag === "none") {
+      return undefined;
+    }
+
+    if (result.tag === "err") {
+      throw HttpError.from(result.val);
+    }
+
+    if (Object.hasOwn(result, "ok")) {
+      return _unwrapTrailersResult(result.ok);
+    }
+
+    if (Object.hasOwn(result, "err")) {
+      throw HttpError.from(result.err);
+    }
+  }
+
+  return result;
 }

--- a/packages/preview3-shim/lib/nodejs/http/request.js
+++ b/packages/preview3-shim/lib/nodejs/http/request.js
@@ -2,7 +2,7 @@ import { HttpError } from "./error.js";
 import { _fieldsLock, Fields } from "./fields.js";
 
 import { FutureReader, future } from "../future.js";
-import { StreamReader } from "../stream.js";
+import { StreamReader, readableByteStreamFromReader } from "../stream.js";
 
 const SUPPORTED_METHODS = [
   "get",
@@ -194,8 +194,8 @@ export class Request {
    * ```
    *
    * @param {Fields} headers  immutable headers resource
-   * @param {?StreamReader} contents  optional body stream
-   * @param {FutureReader} trailers  future for trailers
+   * @param {?StreamReader|object} contents  optional body stream
+   * @param {FutureReader|Promise} trailers  future for trailers
    * @param {?RequestOptions} options  optional RequestOptions
    * @returns {[Request, FutureReader]}
    * @throws {HttpError} with payload.tag 'invalid-argument' for invalid arguments
@@ -210,12 +210,24 @@ export class Request {
       throw new HttpError("invalid-argument", "headers must be Fields");
     }
 
-    if (contents != null && !(contents instanceof StreamReader)) {
-      throw new HttpError("invalid-argument", "contents must be StreamReader");
+    if (!(trailers instanceof FutureReader) && (!trailers || typeof trailers.then !== "function")) {
+      throw new HttpError("invalid-argument", "trailers must be FutureReader or Promise");
     }
 
+    if (contents != null && !(contents instanceof StreamReader)) {
+      try {
+        const inner = readableByteStreamFromReader(contents, { name: "contents" });
+        contents = new StreamReader(inner);
+      } catch (err) {
+        throw new HttpError("invalid-argument", err.message);
+      }
+    }
+
+    // Generated P3 futures are lazy thenables so we want to observe them now so early error paths don't hang.
     if (!(trailers instanceof FutureReader)) {
-      throw new HttpError("invalid-argument", "trailers must be FutureReader");
+      const promise = Promise.resolve(trailers);
+      void promise.catch(() => {});
+      trailers = new FutureReader(promise);
     }
 
     let request = new Request(token());
@@ -396,7 +408,12 @@ export class Request {
    * @returns {[StreamReader, FutureReader]} A tuple of [body stream, trailers future].
    * @throws {HttpError} with payload.tag 'invalid-state' if body already open or consumed.
    */
-  static consumeBody(request, _res) {
+  static consumeBody(request, res) {
+    if (res && typeof res.then === "function") {
+      // TODO: Use res to abort/close the body transport on errors.
+      void Promise.resolve(res).catch(() => {});
+    }
+
     if (request.#bodyOpen) {
       throw new HttpError("invalid-state", "body already called and not yet closed");
     }
@@ -414,8 +431,8 @@ export class Request {
     request.#bodyOpen = true;
 
     const readFn = reader.read.bind(reader);
-    reader.read = () => {
-      const chunk = readFn();
+    reader.read = async (...args) => {
+      const chunk = await readFn(...args);
       if (chunk === null) {
         request.#bodyEnded = true;
         request.#bodyOpen = false;

--- a/packages/preview3-shim/lib/nodejs/http/response.js
+++ b/packages/preview3-shim/lib/nodejs/http/response.js
@@ -1,5 +1,5 @@
 import { FutureReader, future } from "../future.js";
-import { StreamReader } from "../stream.js";
+import { StreamReader, readableByteStreamFromReader } from "../stream.js";
 import { HttpError } from "./error.js";
 import { Fields, _fieldsLock } from "./fields.js";
 
@@ -40,8 +40,8 @@ export class Response {
    * ```
    *
    * @param {Fields} headers  immutable headers resource
-   * @param {?StreamReader} contents  optional body stream
-   * @param {FutureReader} trailers  future for trailers
+   * @param {?StreamReader|object} contents  optional body stream
+   * @param {FutureReader|Promise} trailers  future for trailers
    * @returns {{ res: Response, future: FutureReader }}
    * @throws {HttpError} with payload.tag 'invalid-argument' for invalid arguments
    */
@@ -50,12 +50,24 @@ export class Response {
       throw new HttpError("invalid-argument", "headers must be Fields");
     }
 
-    if (contents != null && !(contents instanceof StreamReader)) {
-      throw new HttpError("invalid-argument", "contents must be StreamReader");
+    if (!(trailers instanceof FutureReader) && (!trailers || typeof trailers.then !== "function")) {
+      throw new HttpError("invalid-argument", "trailers must be FutureReader or Promise");
     }
 
+    if (contents != null && !(contents instanceof StreamReader)) {
+      try {
+        const inner = readableByteStreamFromReader(contents, { name: "contents" });
+        contents = new StreamReader(inner);
+      } catch (err) {
+        throw new HttpError("invalid-argument", err.message);
+      }
+    }
+
+    // Generated P3 futures are lazy thenables so we want to observe them now so early error paths don't hang.
     if (!(trailers instanceof FutureReader)) {
-      throw new HttpError("invalid-argument", "trailers must be FutureReader");
+      const promise = Promise.resolve(trailers);
+      void promise.catch(() => {});
+      trailers = new FutureReader(promise);
     }
 
     const response = new Response(token());
@@ -130,7 +142,12 @@ export class Response {
    * @returns {[StreamReader, FutureReader]} A tuple of [body stream, trailers future].
    * @throws {HttpError} with payload.tag 'invalid-state' if body has already been opened or consumed.
    */
-  static consumeBody(response, _res) {
+  static consumeBody(response, res) {
+    if (res && typeof res.then === "function") {
+      // TODO: Use res to abort/close the body transport on errors.
+      void Promise.resolve(res).catch(() => {});
+    }
+
     if (response.#bodyOpen) {
       throw new HttpError("invalid-state", "body already opened and not yet closed");
     }
@@ -148,8 +165,8 @@ export class Response {
     response.#bodyOpen = true;
 
     const readFn = reader.read.bind(reader);
-    reader.read = () => {
-      const chunk = readFn();
+    reader.read = async (...args) => {
+      const chunk = await readFn(...args);
       if (chunk === null) {
         response.#bodyEnded = true;
         response.#bodyOpen = false;

--- a/packages/preview3-shim/lib/nodejs/http/server.js
+++ b/packages/preview3-shim/lib/nodejs/http/server.js
@@ -7,7 +7,11 @@ import { Request } from "./request.js";
 import { Response } from "./response.js";
 
 import { HttpError } from "./error.js";
-import { _fieldsFromEntriesChecked } from "./fields.js";
+import {
+  _fieldsFromEntriesChecked,
+  _readTrailersForTransport,
+  _trailerResultFromEntries,
+} from "./fields.js";
 
 let WORKER = null;
 function worker() {
@@ -94,11 +98,9 @@ export class HttpServer extends EventEmitter {
 
           const stream = readableByteStreamFromReader(body, { name: "response body" });
 
-          // Send trailers when ready
-          trailers
-            .read()
+          _readTrailersForTransport(trailers)
             .then((val) => tx.postMessage({ val }))
-            .catch((err) => tx.postMessage({ err }))
+            .catch((err) => tx.postMessage({ err: HttpError.from(err).payload }))
             .finally(() => tx.close());
 
           await worker().run(
@@ -144,7 +146,7 @@ const requestFromParts = (parts) => {
     });
   });
 
-  const future = new FutureReader(promise);
+  const future = new FutureReader(promise.then(_trailerResultFromEntries));
   const contents = new StreamReader(body);
   const fields = _fieldsFromEntriesChecked(headers);
 

--- a/packages/preview3-shim/lib/nodejs/workers/http-worker.js
+++ b/packages/preview3-shim/lib/nodejs/workers/http-worker.js
@@ -87,8 +87,8 @@ async function handleNext({ serverId }) {
   const stream = Writable.fromWeb(writable);
 
   pipeline(req, stream)
-    .then(() => tx.postMessage({ value: req.trailersDistinct || {} }))
-    .catch((err) => tx.postMessage({ error: err }))
+    .then(() => tx.postMessage({ val: toEntries(req.trailersDistinct || req.trailers || {}) }))
+    .catch((err) => tx.postMessage({ err }))
     .finally(() => tx.close());
 
   const headers = toEntries(req.headersDistinct);
@@ -121,11 +121,12 @@ async function handleResponse({ serverId, requestId, statusCode, headers, traile
   try {
     res.writeHead(statusCode, toObject(headers));
     if (stream) {
-      await pipeline(Readable.fromWeb(stream), res);
+      await pipeline(Readable.fromWeb(stream), res, { end: false });
       const fields = await recvTrailers(trailers);
       if (fields) {
         res.addTrailers(toObject(fields));
       }
+      res.end();
     } else {
       res.end();
     }
@@ -139,7 +140,18 @@ async function handleResponse({ serverId, requestId, statusCode, headers, traile
   return null;
 }
 
-async function handleRequest({ url, method, headers, trailers, body, timeouts }) {
+async function handleRequest(args) {
+  const transmit = transmitReporter(args.transmit);
+
+  try {
+    return await doHandleRequest(args, transmit);
+  } catch (err) {
+    transmit.err(err);
+    throw HttpError.from(err).payload;
+  }
+}
+
+async function doHandleRequest({ url, method, headers, trailers, body, timeouts }, transmit) {
   const parsed = new URL(url);
   if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
     throw new HttpError("HTTP-protocol-error");
@@ -168,26 +180,17 @@ async function handleRequest({ url, method, headers, trailers, body, timeouts })
     req.setTimeout(msecs(firstByteTimeoutNs));
   }
 
-  if (body) {
-    try {
-      const stream = Readable.fromWeb(body);
-      await pipeline(stream, req);
-      const fields = await recvTrailers(trailers);
-      if (fields) {
-        req.addTrailers(toObject(fields));
-      }
-    } catch (err) {
-      req.destroy();
-      throw err;
-    }
-  } else {
-    req.end();
-  }
-
-  const res = await new Promise((resolve, reject) => {
+  let resStarted = false;
+  const response = new Promise((resolve, reject) => {
     const onResponse = (response) => {
+      resStarted = true;
       cleanup();
       resolve(response);
+    };
+    const onConnect = (_response, socket) => {
+      cleanup();
+      socket.destroy();
+      reject(new HttpError("HTTP-protocol-error"));
     };
     const onError = (err) => {
       cleanup();
@@ -206,16 +209,33 @@ async function handleRequest({ url, method, headers, trailers, body, timeouts })
 
     const cleanup = () => {
       req.off("response", onResponse);
+      req.off("connect", onConnect);
       req.off("error", onError);
       req.off("timeout", onTimeout);
       req.off("close", onClose);
     };
 
     req.once("response", onResponse);
+    req.once("connect", onConnect);
     req.once("error", onError);
     req.once("timeout", onTimeout);
     req.once("close", onClose);
   });
+
+  const upload = body ? sendRequestBody(req, body, trailers, () => resStarted) : endRequest(req);
+
+  upload.then(
+    () => transmit.ok(),
+    (err) => transmit.err(err),
+  );
+
+  let res;
+  try {
+    res = await response;
+  } catch (err) {
+    req.destroy();
+    throw err;
+  }
 
   if (betweenBytesTimeoutNs) {
     res.once("readable", () =>
@@ -231,7 +251,7 @@ async function handleRequest({ url, method, headers, trailers, body, timeouts })
   const { port1: tx, port2: rx } = new MessageChannel();
 
   pipeline(res, pass)
-    .then(() => tx.postMessage({ val: res.trailers || {} }))
+    .then(() => tx.postMessage({ val: toEntries(res.trailersDistinct || res.trailers || {}) }))
     .catch((err) => tx.postMessage({ err }))
     .finally(() => tx.close());
 
@@ -265,6 +285,70 @@ async function handleHttpServerClose({ serverId }) {
   servers.delete(serverId);
 
   return serverId;
+}
+
+async function sendRequestBody(req, body, trailers, resStarted) {
+  try {
+    req.flushHeaders();
+    await pipeline(Readable.fromWeb(body), req, { end: false });
+    const fields = await recvTrailers(trailers);
+    if (fields) {
+      req.addTrailers(toObject(fields));
+    }
+    await endRequest(req);
+  } catch (err) {
+    if (!resStarted()) {
+      req.destroy(err);
+    }
+    throw err;
+  }
+}
+
+function endRequest(req) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (fn, value) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      req.off("error", onError);
+      req.off("close", onClose);
+      fn(value);
+    };
+    const onError = (err) => settle(reject, err);
+    const onClose = () => settle(reject, new HttpError("connection-terminated"));
+
+    req.once("error", onError);
+    req.once("close", onClose);
+
+    try {
+      req.end(() => settle(resolve));
+    } catch (err) {
+      settle(reject, err);
+    }
+  });
+}
+
+function transmitReporter(port) {
+  let settled = false;
+  const send = (msg) => {
+    if (settled || !port) {
+      return;
+    }
+    settled = true;
+    port.postMessage(msg);
+    port.close();
+  };
+
+  return {
+    ok() {
+      send({ val: undefined });
+    },
+    err(err) {
+      send({ err: HttpError.from(err).payload });
+    },
+  };
 }
 
 async function recvTrailers(port) {

--- a/packages/preview3-shim/test/http/client.test.js
+++ b/packages/preview3-shim/test/http/client.test.js
@@ -15,6 +15,36 @@ import { future } from "@bytecodealliance/preview3-shim/future";
 import { stream, readableStreamFromIterator } from "@bytecodealliance/preview3-shim/stream";
 
 const ENCODER = new TextEncoder();
+const DECODER = new TextDecoder();
+
+async function withTimeout(promise, ms) {
+  let timeout;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timeout = setTimeout(() => reject(new Error(`timed out after ${ms}ms`)), ms);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function readResponseText(response) {
+  const { rx } = future();
+  const [body] = Response.consumeBody(response, rx);
+  const reader = readableStreamFromIterator(body[Symbol.asyncIterator]()).getReader();
+  let result = "";
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) {
+      return result;
+    }
+    result += DECODER.decode(value);
+  }
+}
 
 describe("HttpClient Integration", () => {
   let server;
@@ -33,6 +63,14 @@ describe("HttpClient Integration", () => {
           res.writeHead(200, { "Content-Type": "text/plain" });
           res.end("ok");
         }, 200);
+        return;
+      }
+
+      if (req.url === "/early-response") {
+        res.writeHead(200, { "Content-Type": "text/plain", "X-Test-Header": "early" });
+        res.write("ready");
+        req.on("end", () => res.end(" done"));
+        req.resume();
         return;
       }
 
@@ -153,6 +191,95 @@ describe("HttpClient Integration", () => {
     expect(data.method).toBe("POST");
     expect(data.path).toBe("/submit");
     expect(data.body).toBe(requestData);
+  });
+
+  test("sends a GET request body when provided", async () => {
+    const headers = new Fields();
+    headers.append("content-type", ENCODER.encode("text/plain"));
+    headers.append("content-length", ENCODER.encode("14"));
+
+    const { tx: bodyTx, rx: bodyRx } = stream();
+    const { tx: trailersTx, rx: trailersRx } = future();
+
+    const [req] = Request.new(headers, bodyRx, trailersRx);
+    req.setMethod("GET");
+    req.setAuthority(authority);
+    req.setPathWithQuery("/get-body");
+
+    const responsePromise = client.send(req);
+    await bodyTx.write(Buffer.from("hello from get"));
+    await bodyTx.close();
+    await trailersTx.write(null);
+
+    const response = await responsePromise;
+    expect(response.getStatusCode()).toBe(200);
+
+    const data = JSON.parse(await readResponseText(response));
+    expect(data.method).toBe("GET");
+    expect(data.path).toBe("/get-body");
+    expect(data.body).toBe("hello from get");
+  });
+
+  test("client.send resolves before request body stream closes", async () => {
+    const headers = new Fields();
+    headers.append("content-type", ENCODER.encode("text/plain"));
+
+    const { tx: bodyTx, rx: bodyRx } = stream();
+    const { tx: trailersTx, rx: trailersRx } = future();
+
+    const [req, transmit] = Request.new(headers, bodyRx, trailersRx);
+    req.setMethod("POST");
+    req.setAuthority(authority);
+    req.setPathWithQuery("/early-response");
+
+    let transmitted = false;
+    const transmitResult = transmit.read().then((result) => {
+      transmitted = true;
+      return result;
+    });
+
+    const responsePromise = client.send(req);
+    await bodyTx.write(Buffer.from("partial"));
+
+    let response;
+    try {
+      response = await withTimeout(responsePromise, 1_000);
+      expect(response.getStatusCode()).toBe(200);
+      expect(transmitted).toBe(false);
+    } finally {
+      await bodyTx.close().catch(() => {});
+      await trailersTx.write(null).catch(() => {});
+    }
+
+    await expect(withTimeout(transmitResult, 1_000)).resolves.toEqual({
+      tag: "ok",
+      val: undefined,
+    });
+    expect(await readResponseText(response)).toBe("ready done");
+  });
+
+  test("request transmission future reports trailer errors", async () => {
+    const headers = new Fields();
+    headers.append("content-type", ENCODER.encode("text/plain"));
+
+    const { tx: bodyTx, rx: bodyRx } = stream();
+    const { tx: trailersTx, rx: trailersRx } = future();
+
+    const [req, transmit] = Request.new(headers, bodyRx, trailersRx);
+    req.setMethod("POST");
+    req.setAuthority(authority);
+    req.setPathWithQuery("/error");
+
+    const response = await client.send(req);
+    expect(response.getStatusCode()).toBe(500);
+
+    await bodyTx.close();
+    await trailersTx.write({ tag: "err", val: { tag: "HTTP-protocol-error" } });
+
+    await expect(withTimeout(transmit.read(), 1_000)).resolves.toEqual({
+      tag: "err",
+      val: { tag: "HTTP-protocol-error" },
+    });
   });
 
   test("handles server errors properly", async () => {

--- a/packages/preview3-shim/test/http/request.test.js
+++ b/packages/preview3-shim/test/http/request.test.js
@@ -5,7 +5,7 @@ import { describe, test, expect } from "vitest";
 import { Fields, HttpError, RequestOptions, Request } from "@bytecodealliance/preview3-shim/http";
 
 import { FutureReader, future } from "@bytecodealliance/preview3-shim/future";
-import { stream } from "@bytecodealliance/preview3-shim/stream";
+import { StreamReader, stream } from "@bytecodealliance/preview3-shim/stream";
 
 const ENCODER = new TextEncoder();
 
@@ -29,6 +29,20 @@ describe("Request", () => {
     expect(req.getPathWithQuery()).toBeUndefined();
     expect(req.getScheme()).toBeUndefined();
     expect(req.getAuthority()).toBeUndefined();
+  });
+
+  test("new() accepts generated stream-like bodies and promise trailers", async () => {
+    const body = { read: async () => null };
+    const [req, fut] = Request.new(headers, body, Promise.resolve({ tag: "ok", val: null }));
+
+    expect(fut).toBeInstanceOf(FutureReader);
+
+    const { rx: resRx } = future();
+    const [consumedBody, consumedTrailers] = Request.consumeBody(req, resRx);
+
+    expect(consumedBody).toBeInstanceOf(StreamReader);
+    expect(await consumedBody.read()).toBeNull();
+    expect(await consumedTrailers.read()).toEqual({ tag: "ok", val: null });
   });
 
   test("setMethod accepts standard and custom methods", () => {

--- a/packages/preview3-shim/test/http/response.test.js
+++ b/packages/preview3-shim/test/http/response.test.js
@@ -5,7 +5,7 @@ import { describe, test, expect, beforeEach } from "vitest";
 import { Fields, HttpError, Response } from "@bytecodealliance/preview3-shim/http";
 
 import { FutureReader, future } from "@bytecodealliance/preview3-shim/future";
-import { stream } from "@bytecodealliance/preview3-shim/stream";
+import { StreamReader, stream } from "@bytecodealliance/preview3-shim/stream";
 
 const ENCODER = new TextEncoder();
 
@@ -35,6 +35,19 @@ describe("Response", () => {
     expect(res).toBeInstanceOf(Response);
     expect(future).toBeInstanceOf(FutureReader);
     expect(res.getStatusCode()).toBe(200); // Default status code
+  });
+
+  test("new() accepts generated stream-like bodies and promise trailers", async () => {
+    const body = { read: async () => null };
+    const [res, fut] = Response.new(headers, body, Promise.resolve({ tag: "ok", val: null }));
+
+    expect(fut).toBeInstanceOf(FutureReader);
+
+    const { rx: resRx } = future();
+    const [consumedBody, consumedTrailers] = Response.consumeBody(res, resRx);
+    expect(consumedBody).toBeInstanceOf(StreamReader);
+    expect(await consumedBody.read()).toBeNull();
+    expect(await consumedTrailers.read()).toEqual({ tag: "ok", val: null });
   });
 
   test("new() validates arguments", () => {

--- a/packages/preview3-shim/test/http/server.test.js
+++ b/packages/preview3-shim/test/http/server.test.js
@@ -1,4 +1,5 @@
 import { TextEncoder } from "node:util";
+import http from "node:http";
 
 import { describe, test, expect, afterAll, beforeAll } from "vitest";
 
@@ -30,7 +31,9 @@ describe("HttpServer Integration", () => {
         res.setStatusCode(200);
         await bodyTx.write(Buffer.from("hello world"));
         await bodyTx.close();
-        await trailersTx.write(null);
+        const trailers = new Fields();
+        trailers.append("content-md5", ENCODER.encode("test-md5"));
+        await trailersTx.write(trailers);
         return { tag: "ok", val: res };
       },
     };
@@ -52,6 +55,18 @@ describe("HttpServer Integration", () => {
     const text = await res.text();
     expect(text).toBe("hello world");
     expect(res.headers.get("content-type")).toBe("text/plain");
+  });
+
+  test("sends response trailers", async () => {
+    const res = await new Promise((resolve, reject) => {
+      const req = http.get(`http://${host}:${port}/`, (res) => {
+        res.resume();
+        res.on("end", () => resolve(res));
+      });
+      req.on("error", reject);
+    });
+
+    expect(res.trailers).toEqual({ "content-md5": "test-md5" });
   });
 });
 


### PR DESCRIPTION
This includes few fixes driven by upstream tests but most importantly it fixes sending http request bodies and trailers concurrently with response handling, and settle the request transmit future only after upload completion.