### PR TITLE
fix(bindgen): propagate host stream drop/cancel

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -3129,6 +3129,7 @@ impl Bindgen for FunctionBindgen<'_> {
                     .expect("unexpectedly missing StreamLower arg");
                 let async_iterator_symbol = self.intrinsic(Intrinsic::SymbolAsyncIterator);
                 let iterator_symbol = self.intrinsic(Intrinsic::SymbolIterator);
+                let symbol_dispose = self.intrinsic(Intrinsic::SymbolDispose);
                 let external_readable_stream_class =
                     self.intrinsic(Intrinsic::PlatformReadableStreamClass);
                 let get_or_create_async_state_fn = self.intrinsic(Intrinsic::Component(
@@ -3282,14 +3283,17 @@ impl Bindgen for FunctionBindgen<'_> {
                         if ({async_iterator_symbol} in {stream_arg}) {{
                             let asyncIterator = {stream_arg}[{async_iterator_symbol}]();
                             readFn{tmp} = () => asyncIterator.next();
+                            readFn{tmp}.drop = (reason) => asyncIterator.return?.(reason) ?? {stream_arg}[{symbol_dispose}]?.();
                         }} else if ({iterator_symbol} in {stream_arg}) {{
                             let iterator = {stream_arg}[{iterator_symbol}]();
                             readFn{tmp} = async () => iterator.next();
+                            readFn{tmp}.drop = (reason) => iterator.return?.(reason) ?? {stream_arg}[{symbol_dispose}]?.();
                         }} else if ({stream_arg} instanceof {external_readable_stream_class}) {{
                             // At this point we're dealing with a readable stream that *somehow *does not*
                             // implement the async iterator protocol.
                             const lockedReader = {stream_arg}.getReader();
                             readFn{tmp} = () => lockedReader.read();
+                            readFn{tmp}.drop = (reason) => lockedReader.cancel(reason).finally(() => lockedReader.releaseLock());
                         }}
 
                         const hostInjectFn = {gen_stream_host_inject_fn}({{
@@ -3298,6 +3302,7 @@ impl Bindgen for FunctionBindgen<'_> {
                             readEnd: readEnd{tmp},
                         }});
                         readEnd{tmp}.setHostInjectFn(hostInjectFn);
+                        readEnd{tmp}.setHostDropFn(readFn{tmp}.drop);
 
                         const {lowered_stream_waitable_idx} = readEnd{tmp}.waitableIdx();
                     "#

--- a/crates/js-component-bindgen/src/intrinsics/lower.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lower.rs
@@ -1162,12 +1162,14 @@ impl LowerIntrinsic {
                                         elemMeta,
                                     }});
 
+                                    const readFn = {gen_read_fn_from_lowerable_stream_fn}(stream);
                                     const hostInjectFn = {gen_stream_host_inject_fn}({{
-                                        readFn: {gen_read_fn_from_lowerable_stream_fn}(stream),
+                                        readFn,
                                         hostWriteEnd: writeEnd,
                                         readEnd,
                                     }});
                                     readEnd.setHostInjectFn(hostInjectFn);
+                                    readEnd.setHostDropFn(readFn.drop);
 
                                     waitableIdx = readEnd.waitableIdx();
                                 }}

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -1409,6 +1409,14 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
         ])
     }
 
