### PR TITLE
fix WIT type alias in js-component-bindgen (see issue #1534)

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1254,7 +1254,7 @@ impl Bindgen for FunctionBindgen<'_> {
 
                 // Determine what methods to use with a DataView when setting the data
                 let (dataview_set_method, check_fn_intrinsic) =
-                    gen_dataview_set_and_check_fn_js_for_numeric_type(element);
+                    gen_dataview_set_and_check_fn_js_for_numeric_type(resolve, element);
 
                 // Detect whether we're dealing with a regular array
                 uwriteln!(
@@ -3627,7 +3627,10 @@ pub fn js_array_ty(resolve: &Resolve, element_ty: &Type) -> Option<&'static str>
 ///
 /// * `ty` - the [`Type`] to check
 ///
-fn gen_dataview_set_and_check_fn_js_for_numeric_type(ty: &Type) -> (&str, String) {
+fn gen_dataview_set_and_check_fn_js_for_numeric_type(
+    resolve: &Resolve,
+    ty: &Type,
+) -> (&'static str, String) {
     let check_fn = Intrinsic::Conversion(ConversionIntrinsic::RequireValidNumericPrimitive).name();
     match ty {
         // Unsigned Integers
@@ -3644,6 +3647,53 @@ fn gen_dataview_set_and_check_fn_js_for_numeric_type(ty: &Type) -> (&str, String
         // Floating point
         Type::F32 => ("setFloat32", format!("{check_fn}.bind(null, 'f32')",)),
         Type::F64 => ("setFloat64", format!("{check_fn}.bind(null, 'f64')",)),
+        Type::Id(id) => {
+            let type_ = &resolve.types[*id];
+            match type_.kind {
+                TypeDefKind::Type(ty) => {
+                    gen_dataview_set_and_check_fn_js_for_numeric_type(resolve, &ty)
+                }
+                _ => {
+                    unreachable!(
+                        "unsupported type [{ty:?}] (as type {type_:?}) for canonical list lower [{:?}]",
+                        type_
+                    )
+                }
+            }
+        }
         _ => unreachable!("unsupported type [{ty:?}] for canonical list lower"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_alias_type_gen_dataview_set_and_check_fn_js_for_numeric_type() {
+        let mut resolve = Resolve::new();
+
+        let owner = wit_parser::TypeOwner::Interface(resolve.interfaces.next_id());
+
+        let ty_id = resolve.types.alloc(wit_parser::TypeDef {
+            name: None,
+            kind: TypeDefKind::Type(Type::U64),
+            docs: Default::default(),
+            stability: Default::default(),
+            owner,
+            span: Default::default(),
+        });
+
+        let ty_ = Type::Id(ty_id);
+
+        let (dataview_set_method, check_fn_intrinsic) =
+            gen_dataview_set_and_check_fn_js_for_numeric_type(&resolve, &ty_);
+
+        assert_eq!(dataview_set_method, "setBigUint64");
+
+        let check_fn =
+            Intrinsic::Conversion(ConversionIntrinsic::RequireValidNumericPrimitive).name();
+
+        assert_eq!(check_fn_intrinsic, format!("{check_fn}.bind(null, 'u64')",));
     }
 }

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -12,7 +12,7 @@ use wit_bindgen_core::abi::{Bindgen, Bitcast, Instruction};
 use wit_component::StringEncoding;
 use wit_parser::abi::WasmType;
 use wit_parser::{
-    Alignment, ArchitectureSize, Handle, Resolve, SizeAlign, Type, TypeDefKind, TypeId,
+    Alignment, ArchitectureSize, Handle, Resolve, SizeAlign, Type, TypeDef, TypeDefKind, TypeId,
 };
 
 use crate::intrinsics::Intrinsic;
@@ -3647,20 +3647,21 @@ fn gen_dataview_set_and_check_fn_js_for_numeric_type(
         // Floating point
         Type::F32 => ("setFloat32", format!("{check_fn}.bind(null, 'f32')",)),
         Type::F64 => ("setFloat64", format!("{check_fn}.bind(null, 'f64')",)),
-        Type::Id(id) => {
-            let type_ = &resolve.types[*id];
-            match type_.kind {
-                TypeDefKind::Type(ty) => {
-                    gen_dataview_set_and_check_fn_js_for_numeric_type(resolve, &ty)
-                }
-                _ => {
-                    unreachable!(
-                        "unsupported type [{ty:?}] (as type {type_:?}) for canonical list lower [{:?}]",
-                        type_
-                    )
-                }
+        Type::Id(id) => match resolve.types.get(*id) {
+            // Type aliases should resolve to types that have the kind `TypeDefKind::Type`
+            Some(TypeDef {
+                kind: TypeDefKind::Type(inner_ty),
+                ..
+            }) => gen_dataview_set_and_check_fn_js_for_numeric_type(resolve, inner_ty),
+            // We do not expect to resolve to types that *do not* have the `TypeDefKind::Type(...)`
+            Some(inner_ty) => {
+                unreachable!(
+                    "unexpected non-type-kind typedef [{inner_ty:?}] (as type {ty:?}) for canonical list lower [{ty:?}]",
+                )
             }
-        }
+            // All type ids should resolve via the passed in `Resolve`
+            None => unreachable!("missing/unresolvable type [{ty:?}]"),
+        },
         _ => unreachable!("unsupported type [{ty:?}] for canonical list lower"),
     }
 }


### PR DESCRIPTION
This is a fix for issue #1534 where type aliases in some cases can cause a runtime panic. 

> panicked at .cargo/registry/src/index.crates.io-1949cf8c6b5b557f/js-component-bindgen-1.19.2/src/function_bindgen.rs:3647:14:
> internal error: entered unreachable code: unsupported type [Id(Id { idx: 94 })] for canonical list lower

I also included a test case that passes with the fix applied. 

The primary change to `gen_dataview_set_and_check_fn_js_for_numeric_type()` is that it now takes a wit_parser::resolve::Resolve so Type::Id(id) can be looked up. 

I'm not sure if it's actually possible to end up in this state, but one potential risk since `gen_dataview_set_and_check_fn_js_for_numeric_type()` is now called recursively is if a Type::Id is poorly defined such that it references itself it could cause an infinite loop. 