### PR TITLE
test(jco): run remaining p3 http fixtures

### DIFF
--- a/packages/jco/test/p3/fixtures-handler.js
+++ b/packages/jco/test/p3/fixtures-handler.js
@@ -1,15 +1,42 @@
-import { suite, test } from "vitest";
+import { env as processEnv } from "node:process";
+
+import { suite, test, beforeAll, afterAll } from "vitest";
+import { _setHandler } from "@bytecodealliance/preview3-shim/http";
 
 import { P3_HANDLER_RUN_FIXTURES, fixtureTestName, setupP3HandlerFixture } from "./helpers/fixtures.js";
-import { runHandlerFixture } from "./helpers/http.js";
+import { createEchoHandler, runHandlerFixture, startP3HttpServer } from "./helpers/http.js";
 
 suite("P3 handler fixtures", () => {
+    let server;
+    let previousHttpServer;
+    let previousHandler;
+
+    beforeAll(async () => {
+        server = await startP3HttpServer();
+        previousHttpServer = processEnv.HTTP_SERVER;
+        processEnv.HTTP_SERVER = server.address;
+        previousHandler = _setHandler(createEchoHandler());
+    });
+
+    afterAll(async () => {
+        if (previousHttpServer === undefined) {
+            delete processEnv.HTTP_SERVER;
+        } else {
+            processEnv.HTTP_SERVER = previousHttpServer;
+        }
+        _setHandler(previousHandler);
+        await server?.cleanup();
+    });
+
     for (const fixture of P3_HANDLER_RUN_FIXTURES) {
         const run = fixture.failing ? test.skip : test.concurrent;
         run(`invoke ${fixtureTestName(fixture)}`, async () => {
+            const context = { server };
+            const outbound = typeof fixture.outbound === "function" ? fixture.outbound(context) : fixture.outbound;
+            const expect = typeof fixture.expect === "function" ? fixture.expect(context) : fixture.expect;
             const { esModule, cleanup } = await setupP3HandlerFixture(fixture);
             try {
-                await runHandlerFixture({ esModule, outbound: fixture.outbound, expect: fixture.expect });
+                await runHandlerFixture({ esModule, outbound, expect });
             } finally {
                 await cleanup?.();
             }

--- a/packages/jco/test/p3/helpers/chain-http.js
+++ b/packages/jco/test/p3/helpers/chain-http.js
@@ -1,0 +1,3 @@
+import { handler } from "@bytecodealliance/preview3-shim/http";
+
+export const handle = handler.handle;

--- a/packages/jco/test/p3/helpers/fixtures.js
+++ b/packages/jco/test/p3/helpers/fixtures.js
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import { P3_COMPONENT_FIXTURES_DIR } from "../../common.js";
 import { setupAsyncTest } from "../../helpers.js";
 
+const CHAIN_HTTP_HELPER_MODULE = new URL("./chain-http.js", import.meta.url).href;
 const P3_CLI_FIXTURE_OUTPUT_DIR = fileURLToPath(new URL("../../output/p3-cli-fixtures", import.meta.url));
 const P3_HANDLER_FIXTURE_OUTPUT_DIR = fileURLToPath(new URL("../../output/p3-handler-fixtures", import.meta.url));
 
@@ -50,15 +51,22 @@ export const P3_CLI_RUN_FIXTURES = [
     { path: "sockets/p3-sockets-tcp-streams.wasm", failing: true },
 ];
 
+function withExtraHeaders(payload, headers) {
+    return { ...payload, headers: { ...payload.headers, ...headers } };
+}
+
 const REQUEST = {
     headers: { foo: "bar" },
     body: "And the mome raths outgrabe",
     trailers: { fizz: "buzz" },
 };
 
-function withExtraHeaders(payload, headers) {
-    return { ...payload, headers: { ...payload.headers, ...headers } };
-}
+const POST_REQUEST = {
+    ...REQUEST,
+    method: "POST",
+    pathWithQuery: "/post",
+    headers: { ...REQUEST.headers, "content-length": String(Buffer.byteLength(REQUEST.body)) },
+};
 
 export const P3_HANDLER_RUN_FIXTURES = [
     {
@@ -80,10 +88,31 @@ export const P3_HANDLER_RUN_FIXTURES = [
         path: "cli/p3-cli-serve-hello-world.wasm",
         expect: { body: "Hello, WASI!" },
     },
-    // TODO(tandr): cli/p3-cli-serve-sleep.wasm
-    // TODO(tandr): http/p3-http-middleware.wasm
-    // TODO(tandr): http/p3-http-middleware-with-chain.wasm
-    // TODO(tandr): http/p3-http-proxy.wasm
+    {
+        path: "http/p3-http-middleware.wasm",
+        outbound: REQUEST,
+        expect: REQUEST,
+    },
+    {
+        path: "http/p3-http-middleware-with-chain.wasm",
+        outbound: REQUEST,
+        expect: REQUEST,
+        map: { "local:local/chain-http": CHAIN_HTTP_HELPER_MODULE },
+    },
+    {
+        path: "http/p3-http-proxy.wasm",
+        outbound: ({ server }) =>
+            withExtraHeaders(POST_REQUEST, {
+                url: `http://${server.address}/proxy`,
+            }),
+        expect: {
+            body: REQUEST.body,
+            headers: {
+                "x-wasmtime-test-method": "POST",
+                "x-wasmtime-test-uri": "/proxy",
+            },
+        },
+    },
 ];
 
 export function fixtureTestName(fixture) {
@@ -101,7 +130,6 @@ function outputDirFor(fixture) {
 async function setupP3Fixture({ fixture, outputRootDir, asyncExports, preopen = false }) {
     const outputDir = join(outputRootDir, outputDirFor(fixture));
     const preopenDir = preopen ? join(outputDir, "preopen") : null;
-
     await rm(outputDir, { recursive: true, force: true });
     await mkdir(preopenDir ?? outputDir, { recursive: true });
 
@@ -119,6 +147,7 @@ async function setupP3Fixture({ fixture, outputRootDir, asyncExports, preopen = 
                     extraArgs: {
                         instantiation: null,
                         asyncExports,
+                        map: fixture.map,
                     },
                 },
             },

--- a/packages/jco/test/p3/helpers/http.js
+++ b/packages/jco/test/p3/helpers/http.js
@@ -1,4 +1,5 @@
 import { createServer } from "node:http";
+import { Buffer } from "node:buffer";
 
 import { assert } from "vitest";
 
@@ -63,6 +64,33 @@ export async function startP3HttpServer() {
                 server.closeAllConnections?.();
                 server.close((err) => (err ? reject(err) : resolve()));
             }),
+    };
+}
+
+export function createEchoHandler() {
+    return {
+        async handle(request) {
+            const { rx: requestResultRx } = future();
+            const [bodyReader, trailerReader] = Request.consumeBody(request, requestResultRx);
+            const headers = request.getHeaders().copyAll();
+            const body = bodyReader ? await bodyReader.readAll() : Buffer.alloc(0);
+            const trailers = await trailerReader.read();
+
+            const { tx: bodyTx, rx: bodyRx } = stream();
+            const { tx: trailersTx, rx: trailersRx } = future();
+            const [response] = Response.new(Fields.fromList(headers), bodyRx, trailersRx);
+
+            const pump = (async () => {
+                if (body.length > 0) {
+                    await bodyTx.write(body);
+                }
+                await bodyTx.close();
+                await trailersTx.write(trailers);
+            })();
+
+            pump.catch(() => {});
+            return response;
+        },
     };
 }
 

--- a/packages/preview3-shim/lib/nodejs/http.js
+++ b/packages/preview3-shim/lib/nodejs/http.js
@@ -9,6 +9,23 @@ export * from "./http/request.js";
 export * from "./http/response.js";
 export * from "./http/server.js";
 
+let currentHandler = null;
+
+export const handler = {
+  handle(request) {
+    if (!currentHandler) {
+      throw new Error("wasi:http/handler import is not configured");
+    }
+    return currentHandler.handle(request);
+  },
+};
+
+export function _setHandler(nextHandler) {
+  const previous = currentHandler;
+  currentHandler = nextHandler;
+  return previous;
+}
+
 export const types = {
   Fields,
   Request,

--- a/packages/preview3-shim/types/http.d.ts
+++ b/packages/preview3-shim/types/http.d.ts
@@ -1,3 +1,4 @@
 export * as client from "./interfaces/wasi-http-client";
-export type * as handler from "./interfaces/wasi-http-handler.d.ts";
+export * as handler from "./interfaces/wasi-http-handler";
 export * as types from "./interfaces/wasi-http-types";
+export function _setHandler(nextHandler: typeof handler | null): typeof handler | null;


### PR DESCRIPTION
This adds last 3 p3 http handler based tests to regression:
- http/p3-http-middleware.wasm
- http/p3-http-middleware-with-chain.wasm
- http/p3-http-proxy.wasm