### PR TITLE
fix(bindgen): lift imported own handles via captureTable

### DIFF
--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -5227,6 +5227,7 @@ pub fn gen_flat_lift_fn_js_expr(
             instantiator.add_intrinsic(Intrinsic::Lift(LiftIntrinsic::LiftFlatOwn));
             instantiator.add_intrinsic(Intrinsic::JsHelper(JsHelperIntrinsic::EmptyFunc));
             instantiator.add_intrinsic(Intrinsic::SymbolResourceHandle);
+            instantiator.add_intrinsic(Intrinsic::SymbolResourceRep);
             instantiator.add_intrinsic(Intrinsic::SymbolDispose);
             instantiator.add_intrinsic(Intrinsic::Resource(ResourceIntrinsic::ResourceTableRemove));
             instantiator.add_intrinsic(Intrinsic::Resource(ResourceIntrinsic::ResourceTableFlag));
@@ -5264,8 +5265,8 @@ pub fn gen_flat_lift_fn_js_expr(
                         ),
 
                         // Resource type was found in either resource_exports or extra provided resource map
-                        (Some(ResourceTable { data, .. }), _)
-                        | (_, Some(ResourceTable { data, .. })) => match data {
+                        (Some(ResourceTable { imported, data }), _)
+                        | (_, Some(ResourceTable { imported, data })) => match data {
                             ResourceData::Guest { .. } => {
                                 unimplemented!(
                                     "owned resources created by guests should must have host-side data"
@@ -5273,9 +5274,9 @@ pub fn gen_flat_lift_fn_js_expr(
                             }
                             ResourceData::Host {
                                 tid,
+                                rid,
                                 local_name,
                                 dtor_name,
-                                ..
                             } => {
                                 let empty_func = JsHelperIntrinsic::EmptyFunc.name();
                                 let symbol_resource_handle = Intrinsic::SymbolResourceHandle.name();
@@ -5285,43 +5286,66 @@ pub fn gen_flat_lift_fn_js_expr(
                                 let tid = tid.as_u32();
                                 let rsc_flag = ResourceIntrinsic::ResourceTableFlag.name();
 
-                                let dtor_setup_js = dtor_name
-                                .as_ref()
-                                .map(|dtor|
-                                     format!(
-                                         r#"
-                                           Object.defineProperty(
-                                               resourceObj,
-                                               {symbol_dispose},
-                                               {{
-                                                   writable: true,
-                                                   value: function() {{
-                                                       finalizationRegistry{tid}.unregister(resourceObj);
-                                                       {rsc_table_remove}(handleTable{tid}, handle);
-                                                       resourceObj[{symbol_dispose}] = {empty_func};
-                                                       resourceObj[{symbol_resource_handle}] = undefined;
-                                                       {dtor}(handleTable{tid}[(handle << 1) + 1] & ~{rsc_flag});
-                                                   }}
-                                              }}
-                                          );
-                                    "#
-                                     )
-                                ).unwrap_or_default();
+                                // Mirrors `Instruction::HandleLift` in `function_bindgen.rs`:
+                                let create_resource_fn_js = if *imported {
+                                    let symbol_resource_rep = Intrinsic::SymbolResourceRep.name();
+                                    let rid = rid.as_u32();
+                                    format!(
+                                        r#"
+                                      (handle) => {{
+                                          const rep = handleTable{tid}[(handle << 1) + 1] & ~{rsc_flag};
+                                          let resourceObj = captureTable{rid}.get(rep);
+                                          if (!resourceObj) {{
+                                              resourceObj = Object.create({local_name}.prototype);
+                                              Object.defineProperty(resourceObj, {symbol_resource_handle}, {{ writable: true, value: handle }});
+                                              Object.defineProperty(resourceObj, {symbol_resource_rep}, {{ writable: true, value: rep }});
+                                          }} else {{
+                                              captureTable{rid}.delete(rep);
+                                          }}
+                                          {rsc_table_remove}(handleTable{tid}, handle);
+                                          return resourceObj;
+                                      }}
+                                     "#
+                                    )
+                                } else {
+                                    let dtor_setup_js = dtor_name
+                                    .as_ref()
+                                    .map(|dtor|
+                                         format!(
+                                             r#"
+                                               Object.defineProperty(
+                                                   resourceObj,
+                                                   {symbol_dispose},
+                                                   {{
+                                                       writable: true,
+                                                       value: function() {{
+                                                           finalizationRegistry{tid}.unregister(resourceObj);
+                                                           {rsc_table_remove}(handleTable{tid}, handle);
+                                                           resourceObj[{symbol_dispose}] = {empty_func};
+                                                           resourceObj[{symbol_resource_handle}] = undefined;
+                                                           {dtor}(handleTable{tid}[(handle << 1) + 1] & ~{rsc_flag});
+                                                       }}
+                                                  }}
+                                              );
+                                        "#
+                                         )
+                                    ).unwrap_or_default();
 
-                                let create_resource_fn_js = format!(
-                                    r#"
-                                  (handle) => {{
-                                      const resourceObj = Object.create({local_name}.prototype);
-                                      Object.defineProperty(resourceObj, {symbol_resource_handle}, {{
-                                          writable: true,
-                                          value: handle,
-                                      }});
-                                      finalizationRegistry{tid}.register(resourceObj, handle, resourceObj);
-                                      {dtor_setup_js}
-                                      return resourceObj;
-                                  }}
-                                 "#
-                                );
+                                    format!(
+                                        r#"
+                                      (handle) => {{
+                                          const resourceObj = Object.create({local_name}.prototype);
+                                          Object.defineProperty(resourceObj, {symbol_resource_handle}, {{
+                                              writable: true,
+                                              value: handle,
+                                          }});
+                                          finalizationRegistry{tid}.register(resourceObj, handle, resourceObj);
+                                          {dtor_setup_js}
+                                          return resourceObj;
+                                      }}
+                                     "#
+                                    )
+                                };
 
                                 (local_name.to_string(), create_resource_fn_js)
                             }

--- a/crates/test-components/src/bin/async_return_imported_resource.rs
+++ b/crates/test-components/src/bin/async_return_imported_resource.rs
@@ -1,0 +1,26 @@
+//! Regression component for the bindgen imported-own lift fix.
+
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "async-return-imported-resource",
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::return_imported_resource_fns::Guest;
+use bindings::jco::test_components::resources::ExampleResource;
+
+struct Component;
+
+impl Guest for Component {
+    async fn get_resource_result(id: u32) -> Result<ExampleResource, String> {
+        Ok(ExampleResource::new(id))
+    }
+
+    async fn get_resource(id: u32) -> ExampleResource {
+        ExampleResource::new(id)
+    }
+}
+
+fn main() {}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -267,6 +267,17 @@ world future-tx {
   export get-future-async;
 }
 
+interface return-imported-resource-fns {
+  use resources.{example-resource};
+  get-resource: async func(id: u32) -> example-resource;
+  get-resource-result: async func(id: u32) -> result<example-resource, string>;
+}
+
+world async-return-imported-resource {
+  import resources;
+  export return-imported-resource-fns;
+}
+
 interface sleep-post-return {
   run: async func(sleep-time-millis: u64);
 }

--- a/packages/jco/test/p3/async.js
+++ b/packages/jco/test/p3/async.js
@@ -122,4 +122,82 @@ suite("Async (WASI P3)", () => {
 
         await cleanup();
     });
+
+    test("async return of imported owned resource", async () => {
+        class ExampleResource {
+            constructor(id) {
+                this.id = id;
+            }
+            getId() {
+                return this.id;
+            }
+        }
+
+        const { instance, cleanup } = await setupAsyncTest({
+            asyncMode: "jspi",
+            component: {
+                path: join(LOCAL_TEST_COMPONENTS_DIR, "async-return-imported-resource.wasm"),
+                imports: {
+                    ...new WASIShim().getImportObject(),
+                    "jco:test-components/resources": { ExampleResource },
+                },
+            },
+            jco: {
+                transpile: {
+                    extraArgs: {
+                        asyncExports: ["jco:test-components/return-imported-resource-fns#get-resource-result"],
+                    },
+                },
+            },
+        });
+
+        const exported = instance["jco:test-components/return-imported-resource-fns"];
+        assert.instanceOf(exported.getResourceResult, AsyncFunction);
+
+        const resource = await exported.getResourceResult(42);
+        assert.instanceOf(resource, ExampleResource);
+        assert.strictEqual(resource.getId(), 42);
+
+        await cleanup();
+    });
+
+    // TODO(tandr): this test currently fails and needs fixes in wit-bindgen-core:
+    // https://github.com/bytecodealliance/wit-bindgen/pull/1614
+    test.skip("async return of bare imported owned resource", async () => {
+        class ExampleResource {
+            constructor(id) {
+                this.id = id;
+            }
+            getId() {
+                return this.id;
+            }
+        }
+
+        const { instance, cleanup } = await setupAsyncTest({
+            asyncMode: "jspi",
+            component: {
+                path: join(LOCAL_TEST_COMPONENTS_DIR, "async-return-imported-resource.wasm"),
+                imports: {
+                    ...new WASIShim().getImportObject(),
+                    "jco:test-components/resources": { ExampleResource },
+                },
+            },
+            jco: {
+                transpile: {
+                    extraArgs: {
+                        asyncExports: ["jco:test-components/return-imported-resource-fns#get-resource"],
+                    },
+                },
+            },
+        });
+
+        const exported = instance["jco:test-components/return-imported-resource-fns"];
+        assert.instanceOf(exported.getResource, AsyncFunction);
+
+        const resource = await exported.getResource(7);
+        assert.instanceOf(resource, ExampleResource);
+        assert.strictEqual(resource.getId(), 7);
+
+        await cleanup();
+    });
 });


### PR DESCRIPTION
This fixes issue with p3 http handlers throwing:

```
ReferenceError: finalizationRegistry{N} is not defined
```

For `InterfaceType::Own` lift  `ensure_resource_table` only declares `finalizationRegistry{tid}` for guest defined resources and imported resources are tracked by `captureTable{rid}` instead. The pathc just mirrors the logic for `Instruction::HandleLift` from function_bindgen.rs file.