### PR TITLE
fix(p2-shim): Fields.set fails on valid input

### DIFF
--- a/packages/preview2-shim/lib/browser/http.js
+++ b/packages/preview2-shim/lib/browser/http.js
@@ -46,6 +46,19 @@ class Fields {
     return tableEntries.map(([, v]) => v);
   }
 
+  /**
+   * WIT spec (https://github.com/WebAssembly/WASI/blob/91bb44c3c3a9b1e09187db23c85fa844d1fd6b15/proposals/http/wit/types.wit#L215-L223):
+   *
+   * > Set all of the values for a name. Clears any existing values for that
+   * > name, if they have been set.
+   * >
+   * > Fails with `header-error.immutable` if the `fields` are immutable.
+   * >
+   * > Fails with `header-error.invalid-syntax` if the `field-name` or any of
+   * > the `field-value`s are syntactically invalid.
+   *
+   * The existing-branch splice/reuse is an allocation optimization — values are cleared, not retained.
+   */
   set(name, values) {
     if (this.#immutable) {
       throw { tag: "immutable" };

--- a/packages/preview2-shim/lib/nodejs/http.js
+++ b/packages/preview2-shim/lib/nodejs/http.js
@@ -499,6 +499,19 @@ class Fields {
     }
     return tableEntries.map(([, v]) => v);
   }
+  /**
+   * WIT spec (https://github.com/WebAssembly/WASI/blob/91bb44c3c3a9b1e09187db23c85fa844d1fd6b15/proposals/http/wit/types.wit#L215-L223):
+   *
+   * > Set all of the values for a name. Clears any existing values for that
+   * > name, if they have been set.
+   * >
+   * > Fails with `header-error.immutable` if the `fields` are immutable.
+   * >
+   * > Fails with `header-error.invalid-syntax` if the `field-name` or any of
+   * > the `field-value`s are syntactically invalid.
+   *
+   * The existing-branch splice/reuse is an allocation optimization — values are cleared, not retained.
+   */
   set(name, values) {
     if (this.#immutable) {
       throw { tag: "immutable" };

--- a/packages/preview2-shim/lib/nodejs/http.js
+++ b/packages/preview2-shim/lib/nodejs/http.js
@@ -514,17 +514,19 @@ class Fields {
       } catch {
         throw { tag: "invalid-syntax" };
       }
-      throw { tag: "invalid-syntax" };
     }
     const lowercased = name.toLowerCase();
     if (_forbiddenHeaders.has(lowercased)) {
       throw { tag: "forbidden" };
     }
-    const tableEntries = this.#table.get(lowercased);
+    let tableEntries = this.#table.get(lowercased);
     if (tableEntries) {
       this.#entries = this.#entries.filter((entry) => !tableEntries.includes(entry));
+      tableEntries.splice(0, tableEntries.length);
+    } else {
+      this.#table.set(lowercased, []);
+      tableEntries = this.#table.get(lowercased);
     }
-    tableEntries.splice(0, tableEntries.length);
     for (const value of values) {
       const entry = [name, value];
       this.#entries.push(entry);

--- a/packages/preview2-shim/test/test.js
+++ b/packages/preview2-shim/test/test.js
@@ -128,6 +128,108 @@ suite("Node.js Preview2", () => {
     }
   });
 
+  test("Fields.set on a fresh Fields", async () => {
+    const { http } = await import("@bytecodealliance/preview2-shim");
+    const { Fields } = http.types;
+    const encoder = new TextEncoder();
+
+    // valid set on a new key must succeed (regression for #1503)
+    const fields = Fields.fromList([]);
+    fields.set("content-type", [encoder.encode("text/plain; charset=utf-8")]);
+
+    const entries = fields.entries();
+    assert.strictEqual(entries.length, 1);
+    assert.strictEqual(entries[0][0], "content-type");
+    assert.deepEqual(entries[0][1], encoder.encode("text/plain; charset=utf-8"));
+  });
+
+  test("Fields.set replaces existing values", async () => {
+    const { http } = await import("@bytecodealliance/preview2-shim");
+    const { Fields } = http.types;
+    const encoder = new TextEncoder();
+
+    const fields = Fields.fromList([["content-type", encoder.encode("text/plain")]]);
+    fields.set("content-type", [encoder.encode("application/json")]);
+
+    const entries = fields.entries();
+    assert.strictEqual(entries.length, 1);
+    assert.deepEqual(entries[0][1], encoder.encode("application/json"));
+  });
+
+  test("Fields.set with an empty values list registers the key with no entries", async () => {
+    // The fix introduces a new else-branch that initializes
+    // `this.#table.set(lowercased, [])` for new keys. Calling set with an
+    // empty values list exercises that branch without pushing any entry,
+    // so this locks in the resulting state.
+    const { http } = await import("@bytecodealliance/preview2-shim");
+    const { Fields } = http.types;
+
+    const fields = Fields.fromList([]);
+    fields.set("x-foo", []);
+
+    assert.strictEqual(fields.has("x-foo"), true);
+    assert.deepEqual(fields.get("x-foo"), []);
+    assert.strictEqual(fields.entries().length, 0);
+  });
+
+  test("Fields.set throws immutable when fields are locked", async () => {
+    const { http } = await import("@bytecodealliance/preview2-shim");
+    const { Fields, OutgoingRequest } = http.types;
+    const encoder = new TextEncoder();
+
+    // OutgoingRequest's constructor locks the Fields passed in.
+    const hdrs = Fields.fromList([]);
+    new OutgoingRequest(hdrs);
+
+    throws(
+      () => hdrs.set("content-type", [encoder.encode("text/plain")]),
+      (err) => err?.tag === "immutable",
+    );
+  });
+
+  test("Fields.set throws invalid-syntax for an invalid name", async () => {
+    const { http } = await import("@bytecodealliance/preview2-shim");
+    const { Fields } = http.types;
+    const encoder = new TextEncoder();
+
+    const fields = Fields.fromList([]);
+    throws(
+      // names with spaces are rejected by node:http's validateHeaderName
+      () => fields.set("bad header", [encoder.encode("ok value")]),
+      (err) => err?.tag === "invalid-syntax",
+    );
+  });
+
+  test("Fields.set throws invalid-syntax for an invalid value", async () => {
+    const { http } = await import("@bytecodealliance/preview2-shim");
+    const { Fields } = http.types;
+    const encoder = new TextEncoder();
+
+    const fields = Fields.fromList([]);
+    throws(
+      // values containing CR/LF are rejected by node:http's validateHeaderValue
+      () => fields.set("x-foo", [encoder.encode("bad\nvalue")]),
+      (err) => err?.tag === "invalid-syntax",
+    );
+  });
+
+  test("Fields.set throws forbidden for restricted header names", async () => {
+    const { http } = await import("@bytecodealliance/preview2-shim");
+    const { Fields } = http.types;
+    const encoder = new TextEncoder();
+
+    // _forbiddenHeaders is { connection, keep-alive, host } (lowercased),
+    // so the input is matched case-insensitively.
+    for (const name of ["Connection", "Keep-Alive", "Host"]) {
+      const fields = Fields.fromList([]);
+      throws(
+        () => fields.set(name, [encoder.encode("x")]),
+        (err) => err?.tag === "forbidden",
+        `expected forbidden for ${name}`,
+      );
+    }
+  });
+
   test(
     "WASI HTTP",
     testWithGCWrap(async () => {


### PR DESCRIPTION
Fixes #1503.

## Changes

`packages/preview2-shim/lib/nodejs/http.js` — port the `Fields.set` structure from `lib/browser/http.js`:

- Drop the unconditional `throw { tag: "invalid-syntax" }` placed inside the values loop after the `validateHeaderValue` try/catch.
- Change `const tableEntries` to `let` so the new branch can reassign.
- Move `tableEntries.splice(...)` inside the `if (tableEntries)` guard (was previously outside, crashing with `TypeError` for any new key once the unconditional throw was bypassed).
- Add an `else` branch that initializes `this.#table.set(lowercased, [])` before the subsequent push loop.

`packages/preview2-shim/test/test.js` — seven regression tests, each covering a distinct branch of `Fields.set`. Both green-path tests were verified TDD-style (RED with the bug present, GREEN with the fix):

- `Fields.set on a fresh Fields` — new-key path, single value (regression for #1503).
- `Fields.set replaces existing values` — existing-key path through the splice branch.
- `Fields.set with an empty values list registers the key with no entries` — locks in the behavior of the new else-branch when `values` is empty.
- `Fields.set throws immutable when fields are locked` — verifies the immutable guard against a Fields locked via `OutgoingRequest`.
- `Fields.set throws invalid-syntax for an invalid name` — `validateHeaderName` rejection path.
- `Fields.set throws invalid-syntax for an invalid value` — `validateHeaderValue` rejection path (one element of `values` contains an invalid byte).
- `Fields.set throws forbidden for restricted header names` — `_forbiddenHeaders` (case-insensitive) for Connection / Keep-Alive / Host.

Tests use `Fields.fromList([])` to mirror the construction style from `lib/browser/http.js` tests.

## Open question: browser-side tests

Should this PR also add the equivalent `Fields.set` tests to `packages/preview2-shim/test/browser.js`?

State of the browser-side tests today:

- `lib/browser/http.js`'s `Fields.set` implementation is structurally correct (it's the reference we ported from), so the bug being fixed here does not exist on the browser target.
- However, `test/browser.js` only exercises `Fields.set` once (L919, for the `immutable` error case). The success paths (new-key / replace / empty values) and the other error variants (`invalid-syntax`, `forbidden`) on `Fields.set` are not covered there either.

Trade-offs:

- **Adding parity now** broadens this PR but gives symmetric coverage across both targets.
- **Leaving it out** keeps this PR focused on the nodejs bug; a follow-up issue can track adding equivalent browser-side coverage. Since the browser implementation is not buggy today, this is purely coverage extension rather than regression repair.

I lean toward leaving the browser side as-is in this PR and filing a follow-up issue, but happy to add the browser tests here if you'd prefer. Please advise.

## Test plan

- [x] `npm test --workspace=@bytecodealliance/preview2-shim` locally: 60/61 pass (the remaining failure is `WASI Sockets (TCP) > tcp.connect()`, which is unrelated and was already failing on `upstream/main` before this change in this local environment).
- [x] All seven new tests verified individually against the fix.
- [x] `npm run lint` / `npm run fmt:check` pass locally (oxlint / oxfmt darwin-arm64 native bindings required a manual `npm install --no-save @oxlint/binding-darwin-arm64 @oxfmt/binding-darwin-arm64` to work around an npm optional-deps resolution issue; the formatter then made one small whitespace change which is included in this commit).