+    if args.intrinsics.contains(&Intrinsic::AsyncStream(
+        AsyncStreamIntrinsic::GenStreamHostInjectFn,
+    )) {
+        args.intrinsics.insert(Intrinsic::AsyncStream(
+            AsyncStreamIntrinsic::PendingValueQueueClass,
+        ));
+    }
+
     if args
         .intrinsics
         .contains(&Intrinsic::Lower(LowerIntrinsic::LowerFlatFuture))

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
@@ -1373,7 +1373,9 @@ impl AsyncFutureIntrinsic {
                     r#"
                       function {gen_host_inject_fn}(genArgs) {{
                           const {{ promise, hostWriteEnd, stringEncoding, getReallocFn }} = genArgs;
-
+                          if (promise instanceof Promise) {{
+                              promise.catch(() => {{}});
+                          }}
                           let done;
 
                           return async function generateFutureHostInject(args) {{

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -53,6 +53,9 @@ pub enum AsyncStreamIntrinsic {
     ///
     ExternalStreamClass,
 
+    /// The definition of the pending value queue used by host stream injection
+    PendingValueQueueClass,
+
     /// Create a new stream
     ///
     /// See: https://github.com/WebAssembly/component-model/blob/main/design/mvp/CanonicalABI.md#-canon-streamfuturenew
@@ -250,6 +253,7 @@ impl AsyncStreamIntrinsic {
             Self::StreamReadableEndClass => "StreamReadableEnd",
             Self::HostStreamClass => "HostStream",
             Self::ExternalStreamClass => "Stream",
+            Self::PendingValueQueueClass => "PendingValueQueue",
             Self::StreamNew => "streamNew",
             Self::StreamNewFromLift => "streamNewFromLift",
             Self::StreamRead => "streamRead",
@@ -863,7 +867,7 @@ impl AsyncStreamIntrinsic {
                             // (i.e. write #3 must wait on write #2, *not* write #1)
                             //
                             let newResult = {promise_with_resolvers_fn}();
-                            if (this.#result) {{
+                            if (this.#result && !this.#isHostOwned) {{
                                 try {{
                                     const p = this.#result.promise;
                                     this.#result = newResult;
@@ -897,7 +901,7 @@ impl AsyncStreamIntrinsic {
                                 buffer.setTarget(`host stream write buffer (id [${{bufferID}}], count [${{count}}], data len [${{data.length}}])`);
 
                                 let packedResult;
-                                packedResult = await this.copy({{
+                                const copyPromise = this.copy({{
                                     isAsync: true,
                                     count,
                                     bufferID,
@@ -905,6 +909,15 @@ impl AsyncStreamIntrinsic {
                                     eventCode: {async_event_code_enum}.STREAM_WRITE,
                                     componentIdx: -1,
                                 }});
+                                if (this.#isHostOwned && this.hasPendingEvent()) {{
+                                    // Host owned writes are just-in-time writes for an already pending guest read.
+                                    // The guest read path consumes the pending event, so waiting here can deadlock.
+                                    copyPromise.catch(err => reject(err));
+                                    this.#result = null;
+                                    resolve();
+                                    return await promise;
+                                }}
+                                packedResult = await copyPromise;
 
                                 // If we are dealing with a blocked component write operation, we do an immedaite wait
                                 // on the host side to pause the host until the write can be completed.
@@ -1129,6 +1142,8 @@ impl AsyncStreamIntrinsic {
 
                         // only populated for lowered (read) stream ends
                         #hostInjectFn;
+                        #hostDropFn;
+                        #hostCancelFn;
                         // only populated for the write side of a lowered read stream end
                         #isHostOwned;
 
@@ -1173,6 +1188,11 @@ impl AsyncStreamIntrinsic {
                             if (this.#hostInjectFn) {{ throw new Error('host injection fn is already set'); }}
                             this.#hostInjectFn = f;
                         }}
+                        setHostDropFn(f) {{
+                            if (this.#hostDropFn) {{ throw new Error('host drop fn is already set'); }}
+                            this.#hostDropFn = f;
+                        }}
+                        setHostCancelFn(f) {{ this.#hostCancelFn = f; }}
 
                         getElemMeta() {{ return {{...this.#elemMeta}}; }}
 
@@ -1209,15 +1229,36 @@ impl AsyncStreamIntrinsic {
 
                         cancel() {{
                             {debug_log_fn}('[{stream_end_class}#cancel()]');
-                            this.resetAndNotifyPending({stream_end_class}.CopyResult.CANCELLED);
+                            const completeCancel = () => {{
+                                if (this.isDropped()) {{ return; }}
+                                if (this.#hostCancelFn?.()) {{ return; }}
+                                const result = this.#pendingBufferMeta?.buffer?.processed > 0
+                                    ? {stream_end_class}.CopyResult.COMPLETED
+                                    : {stream_end_class}.CopyResult.CANCELLED;
+                                this.resetAndNotifyPending(result);
+                            }};
+                            if (this.#hostInjectFn) {{
+                                setTimeout(completeCancel, 0);
+                            }} else {{
+                                completeCancel();
+                            }}
                         }}
 
                         drop() {{
                             {debug_log_fn}('[{stream_end_class}#drop()]');
                             if (this.isDropped()) {{ return; }}
+                            if (this.#hostDropFn) {{
+                                Promise.resolve(this.#hostDropFn()).catch(err => {{
+                                    {debug_log_fn}('[{stream_end_class}#drop()] host drop failed', err);
+                                }});
+                                this.#hostDropFn = null;
+                            }}
                             super.drop();
                             if (this.#pendingBufferMeta) {{
-                                this.resetAndNotifyPending({stream_end_class}.CopyResult.DROPPED);
+                                const result = this.#pendingBufferMeta.buffer?.processed > 0
+                                    ? {stream_end_class}.CopyResult.COMPLETED
+                                    : {stream_end_class}.CopyResult.DROPPED;
+                                this.resetAndNotifyPending(result);
                             }}
                         }}
                     }}
@@ -1382,6 +1423,97 @@ impl AsyncStreamIntrinsic {
                 ));
             }
 
+            Self::PendingValueQueueClass => {
+                let pending_value_queue_class = self.name();
+
+                output.push_str(&format!(
+                    r#"
+                      class {pending_value_queue_class} {{
+                          #readFn;
+                          #elemMeta;
+                          #done = false;
+                          #sourceReadPromise = null;
+                          #chunks = [];
+                          #offset = 0;
+                          #length = 0;
+
+                          constructor(readFn, elemMeta) {{
+                              this.#readFn = readFn;
+                              this.#elemMeta = elemMeta;
+                          }}
+
+                          get length() {{ return this.#length; }}
+                          get done() {{ return this.#done; }}
+
+                          push(source) {{
+                              if (source.length === 0) {{ return 0; }}
+                              this.#chunks.push(source);
+                              this.#length += source.length;
+                              return source.length;
+                          }}
+
+                          appendReadValue(value) {{
+                              if (value === undefined) {{ return 0; }}
+                              if (this.#elemMeta.isNumeric) {{
+                                  if (value instanceof ArrayBuffer) {{
+                                      value = new Uint8Array(value);
+                                  }}
+                                  if (Array.isArray(value) || (ArrayBuffer.isView(value) && typeof value.length === 'number')) {{
+                                      return this.push(value);
+                                  }}
+                              }}
+                              return this.push([value]);
+                          }}
+
+                          async readSource() {{
+                              if (!this.#sourceReadPromise) {{
+                                  this.#sourceReadPromise = (async () => {{
+                                      const res = await this.#readFn();
+                                      const appended = this.appendReadValue(res.value);
+                                      this.#done = res.done;
+                                      return appended;
+                                  }})().finally(() => {{
+                                      this.#sourceReadPromise = null;
+                                  }});
+                              }}
+                              return this.#sourceReadPromise;
+                          }}
+
+                          prepend(source) {{
+                              if (source.length === 0) {{ return; }}
+                              if (this.#offset !== 0 && this.#chunks.length > 0) {{
+                                  this.#chunks[0] = this.#chunks[0].slice(this.#offset);
+                                  this.#offset = 0;
+                              }}
+                              this.#chunks.unshift(source);
+                              this.#length += source.length;
+                          }}
+
+                          drainInto(target, maxCount) {{
+                              let transferred = 0;
+                              let remaining = Math.min(maxCount, this.#length);
+                              while (remaining > 0) {{
+                                  const chunk = this.#chunks[0];
+                                  const transfer = Math.min(remaining, chunk.length - this.#offset);
+                                  for (let i = 0; i < transfer; i++) {{
+                                      target.push(chunk[this.#offset + i]);
+                                  }}
+                                  this.#offset += transfer;
+                                  this.#length -= transfer;
+                                  transferred += transfer;
+                                  remaining -= transfer;
+                                  if (this.#offset === chunk.length) {{
+                                      this.#chunks.shift();
+                                      this.#offset = 0;
+                                  }}
+                              }}
+                              return transferred;
+                          }}
+                      }}
+                    "#
+                ));
+            }
+
             // NOTE: this stream class is meant to be given to external users and can be passed along
             // to the outside world.
             //
@@ -1432,6 +1564,11 @@ impl AsyncStreamIntrinsic {
                         }}
 
                         [{symbol_async_iterator}]() {{ return this; }}
+
+                        async return() {{
+                            this[{symbol_dispose}]();
+                            return {{ done: true }};
+                        }}
 
                         async next() {{
                             {debug_log_fn}('[{external_stream_class_name}#next()]');
@@ -1880,6 +2017,7 @@ impl AsyncStreamIntrinsic {
                 let async_iterator_symbol = Intrinsic::SymbolAsyncIterator.name();
                 let iterator_symbol = Intrinsic::SymbolIterator.name();
                 let external_readable_stream_class = Intrinsic::PlatformReadableStreamClass.name();
+                let symbol_dispose = Intrinsic::SymbolDispose.name();
 
                 output.push_str(&format!(
                     r#"
@@ -1892,14 +2030,17 @@ impl AsyncStreamIntrinsic {
                           if ({async_iterator_symbol} in stream) {{
                               let asyncIterator = stream[{async_iterator_symbol}]();
                               readFn = () => asyncIterator.next();
+                              readFn.drop = (reason) => asyncIterator.return?.(reason) ?? stream[{symbol_dispose}]?.();
                           }} else if ({iterator_symbol} in stream) {{
                               let iterator = stream[{iterator_symbol}]();
                               readFn = async () => iterator.next();
+                              readFn.drop = (reason) => iterator.return?.(reason) ?? stream[{symbol_dispose}]?.();
                           }} else if (stream instanceof {external_readable_stream_class}) {{
                               // At this point we're dealing with a readable stream that *somehow *does not*
                               // implement the async iterator protocol.
                               const lockedReader = stream.getReader();
                               readFn = () => lockedReader.read();
+                              readFn.drop = (reason) => lockedReader.cancel(reason).finally(() => lockedReader.releaseLock());
                           }} else {{
                               throw new Error("invalid stream object, cannot generate read fn");
                           }}
@@ -1912,6 +2053,7 @@ impl AsyncStreamIntrinsic {
 
             Self::GenStreamHostInjectFn => {
                 let gen_host_inject_fn = self.name();
+                let pending_value_queue_class = Self::PendingValueQueueClass.name();
 
                 output.push_str(&format!(
                     r#"
@@ -1925,75 +2067,96 @@ impl AsyncStreamIntrinsic {
                               if (hostWriteEnd.hasPendingEvent()) {{ hostWriteEnd.getPendingEvent(); }}
                           }};
 
-                          let done = false;
-                          const pendingValues = [];
+                          const elemMeta = hostWriteEnd.getElemMeta();
+
+                          const pendingValues = new {pending_value_queue_class}(readFn, elemMeta);
 
                           return async function generatedStreamHostInject(args) {{
                               let {{ count }} = args;
                               if (count < 0) {{ throw new Error('invalid count'); }}
-                              if (count === 0) {{ return doNothingFn; }}
-                              if (readEnd.hasPendingEvent()) {{ return doNothingFn; }}
+                              if (readEnd.hasPendingEvent()) {{ return resetWriteEndToIdleFn; }}
 
                               if (hostWriteEnd.isDoneState()) {{
                                   return doNothingFn;
                               }}
 
                               const values = [];
-                              const elemMeta = hostWriteEnd.getElemMeta();
-
-                              const appendValues = (source) => {{
-                                  const transfer = Math.min(count, source.length);
-                                  for (let i = 0; i < transfer; i++) {{
-                                      values.push(source[i]);
-                                  }}
-                                  count -= transfer;
-                                  for (let i = transfer; i < source.length; i++) {{
-                                      pendingValues.push(source[i]);
-                                  }}
-                                  return source.length;
-                              }};
-
-                              const appendReadValue = (value) => {{
-                                  if (value === undefined) {{ return 0; }}
-                                  if (elemMeta.isNumeric) {{
-                                      if (value instanceof ArrayBuffer) {{
-                                          value = new Uint8Array(value);
-                                      }}
-                                      if (Array.isArray(value) || (ArrayBuffer.isView(value) && typeof value.length === 'number')) {{
-                                          return appendValues(value);
-                                      }}
-                                  }}
-                                  return appendValues([value]);
-                              }};
+                              const hasPendingReadBuffer = () => !!readEnd.getPendingBufferMeta?.().buffer;
 
                               const drainPendingValues = () => {{
-                                  const transfer = Math.min(count, pendingValues.length);
-                                  for (let i = 0; i < transfer; i++) {{
-                                      values.push(pendingValues[i]);
-                                  }}
-                                  pendingValues.splice(0, transfer);
-                                  count -= transfer;
+                                  count -= pendingValues.drainInto(values, count);
                               }};
 
+                              const writeValues = async (writeValues) => {{
+                                  const writePromise = hostWriteEnd.writeMany(writeValues);
+                                  if (hostWriteEnd.hasPendingEvent()) {{
+                                      void writePromise.catch(() => {{}});
+                                  }} else {{
+                                      await writePromise;
+                                  }}
+                                  resetWriteEndToIdleFn();
+                              }};
+
+                              const bail = () => {{
+                                  pendingValues.prepend(values);
+                                  return doNothingFn;
+                              }};
+
+                              readEnd.setHostCancelFn?.(() => {{
+                                  const buffer = readEnd.getPendingBufferMeta?.().buffer;
+                                  if (!buffer || pendingValues.length === 0) {{ return false; }}
+                                  const cancelValues = [];
+                                  pendingValues.drainInto(cancelValues, buffer.remaining());
+                                  if (cancelValues.length === 0) {{ return false; }}
+                                  const writePromise = hostWriteEnd.writeMany(cancelValues);
+                                  if (!hostWriteEnd.hasPendingEvent()) {{
+                                      pendingValues.prepend(cancelValues);
+                                      return false;
+                                  }}
+                                  void writePromise.catch(() => {{}});
+                                  resetWriteEndToIdleFn();
+                                  return true;
+                              }});
+
+                              if (!hasPendingReadBuffer()) {{ return doNothingFn; }}
+                              if (count === 0) {{
+                                  if (pendingValues.length === 0 && !pendingValues.done) {{
+                                      await pendingValues.readSource();
+                                      if (readEnd.hasPendingEvent() || !hasPendingReadBuffer()) {{ return doNothingFn; }}
+                                  }}
+                                  if (pendingValues.length > 0) {{
+                                      const readyValues = [];
+                                      pendingValues.drainInto(readyValues, 1);
+                                      await writeValues(readyValues);
+                                  }} else if (pendingValues.done) {{
+                                      hostWriteEnd.getPendingEvent();
+                                      hostWriteEnd.drop();
+                                  }}
+                                  return doNothingFn;
+                              }}
                               drainPendingValues();
 
-                              while (count > 0 && !done) {{
-                                  const res = await readFn();
-                                  const appended = appendReadValue(res.value);
-                                  done = res.done;
-                                  if (appended === 0 && !done) {{ count -= 1; }}
-                                  if (done) {{ break; }}
+                              while (count > 0 && !pendingValues.done) {{
+                                  const appended = await pendingValues.readSource();
+                                  if (readEnd.hasPendingEvent()) {{ return bail(); }}
+                                  if (!hasPendingReadBuffer()) {{ return bail(); }}
+                                  drainPendingValues();
+                                  if (appended === 0 && !pendingValues.done) {{ count -= 1; }}
+                                  if (pendingValues.done) {{ break; }}
                               }}
 
                               // Iterator provided `done: true` with no final value
-                              if (done && values.length === 0) {{
+                              if (pendingValues.done && values.length === 0 && pendingValues.length > 0 && hasPendingReadBuffer()) {{
+                                  drainPendingValues();
+                              }}
+                              if (pendingValues.done && values.length === 0) {{
                                   hostWriteEnd.getPendingEvent();
                                   hostWriteEnd.drop();
                                   return doNothingFn;
                               }}
 
-                              await hostWriteEnd.writeMany(values);
-                              resetWriteEndToIdleFn();
+                              if (!hasPendingReadBuffer()) {{ return bail(); }}
+                              await writeValues(values);
 
                               return doNothingFn;
                           }};

--- a/crates/test-components/src/bin/stream_concurrency.rs
+++ b/crates/test-components/src/bin/stream_concurrency.rs
@@ -8,7 +8,9 @@ mod bindings {
 
 use bindings::exports::jco::test_components::stream_concurrency_test;
 use bindings::jco::test_components::stream_concurrency_host;
-use wit_bindgen::StreamReader;
+use std::pin::pin;
+use std::task::{Context, Poll, Waker};
+use wit_bindgen::{StreamReader, StreamResult};
 
 struct Component;
 
@@ -26,6 +28,38 @@ impl stream_concurrency_test::Guest for Component {
                 stream_concurrency_host::signal();
             },
         );
+        values
+    }
+
+    async fn zero_read_after_cancel(mut rx: StreamReader<u8>) -> Vec<u8> {
+        let (status, buf) = {
+            let mut fut = pin!(rx.read(Vec::with_capacity(1)));
+            let mut cx = Context::from_waker(Waker::noop());
+            match fut.as_mut().poll(&mut cx) {
+                Poll::Ready(pair) => pair,
+                Poll::Pending => fut.cancel(),
+            }
+        };
+        assert_eq!(status, StreamResult::Cancelled);
+        assert!(buf.is_empty());
+
+        let ((status, buf), ()) = futures::join!(
+            async {
+                let pair = rx.read(Vec::new()).await;
+                stream_concurrency_host::zero_read_complete();
+                pair
+            },
+            async {
+                stream_concurrency_host::signal();
+            },
+        );
+        assert_eq!(status, StreamResult::Complete(0));
+        assert!(buf.is_empty());
+
+        let mut values = Vec::new();
+        while let Some(value) = rx.next().await {
+            values.push(value);
+        }
         values
     }
 }

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -308,10 +308,12 @@ world future-concurrency {
 
 interface stream-concurrency-host {
   signal: func();
+  zero-read-complete: func();
 }
 
 interface stream-concurrency-test {
   read-after-signal: async func(s: stream<u8>) -> list<u8>;
+  zero-read-after-cancel: async func(s: stream<u8>) -> list<u8>;
 }
 
 world stream-concurrency {

--- a/packages/jco/test/p3/deadlock-regressions.js
+++ b/packages/jco/test/p3/deadlock-regressions.js
@@ -63,6 +63,7 @@ suite("async scheduling regressions", () => {
                     ...new WASIShim().getImportObject(),
                     "jco:test-components/stream-concurrency-host": {
                         signal: () => signaled.resolve(),
+                        zeroReadComplete: () => {},
                     },
                 },
             },
@@ -71,6 +72,58 @@ suite("async scheduling regressions", () => {
         try {
             assert.deepEqual(
                 await instance["jco:test-components/stream-concurrency-test"].readAfterSignal(stream),
+                new Uint8Array([42]),
+            );
+        } finally {
+            await cleanup();
+        }
+    });
+
+    test("zero-length read after cancellation waits for host readiness", async () => {
+        const signaled = Promise.withResolvers();
+        let readStarted = false;
+        let signalCalled = false;
+        let yielded = false;
+
+        const stream = {
+            [Symbol.asyncIterator]() {
+                return {
+                    next: async () => {
+                        readStarted = true;
+                        await signaled.promise;
+                        if (yielded) {
+                            return { value: undefined, done: true };
+                        }
+                        yielded = true;
+                        return { value: 42, done: false };
+                    },
+                };
+            },
+        };
+
+        const { instance, cleanup } = await setupAsyncTest({
+            asyncMode: "jspi",
+            component: {
+                path: join(LOCAL_TEST_COMPONENTS_DIR, "stream-concurrency.wasm"),
+                imports: {
+                    ...new WASIShim().getImportObject(),
+                    "jco:test-components/stream-concurrency-host": {
+                        signal: () => {
+                            assert.isTrue(readStarted);
+                            signalCalled = true;
+                            signaled.resolve();
+                        },
+                        zeroReadComplete: () => {
+                            assert.isTrue(signalCalled);
+                        },
+                    },
+                },
+            },
+        });
+
+        try {
+            assert.deepEqual(
+                await instance["jco:test-components/stream-concurrency-test"].zeroReadAfterCancel(stream),
                 new Uint8Array([42]),
             );
         } finally {

--- a/packages/jco/test/p3/helpers/fixtures.js
+++ b/packages/jco/test/p3/helpers/fixtures.js
@@ -36,6 +36,7 @@ export const P3_CLI_RUN_FIXTURES = [
     { path: "sockets/p3-sockets-tcp-sample-application.wasm" },
     { path: "sockets/p3-sockets-tcp-sockopts.wasm" },
     { path: "sockets/p3-sockets-tcp-states.wasm" },
+    { path: "sockets/p3-sockets-tcp-streams.wasm" },
     { path: "sockets/p3-sockets-udp-bind.wasm" },
     { path: "sockets/p3-sockets-udp-connect.wasm" },
     { path: "sockets/p3-sockets-udp-receive.wasm" },
@@ -47,7 +48,6 @@ export const P3_CLI_RUN_FIXTURES = [
     { path: "http/p3-http-outbound-request-content-length.wasm", failing: true },
     { path: "http/p3-http-outbound-request-large-post.wasm", failing: true },
     { path: "http/p3-http-outbound-request-response-build.wasm" },
-    { path: "sockets/p3-sockets-tcp-streams.wasm", failing: true },
 ];
 
 const REQUEST = {

--- a/packages/preview3-shim/lib/nodejs/future.js
+++ b/packages/preview3-shim/lib/nodejs/future.js
@@ -52,6 +52,9 @@ export class FutureReader {
     if (!promise || typeof promise.then !== "function") {
       throw new Error("Provided future must be a Promise");
     }
+    if (promise instanceof Promise) {
+      promise.catch(() => {});
+    }
     this.#promise = promise;
   }
 

--- a/packages/preview3-shim/lib/nodejs/http/request.js
+++ b/packages/preview3-shim/lib/nodejs/http/request.js
@@ -231,7 +231,6 @@ export class Request {
     // Generated P3 futures are lazy thenables so we want to observe them now so early error paths don't hang.
     if (!(trailers instanceof FutureReader)) {
       const promise = Promise.resolve(trailers);
-      void promise.catch(() => {});
       trailers = new FutureReader(promise);
     }
 

--- a/packages/preview3-shim/lib/nodejs/http/response.js
+++ b/packages/preview3-shim/lib/nodejs/http/response.js
@@ -71,7 +71,6 @@ export class Response {
     // Generated P3 futures are lazy thenables so we want to observe them now so early error paths don't hang.
     if (!(trailers instanceof FutureReader)) {
       const promise = Promise.resolve(trailers);
-      void promise.catch(() => {});
       trailers = new FutureReader(promise);
     }
 

--- a/packages/preview3-shim/lib/nodejs/sockets/error.js
+++ b/packages/preview3-shim/lib/nodejs/sockets/error.js
@@ -20,6 +20,7 @@ export const ERROR_MAP = {
   ENONET: "remote-unreachable",
   ECONNREFUSED: "connection-refused",
   EPIPE: "connection-broken",
+  "write EPIPE": "connection-broken",
   ECONNRESET: "connection-reset",
   ECONNABORTED: "connection-aborted",
   EMSGSIZE: "datagram-too-large",

--- a/packages/preview3-shim/lib/nodejs/sockets/tcp.js
+++ b/packages/preview3-shim/lib/nodejs/sockets/tcp.js
@@ -13,6 +13,7 @@ import {
 } from "./address.js";
 
 let WORKER = null;
+const symbolDispose = Symbol.dispose || Symbol.for("dispose");
 function worker() {
   return (WORKER ??= new ResourceWorker(new URL("../workers/tcp-worker.js", import.meta.url)));
 }
@@ -61,6 +62,8 @@ export class TcpSocket {
   #socketId = null;
   #family = null;
   #state = "unbound";
+  #sendStarted = false;
+  #receiveStarted = false;
   #options = {
     // defaults per https://nodejs.org/docs/latest/api/net.html#socketsetkeepaliveenable-initialdelay
     keepAliveEnabled: false,
@@ -270,6 +273,10 @@ export class TcpSocket {
     if (this.#state !== STATE.CONNECTED) {
       throw new SocketError("invalid-state");
     }
+    if (this.#sendStarted) {
+      data?.[symbolDispose]?.();
+      throw new SocketError("invalid-state");
+    }
     let stream;
     try {
       stream = readableByteStreamFromReader(data, { name: "tcp send data" });
@@ -279,6 +286,7 @@ export class TcpSocket {
       }
       throw error;
     }
+    this.#sendStarted = true;
 
     try {
       // Transfer the stream to the worker
@@ -310,6 +318,16 @@ export class TcpSocket {
     if (this.#state !== STATE.CONNECTED) {
       throw new SocketError("invalid-state");
     }
+    if (this.#receiveStarted) {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.close();
+        },
+      });
+      const promise = Promise.reject(new SocketError("invalid-state"));
+      return [new StreamReader(stream, { preventCancel: false }), new FutureReader(promise)];
+    }
+    this.#receiveStarted = true;
 
     const transform = new TransformStream();
     const promise = worker()
@@ -325,7 +343,10 @@ export class TcpSocket {
         throw SocketError.from(err);
       });
 
-    return [new StreamReader(transform.readable), new FutureReader(promise)];
+    return [
+      new StreamReader(transform.readable, { preventCancel: false }),
+      new FutureReader(promise),
+    ];
   }
 
   /**

--- a/packages/preview3-shim/lib/nodejs/stream.js
+++ b/packages/preview3-shim/lib/nodejs/stream.js
@@ -1,4 +1,5 @@
 export const DEFAULT_BYTE_STREAM_CHUNK_SIZE = 64 * 1024;
+const symbolDispose = Symbol.dispose || Symbol.for("dispose");
 
 let BYTE_STREAM_ENCODER = null;
 function encoder() {
@@ -84,6 +85,15 @@ function byteStreamSource(reader, opts) {
           return result;
         }
         return { value: result, done: result === null };
+      },
+      cancel(reason) {
+        if (typeof reader.cancel === "function") {
+          return reader.cancel(reason);
+        }
+        if (typeof reader.close === "function") {
+          return reader.close();
+        }
+        return reader[symbolDispose]?.();
       },
     };
   }
@@ -196,7 +206,7 @@ export class StreamReader {
    * @param {AsyncIterable|Iterable} source - An async or sync iterable to consume e.g. ReadableStream, async generator, array.
    * @throws {Error} If the provided source does not implement `[Symbol.asyncIterator]` or `[Symbol.iterator]`.
    */
-  constructor(source) {
+  constructor(source, opts = {}) {
     if (
       !source ||
       (typeof source[Symbol.asyncIterator] !== "function" &&
@@ -210,7 +220,7 @@ export class StreamReader {
     // For ReadableStream, use values() with preventCancel so the underlying
     // stream is not cancelled when the iterator is released.
     if (source instanceof ReadableStream) {
-      this.#iterator = source.values({ preventCancel: true });
+      this.#iterator = source.values({ preventCancel: opts.preventCancel ?? true });
     } else if (typeof source[Symbol.asyncIterator] === "function") {
       this.#iterator = source[Symbol.asyncIterator]();
     } else {
@@ -296,6 +306,10 @@ export class StreamReader {
       this.#iterator.return();
     }
     this.#iterator = null;
+  }
+
+  [symbolDispose]() {
+    this.close();
   }
 
   /**

--- a/packages/preview3-shim/lib/nodejs/workers/tcp-worker.js
+++ b/packages/preview3-shim/lib/nodejs/workers/tcp-worker.js
@@ -1,5 +1,5 @@
 import { Socket, Server } from "node:net";
-import { Readable, Writable } from "stream";
+import { Readable } from "stream";
 import { pipeline } from "stream/promises";
 import { once } from "node:events";
 
@@ -48,6 +48,8 @@ function handleTcpCreate({ family }) {
     server: null,
     backlog: 128,
     localAddress: null,
+    disposed: false,
+    activeStreams: 0,
   });
 
   return { socketId };
@@ -143,6 +145,7 @@ async function handleTcpListen({ socketId, stream }) {
   }
 
   server.on("connection", (conn) => {
+    conn.allowHalfOpen = true;
     const id = NEXT_SOCKET_ID++;
     sockets.set(id, {
       handle: conn._handle,
@@ -151,6 +154,8 @@ async function handleTcpListen({ socketId, stream }) {
       tcp: conn,
       server: null,
       localAddress: makeIpAddress(family, conn.localAddress, conn.localPort),
+      disposed: false,
+      activeStreams: 0,
     });
     writer.write({ family, socketId: id });
   });
@@ -162,19 +167,110 @@ async function handleTcpListen({ socketId, stream }) {
 
 async function handleTcpSend({ socketId, stream }) {
   const socket = sockets.get(socketId);
+  socket.activeStreams++;
+
   const { tcp } = socket;
   const readable = Readable.fromWeb(stream);
 
-  // TODO(tandr): Should we handle FIN packet?
-  await pipeline(readable, tcp);
+  try {
+    await pipeline(readable, tcp);
+  } finally {
+    socket.activeStreams--;
+    cleanupDisposedSocket(socketId, socket);
+  }
 }
 
 async function handleTcpReceive({ socketId, stream }) {
   const socket = sockets.get(socketId);
+  const writer = stream.getWriter();
+  socket.activeStreams++;
+
   const { tcp } = socket;
 
-  const writable = Writable.fromWeb(stream);
-  await pipeline(tcp, writable);
+  try {
+    await new Promise((resolve, reject) => {
+      let settled = false;
+      let pending = Promise.resolve();
+
+      const cleanup = () => {
+        tcp.off("data", onData);
+        tcp.off("end", onEnd);
+        tcp.off("error", onError);
+      };
+      const settle = (err) => {
+        if (settled) {
+          return;
+        }
+        settled = true;
+        cleanup();
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      };
+      const onData = (chunk) => {
+        tcp.pause();
+        pending = pending.then(async () => {
+          try {
+            await writer.write(chunk);
+          } catch {
+            settle();
+            return;
+          } finally {
+            if (!tcp.destroyed) {
+              tcp.resume();
+            }
+          }
+        }, settle);
+      };
+      const onEnd = () => {
+        pending = pending.then(async () => {
+          try {
+            await writer.close();
+          } catch {
+            // The guest can drop the receive stream before remote EOF.
+          }
+          settle();
+        }, settle);
+      };
+      const onError = (err) => {
+        pending = pending.finally(() => settle(err));
+      };
+
+      writer.closed.then(
+        () => settle(),
+        () => settle(),
+      );
+      tcp.on("data", onData);
+      tcp.once("end", onEnd);
+      tcp.once("error", onError);
+      tcp.resume();
+    });
+  } finally {
+    writer.releaseLock();
+    socket.activeStreams--;
+    cleanupDisposedSocket(socketId, socket);
+  }
+}
+
+function cleanupDisposedSocket(socketId, socket) {
+  if (!socket.disposed || socket.activeStreams > 0) {
+    return;
+  }
+
+  if (socket.server) {
+    socket.server.close();
+  }
+
+  if (socket.tcp) {
+    socket.tcp.destroy();
+  }
+  if (socket.handle) {
+    socket.handle.close();
+  }
+
+  sockets.delete(socketId);
 }
 
 async function handleGetLocalAddress({ socketId }) {
@@ -241,18 +337,8 @@ function handleTcpDispose({ socketId }) {
     return;
   }
 
-  if (socket.server) {
-    socket.server.close();
-  }
-
-  if (socket.tcp) {
-    socket.tcp.destroy();
-  }
-  if (socket.handle) {
-    socket.handle.close();
-  }
-
-  sockets.delete(socketId);
+  socket.disposed = true;
+  cleanupDisposedSocket(socketId, socket);
 }
 
 let _recvBufferSize, _sendBufferSize;


### PR DESCRIPTION
Propagate host stream drop/cancel in bindgen lowering, preserve pending host values across cancelled reads, and make tcp send/receive streams survive parent socket disposal.

This fixes p3-sockets-tcp-streams.wasm component test.