### PR TITLE
chore(jco): update componentizejs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -189,13 +189,13 @@ jobs:
       # NOTE: We can stop pinning the version of puppeteer when the version that the mac atttempts to use
       # syncs up (right now newest is 148.0.7778.178, but puppeteer will attempt to use 148.0.7778.97)
       - name: Install puppeteer (pinned)
-        if: ${{ startsWith(runner.os, 'macos') && matrix.node == 'latest' }}
+        if: ${{ matrix.node == 'latest' }}
         run: |
           export PUPPETEER_VERSION=148.0.7778.97
           pnpm run test:setup:puppeteer
 
       - name: Install puppeteer
-        if: ${{ !startsWith(runner.os, 'macos') || matrix.node != 'latest' }}
+        if: ${{ matrix.node != 'latest' }}
         run: |
           pnpm run test:setup:puppeteer
 

--- a/packages/jco-std/package.json
+++ b/packages/jco-std/package.json
@@ -88,7 +88,7 @@
     "prepack": "pnpm run build"
   },
   "devDependencies": {
-    "@bytecodealliance/componentize-js": "^0.20.0",
+    "@bytecodealliance/componentize-js": "^0.21.0",
     "@bytecodealliance/componentize-js-0-19-3": "npm:@bytecodealliance/componentize-js@^0.19.3",
     "@bytecodealliance/jco-transpile": "^0.1.1",
     "@bytecodealliance/preview2-shim": "^0.17.5",

--- a/packages/jco/package.json
+++ b/packages/jco/package.json
@@ -74,7 +74,7 @@
         "prepack": "cargo xtask build release"
     },
     "dependencies": {
-        "@bytecodealliance/componentize-js": "^0.20.0",
+        "@bytecodealliance/componentize-js": "^0.21.0",
         "@bytecodealliance/componentize-js-0-19-3": "npm:@bytecodealliance/componentize-js@^0.19.3",
         "@bytecodealliance/preview2-shim": "^0.17.9",
         "@bytecodealliance/preview3-shim": "workspace:^0.1.0",

--- a/packages/preview2-shim/package.json
+++ b/packages/preview2-shim/package.json
@@ -57,7 +57,7 @@
     "test": "vitest run -c test/vitest.ts"
   },
   "devDependencies": {
-    "@bytecodealliance/componentize-js": "0.20.0",
+    "@bytecodealliance/componentize-js": "0.21.0",
     "@bytecodealliance/jco": "1.15.2",
     "mime": "^4.0.7",
     "puppeteer": "^24.43.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -239,8 +239,8 @@ importers:
   packages/jco:
     dependencies:
       '@bytecodealliance/componentize-js':
-        specifier: ^0.20.0
-        version: 0.20.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.21.0
+        version: 0.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@bytecodealliance/componentize-js-0-19-3':
         specifier: npm:@bytecodealliance/componentize-js@^0.19.3
         version: '@bytecodealliance/componentize-js@0.19.3'
@@ -309,8 +309,8 @@ importers:
   packages/jco-std:
     devDependencies:
       '@bytecodealliance/componentize-js':
-        specifier: ^0.20.0
-        version: 0.20.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^0.21.0
+        version: 0.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@bytecodealliance/componentize-js-0-19-3':
         specifier: npm:@bytecodealliance/componentize-js@^0.19.3
         version: '@bytecodealliance/componentize-js@0.19.3'
@@ -361,8 +361,8 @@ importers:
   packages/preview2-shim:
     devDependencies:
       '@bytecodealliance/componentize-js':
-        specifier: 0.20.0
-        version: 0.20.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: 0.21.0
+        version: 0.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@bytecodealliance/jco':
         specifier: 1.15.2
         version: 1.15.2
@@ -411,6 +411,10 @@ packages:
 
   '@bytecodealliance/componentize-js@0.20.0':
     resolution: {integrity: sha512-JPRYUTD8v1QUsZ5eqhCtQR7amOTugjV2ofSjFv1/zAGksf4AZUoCFYiKTQ61E+hKUVNJKIdYLOw+stGqAL9qAg==}
+    hasBin: true
+
+  '@bytecodealliance/componentize-js@0.21.0':
+    resolution: {integrity: sha512-Av/XS3bJXE812P/bff3qtrJmehpgD0niK2A0fF3YIdM+jOD6E+mFrxOmuAgaIR0GNkpnm03+GE3ttt/+muqyCQ==}
     hasBin: true
 
   '@bytecodealliance/jco-std@0.1.3':
@@ -3379,6 +3383,17 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  '@bytecodealliance/componentize-js@0.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@bytecodealliance/jco': 1.17.6
+      '@bytecodealliance/weval': 0.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@bytecodealliance/wizer': 10.0.0
+      es-module-lexer: 1.7.0
+      oxc-parser: 0.76.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   '@bytecodealliance/jco-std@0.1.3': {}
 
   '@bytecodealliance/jco-transpile@0.1.3':
@@ -3422,7 +3437,7 @@ snapshots:
 
   '@bytecodealliance/jco@file:packages/jco(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@bytecodealliance/componentize-js': 0.20.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@bytecodealliance/componentize-js': 0.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3'
       '@bytecodealliance/preview2-shim': 0.17.9
       '@bytecodealliance/preview3-shim': link:packages/preview3-shim

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,3 +26,6 @@ packages:
   - examples/components/ts-resource-import
   - examples/components/typegen-async-export
   - examples/components/webidl-book-library
+
+minimumReleaseAgeExclude:
+  - '@bytecodealliance/componentize-js@0.21.0'


### PR DESCRIPTION
NOTE: we can update the version and merge this once the upstream release PR merges https://github.com/bytecodealliance/ComponentizeJS/pull/341 (and the new version of `componentize-js` is released)