### PR TITLE
fix(p3-shim): enforce outbound request content length

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -591,6 +591,9 @@ impl Intrinsic {
                                     const remainingItems = this.#hostOnlyData.slice(count);
                                     values.push(...this.#hostOnlyData.slice(0, count));
                                     this.#hostOnlyData = remainingItems;
+                                }} else if (this.#elemMeta.payloadTypeName === 'U8') {{
+                                    values = Array.from(new Uint8Array(this.#memory.buffer, this.#ptr, count));
+                                    this.#ptr += count;
                                 }} else {{
                                     let currentCount = count;
                                     let startPtr = this.#ptr;
@@ -633,6 +636,9 @@ impl Intrinsic {
                             }} else {{
                                 if (this.isHostOwned()) {{
                                     this.#hostOnlyData.push(...values);
+                                }} else if (this.#elemMeta.payloadTypeName === 'U8') {{
+                                    new Uint8Array(this.#memory.buffer, this.#ptr, values.length).set(values);
+                                    this.#ptr += values.length;
                                 }} else {{
                                     let startPtr = this.#ptr;
                                     if (this.#elemMeta.stringEncoding === undefined) {{

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -493,7 +493,7 @@ impl AsyncStreamIntrinsic {
                         }}
 
                         const streamEnd = this;
-                        const processFn = (result, reclaimBufferFn) => {{
+                        const processFn = (result, reclaimBufferFn, rejectedLength) => {{
                             if (reclaimBufferFn) {{ reclaimBufferFn(); }}
 
                             if (result === {stream_end_class}.CopyResult.DROPPED) {{
@@ -512,6 +512,9 @@ impl AsyncStreamIntrinsic {
 
                             const packedResult = (Number(buffer.processed) << 4) | result;
                             const event = {{ code: eventCode, payload0: streamEnd.waitableIdx(), payload1: packedResult }};
+                            if (rejectedLength !== undefined) {{
+                                event.rejectedLength = rejectedLength;
+                            }}
 
                             return event;
                         }};
@@ -522,9 +525,9 @@ impl AsyncStreamIntrinsic {
                             }});
                         }};
 
-                        const onCopyDoneFn = (result) => {{
+                        const onCopyDoneFn = (result, rejectedLength) => {{
                             streamEnd.setPendingEvent(() => {{
-                                return processFn(result);
+                                return processFn(result, undefined, rejectedLength);
                             }});
                         }};
 
@@ -590,6 +593,14 @@ impl AsyncStreamIntrinsic {
                                 // to the internal buffer from the incoming buffer
                                 let transferred = false;
                                 if (buffer.remaining() > 0) {{
+                                    const rejectLength = this.#pendingBufferMeta.rejectLength;
+                                    if (rejectLength !== undefined && buffer.remaining() > rejectLength) {{
+                                        const pendingOnCopyDoneFn = this.#pendingBufferMeta.onCopyDoneFn;
+                                        this.resetPendingBufferMeta();
+                                        pendingOnCopyDoneFn({stream_end_class}.CopyResult.DROPPED, buffer.remaining());
+                                        onCopyDoneFn({stream_end_class}.CopyResult.DROPPED);
+                                        return;
+                                    }}
                                     const numElements = Math.min(buffer.remaining(), this.#pendingBufferMeta.buffer.remaining());
                                     this.#pendingBufferMeta.buffer.write(buffer.read(numElements));
                                     this.#pendingBufferMeta.onCopyFn(() => this.resetPendingBufferMeta());
@@ -610,7 +621,7 @@ impl AsyncStreamIntrinsic {
                         format!(
                             r#"
                             _read(args) {{
-                                const {{ buffer, onCopyDoneFn, onCopyFn, componentIdx }} = args;
+                                const {{ buffer, onCopyDoneFn, onCopyFn, componentIdx, rejectLength }} = args;
                                 if (this.isDropped()) {{
                                     onCopyDoneFn({stream_end_class}.CopyResult.DROPPED);
                                     return;
@@ -622,6 +633,7 @@ impl AsyncStreamIntrinsic {
                                         buffer,
                                         onCopyFn,
                                         onCopyDoneFn,
+                                        rejectLength,
                                     }});
                                     return;
                                 }}
@@ -653,6 +665,11 @@ impl AsyncStreamIntrinsic {
                                 let transferred = false;
                                 if (pendingRemaining > 0) {{
                                     const bufferRemaining = buffer.remaining();
+                                    if (rejectLength !== undefined && pendingRemaining > rejectLength) {{
+                                        this.resetAndNotifyPending({stream_end_class}.CopyResult.DROPPED);
+                                        onCopyDoneFn({stream_end_class}.CopyResult.DROPPED, pendingRemaining);
+                                        return;
+                                    }}
                                     if (bufferRemaining > 0) {{
                                         const count = Math.min(pendingRemaining, bufferRemaining);
                                         buffer.write(this.#pendingBufferMeta.buffer.read(count))
@@ -666,7 +683,7 @@ impl AsyncStreamIntrinsic {
                                 }}
 
                                 this.resetAndNotifyPending({stream_end_class}.CopyResult.COMPLETED);
-                                this.setPendingBufferMeta({{ componentIdx, buffer, onCopyFn, onCopyDoneFn }});
+                                this.setPendingBufferMeta({{ componentIdx, buffer, onCopyFn, onCopyDoneFn, rejectLength }});
                             }}
                             "#,
                         ),
@@ -696,6 +713,7 @@ impl AsyncStreamIntrinsic {
                                  skipStateCheck,
                                  stringEncoding,
                                  reallocFn,
+                                 rejectLength,
                              }} = args;
                              if (eventCode === undefined) {{ throw new TypeError('missing/invalid event code'); }}
 
@@ -743,6 +761,7 @@ impl AsyncStreamIntrinsic {
                                  onCopyFn,
                                  onCopyDoneFn,
                                  componentIdx,
+                                 rejectLength,
                              }});
 
                              let injectedWritePromise;
@@ -812,6 +831,9 @@ impl AsyncStreamIntrinsic {
                                  throw new Error(errMsg);
                              }}
 
+                             if (event.rejectedLength !== undefined) {{
+                                 this.#rejectedLength = event.rejectedLength;
+                             }}
                              return payload;
                          }}
                     "#
@@ -1000,12 +1022,13 @@ impl AsyncStreamIntrinsic {
                     // fn (below) via an anonymous function.
                     Self::StreamReadableEndClass => format!(
                         r#"
-                         async read(count = 1) {{
+                         async read(opts = 1) {{
                             {debug_log_fn}('[{end_class_name}#read()]');
 
                             if (this.#endOfStream) {{
                                 return {{ value: undefined, done: true }};
                             }}
+                            let {{ count, rejectLength }} = this.#readOpts(opts);
 
                             // Wait for an existing read operation to end, if present,
                             // otherwise register this read for any future operations.
@@ -1034,9 +1057,6 @@ impl AsyncStreamIntrinsic {
                             // TODO(fix): when we do a read, we need to GET the string encoding from the
                             // other side, via the lift/lower fn?
 
-                            if (!Number.isInteger(count) || count < 1) {{
-                                throw new TypeError(`invalid stream read count [${{count}}]`);
-                            }}
                             count = Math.min(count, {managed_buffer_class}.MAX_LENGTH);
                             try {{
                                 const {{ id: bufferID, buffer }} = {global_buffer_manager}.createBuffer({{
@@ -1057,6 +1077,7 @@ impl AsyncStreamIntrinsic {
                                     buffer,
                                     eventCode: {async_event_code_enum}.STREAM_READ,
                                     componentIdx: -1,
+                                    rejectLength,
                                 }});
 
                                 if (packedResult === {async_blocked_const}) {{
@@ -1085,6 +1106,9 @@ impl AsyncStreamIntrinsic {
                                     }}
 
                                     if (index !== this.waitableIdx()) {{ throw new Error('invalid stream end index'); }}
+                                    if (event.rejectedLength !== undefined) {{
+                                        this.#rejectedLength = event.rejectedLength;
+                                    }}
                                     packedResult = payload;
 
                                     if (packedResult === {async_blocked_const}) {{
@@ -1116,7 +1140,25 @@ impl AsyncStreamIntrinsic {
                             }}
 
                             const res = await promise;
-                            return {{ value: res, done: res === undefined }};
+                            const rejectedLength = this.#rejectedLength;
+                            this.#rejectedLength = null;
+                            const result = {{ value: res, done: res === undefined }};
+                            if (rejectedLength !== null) {{
+                                result.rejectedLength = rejectedLength;
+                            }}
+                            return result;
+                         }}
+
+                         #readOpts(opts) {{
+                             const count = opts === undefined ? 1 : typeof opts === "number" ? opts : opts && typeof opts === "object" ? opts.count ?? 1 : undefined;
+                             const rejectLength = opts && typeof opts === "object" ? opts.rejectLength : undefined;
+                             if (!Number.isInteger(count) || count < (rejectLength !== undefined ? 0 : 1)) {{
+                                 throw new TypeError(`invalid stream read count [${{count}}]`);
+                             }}
+                             if (rejectLength !== undefined && (!Number.isInteger(rejectLength) || rejectLength < 0)) {{
+                                 throw new TypeError(`invalid stream read reject length [${{rejectLength}}]`);
+                             }}
+                             return {{ count, rejectLength }};
                          }}
                         "#
                     ),
@@ -1150,6 +1192,7 @@ impl AsyncStreamIntrinsic {
                         #result = null;
 
                         #endOfStream = false;
+                        #rejectedLength = null;
 
                         constructor(args) {{
                             {debug_log_fn}('[{end_class_name}#constructor()] args', args);
@@ -1208,15 +1251,16 @@ impl AsyncStreamIntrinsic {
                         {copy_impl}
 
                         setPendingBufferMeta(args) {{
-                            const {{ componentIdx, buffer, onCopyFn, onCopyDoneFn }} = args;
+                            const {{ componentIdx, buffer, onCopyFn, onCopyDoneFn, rejectLength }} = args;
                             this.#pendingBufferMeta.componentIdx = componentIdx;
                             this.#pendingBufferMeta.buffer = buffer;
                             this.#pendingBufferMeta.onCopyFn = onCopyFn;
                             this.#pendingBufferMeta.onCopyDoneFn = onCopyDoneFn;
+                            this.#pendingBufferMeta.rejectLength = rejectLength;
                         }}
 
                         resetPendingBufferMeta() {{
-                            this.setPendingBufferMeta({{ componentIdx: null, buffer: null, onCopyFn: null, onCopyDoneFn: null }});
+                            this.setPendingBufferMeta({{ componentIdx: null, buffer: null, onCopyFn: null, onCopyDoneFn: null, rejectLength: undefined }});
                         }}
 
                         getPendingBufferMeta() {{ return this.#pendingBufferMeta; }}
@@ -1409,8 +1453,8 @@ impl AsyncStreamIntrinsic {
                                 isReadable: streamEnd.isReadable(),
                                 isWritable: streamEnd.isWritable(),
                                 globalRep: this.#rep,
-                                readFn: async (count) => {{
-                                    return await streamEnd.read(count);
+                                readFn: async (opts) => {{
+                                    return await streamEnd.read(opts);
                                 }},
                                 writeFn: async (v) => {{
                                     await streamEnd.write(v);
@@ -1578,13 +1622,18 @@ impl AsyncStreamIntrinsic {
                         async read(opts) {{
                             {debug_log_fn}('[{external_stream_class_name}#read()]', {{ opts }});
                             if (!this.#isReadable) {{ throw new Error("stream is not marked as readable and cannot be read from"); }}
-                            return this.#readFn(this.#readCount(opts));
+                            const readOpts = this.#readOpts(opts);
+                            return this.#readFn(readOpts);
                         }}
 
-                        #readCount(opts) {{
+                        #readOpts(opts) {{
                             const count = opts === undefined ? 1 : typeof opts === "number" ? opts : opts && typeof opts === "object" ? opts.count ?? 1 : undefined;
-                            if (!Number.isInteger(count) || count < 1) {{ throw new TypeError(`invalid stream read count [${{count}}]`); }}
-                            return count;
+                            const rejectLength = opts && typeof opts === "object" ? opts.rejectLength : undefined;
+                            if (!Number.isInteger(count) || count < (rejectLength !== undefined ? 0 : 1)) {{ throw new TypeError(`invalid stream read count [${{count}}]`); }}
+                            if (rejectLength !== undefined && (!Number.isInteger(rejectLength) || rejectLength < 0)) {{
+                                throw new TypeError(`invalid stream read reject length [${{rejectLength}}]`);
+                            }}
+                            return {{ count, rejectLength }};
                         }}
 
                         async write() {{

--- a/packages/jco/test/p3/helpers/fixtures.js
+++ b/packages/jco/test/p3/helpers/fixtures.js
@@ -18,6 +18,7 @@ export const P3_CLI_RUN_FIXTURES = [
     { path: "fs/p3-file-write.wasm" },
     { path: "fs/p3-filesystem-file-read-write.wasm" },
     { path: "fs/p3-readdir.wasm" },
+    { path: "http/p3-http-outbound-request-content-length.wasm" },
     { path: "http/p3-http-outbound-request-get.wasm" },
     { path: "http/p3-http-outbound-request-invalid-dnsname.wasm" },
     { path: "http/p3-http-outbound-request-invalid-header.wasm" },
@@ -26,6 +27,7 @@ export const P3_CLI_RUN_FIXTURES = [
     { path: "http/p3-http-outbound-request-missing-path-and-query.wasm" },
     { path: "http/p3-http-outbound-request-post.wasm" },
     { path: "http/p3-http-outbound-request-put.wasm" },
+    { path: "http/p3-http-outbound-request-response-build.wasm" },
     { path: "http/p3-http-outbound-request-timeout.wasm" },
     { path: "http/p3-http-outbound-request-unknown-method.wasm" },
     { path: "http/p3-http-outbound-request-unsupported-scheme.wasm" },
@@ -46,9 +48,7 @@ export const P3_CLI_RUN_FIXTURES = [
     { path: "sockets/p3-sockets-udp-sockopts.wasm" },
     { path: "sockets/p3-sockets-udp-states.wasm" },
     // currently failing
-    { path: "http/p3-http-outbound-request-content-length.wasm", failing: true },
     { path: "http/p3-http-outbound-request-large-post.wasm", failing: true },
-    { path: "http/p3-http-outbound-request-response-build.wasm" },
 ];
 
 function withExtraHeaders(payload, headers) {

--- a/packages/preview3-shim/lib/nodejs/http/client.js
+++ b/packages/preview3-shim/lib/nodejs/http/client.js
@@ -136,7 +136,7 @@ const responseFromParts = (parts) => {
     });
   });
 
-  const future = new FutureReader(promise.then(_trailerResultFromEntries));
+  const future = new TrailerFutureReader(promise.then(_trailerResultFromEntries), trailers);
   const contents = new StreamReader(body);
   const fields = _fieldsFromEntriesChecked(headers);
 
@@ -144,3 +144,18 @@ const responseFromParts = (parts) => {
   res.setStatusCode(statusCode);
   return res;
 };
+
+class TrailerFutureReader extends FutureReader {
+  #trailers;
+
+  constructor(promise, trailers) {
+    super(promise);
+    this.#trailers = trailers;
+  }
+
+  close() {
+    this.#trailers?.close();
+    this.#trailers = null;
+    super.close();
+  }
+}

--- a/packages/preview3-shim/lib/nodejs/http/request.js
+++ b/packages/preview3-shim/lib/nodejs/http/request.js
@@ -2,7 +2,12 @@ import { HttpError } from "./error.js";
 import { _fieldsLock, Fields } from "./fields.js";
 
 import { FutureReader, future } from "../future.js";
-import { StreamReader, readableByteStreamFromReader } from "../stream.js";
+import {
+  DEFAULT_BYTE_STREAM_CHUNK_SIZE,
+  StreamReader,
+  _byteChunk,
+  readableByteStreamFromReader,
+} from "../stream.js";
 
 const symbolDispose = Symbol.dispose || Symbol.for("dispose");
 
@@ -221,7 +226,7 @@ export class Request {
     if (contents != null && !(contents instanceof StreamReader)) {
       try {
         dispose = contents[symbolDispose]?.bind(contents);
-        const inner = readableByteStreamFromReader(contents, { name: "contents" });
+        const inner = readableContentsStream(contents, headers);
         contents = new StreamReader(inner);
       } catch (err) {
         throw new HttpError("invalid-argument", err.message);
@@ -475,6 +480,93 @@ export class Request {
     }
   }
 }
+
+function readableContentsStream(reader, headers) {
+  const expectedLength = contentLength(headers.copyAll());
+  if (expectedLength === null) {
+    return readableByteStreamFromReader(reader, { name: "contents" });
+  }
+
+  const source =
+    typeof reader?.read === "function"
+      ? reader
+      : new StreamReader(readableByteStreamFromReader(reader, { name: "contents" }));
+  return readableByteStreamFromReader(contentLengthReader(source, expectedLength), {
+    name: "contents",
+  });
+}
+
+function contentLengthReader(reader, expectedLength) {
+  let sent = 0n;
+  return {
+    async read() {
+      const result = await reader.read(readOpts(expectedLength - sent));
+      if (isIteratorResult(result) && result.rejectedLength !== undefined) {
+        throw requestBodySizeError(sent + BigInt(result.rejectedLength));
+      }
+      if (isIteratorResult(result) && result.done) {
+        if (sent < expectedLength) {
+          throw requestBodySizeError(sent);
+        }
+        return result;
+      }
+
+      const value = isIteratorResult(result) ? result.value : result;
+      const chunk = _byteChunk(value);
+      sent += BigInt(chunk.byteLength);
+      if (sent > expectedLength) {
+        throw requestBodySizeError(sent);
+      }
+      return { value: chunk, done: false };
+    },
+    cancel(reason) {
+      if (typeof reader.cancel === "function") {
+        return reader.cancel(reason);
+      }
+      if (typeof reader.close === "function") {
+        return reader.close();
+      }
+      return reader[symbolDispose]?.();
+    },
+  };
+}
+
+function readOpts(remaining) {
+  if (remaining <= 0n) {
+    return { count: 0, rejectLength: 0 };
+  }
+
+  const count = Number(
+    remaining <= BigInt(DEFAULT_BYTE_STREAM_CHUNK_SIZE)
+      ? remaining
+      : BigInt(DEFAULT_BYTE_STREAM_CHUNK_SIZE),
+  );
+  const opts = { count };
+  if (remaining <= BigInt(Number.MAX_SAFE_INTEGER)) {
+    opts.rejectLength = Number(remaining);
+  }
+  return opts;
+}
+
+function requestBodySizeError(bytes) {
+  return { tag: "HTTP-request-body-size", val: bytes };
+}
+
+function isIteratorResult(value) {
+  return value != null && typeof value === "object" && typeof value.done === "boolean";
+}
+
+const decoder = new TextDecoder();
+
+const contentLength = (entries) => {
+  const entry = entries.findLast(([name]) => name.toLowerCase() === "content-length");
+  if (!entry) {
+    return null;
+  }
+
+  const value = decoder.decode(entry[1]);
+  return /^\d+$/.test(value) ? BigInt(value) : null;
+};
 
 const UrlPart = {
   PATH_WITH_QUERY: "pathWithQuery",

--- a/packages/preview3-shim/lib/nodejs/http/response.js
+++ b/packages/preview3-shim/lib/nodejs/http/response.js
@@ -89,7 +89,7 @@ export class Response {
   [symbolDispose]() {
     if (this.#contents && !this.#bodyOpen && !this.#bodyEnded) {
       this.#contentsDispose?.();
-      this.#contents.close();
+      this.#closeBody();
     }
     this.#contents = null;
     this.#contentsDispose = null;
@@ -193,9 +193,12 @@ export class Response {
 
     const closedFn = reader.close.bind(reader);
     reader.close = () => {
-      closedFn();
-      response.#bodyEnded = true;
-      response.#bodyOpen = false;
+      response.#closeBody(closedFn);
+    };
+
+    const cancelFn = reader.cancel.bind(reader);
+    reader.cancel = async (...args) => {
+      await response.#closeBody(() => cancelFn(...args));
     };
 
     return [response.#contents, response.#trailersFuture];
@@ -206,6 +209,19 @@ export class Response {
     if (this.#responseFuture) {
       this.#responseFuture.write(result);
       this.#responseFuture = null;
+    }
+  }
+
+  #closeBody(close = this.#contents?.close.bind(this.#contents)) {
+    const closeTrailers = !this.#bodyEnded;
+    try {
+      return close?.();
+    } finally {
+      if (closeTrailers) {
+        this.#trailersFuture.close();
+      }
+      this.#bodyEnded = true;
+      this.#bodyOpen = false;
     }
   }
 }

--- a/packages/preview3-shim/lib/nodejs/stream.js
+++ b/packages/preview3-shim/lib/nodejs/stream.js
@@ -62,7 +62,7 @@ export function readableByteStreamFromReader(reader, opts = {}) {
         controller.close();
         return;
       }
-      controller.enqueue(byteChunk(value));
+      controller.enqueue(_byteChunk(value));
     },
     cancel(reason) {
       return source.cancel?.(reason);
@@ -117,7 +117,7 @@ function isIteratorResult(value) {
   return value != null && typeof value === "object" && typeof value.done === "boolean";
 }
 
-function byteChunk(value) {
+export function _byteChunk(value) {
   if (value instanceof Uint8Array) {
     return value;
   }

--- a/packages/preview3-shim/lib/nodejs/workers/http-worker.js
+++ b/packages/preview3-shim/lib/nodejs/workers/http-worker.js
@@ -222,7 +222,10 @@ async function doHandleRequest({ url, method, headers, trailers, body, timeouts 
     req.once("close", onClose);
   });
 
-  const upload = body ? sendRequestBody(req, body, trailers, () => resStarted) : endRequest(req);
+  const expectedLength = contentLength(headers);
+  const upload = body
+    ? sendRequestBody(req, body, trailers, () => resStarted, expectedLength)
+    : endRequest(req);
 
   upload.then(
     () => transmit.ok(),
@@ -287,10 +290,12 @@ async function handleHttpServerClose({ serverId }) {
   return serverId;
 }
 
-async function sendRequestBody(req, body, trailers, resStarted) {
+async function sendRequestBody(req, body, trailers, resStarted, expectedLength) {
   try {
     req.flushHeaders();
-    await pipeline(Readable.fromWeb(body), req, { end: false });
+    await pipeline(validateRequestBody(Readable.fromWeb(body), expectedLength), req, {
+      end: false,
+    });
     const fields = await recvTrailers(trailers);
     if (fields) {
       req.addTrailers(toObject(fields));
@@ -301,6 +306,21 @@ async function sendRequestBody(req, body, trailers, resStarted) {
       req.destroy(err);
     }
     throw err;
+  }
+}
+
+async function* validateRequestBody(body, expectedLength) {
+  let bytes = 0n;
+  for await (const chunk of body) {
+    bytes += BigInt(chunk.byteLength);
+    if (expectedLength !== null && bytes > expectedLength) {
+      throw new HttpError("HTTP-request-body-size", undefined, bytes);
+    }
+    yield chunk;
+  }
+
+  if (expectedLength !== null && bytes < expectedLength) {
+    throw new HttpError("HTTP-request-body-size", undefined, bytes);
   }
 }
 
@@ -373,6 +393,16 @@ const msecs = (time) => {
 };
 
 const decoder = new TextDecoder();
+
+const contentLength = (entries) => {
+  const entry = entries.findLast(([name]) => name.toLowerCase() === "content-length");
+  if (!entry) {
+    return null;
+  }
+
+  const value = decoder.decode(entry[1]);
+  return /^\d+$/.test(value) ? BigInt(value) : null;
+};
 
 const toObject = (entries) => {
   return Object.fromEntries(entries.map(([key, val]) => [key, decoder.decode(val)]));

--- a/packages/preview3-shim/lib/nodejs/workers/tcp-worker.js
+++ b/packages/preview3-shim/lib/nodejs/workers/tcp-worker.js
@@ -217,11 +217,8 @@ async function handleTcpReceive({ socketId, stream }) {
           } catch {
             settle();
             return;
-          } finally {
-            if (!tcp.destroyed) {
-              tcp.resume();
-            }
           }
+          tcp.resume();
         }, settle);
       };
       const onEnd = () => {

--- a/packages/preview3-shim/test/http/client.test.js
+++ b/packages/preview3-shim/test/http/client.test.js
@@ -282,6 +282,39 @@ describe("HttpClient Integration", () => {
     });
   });
 
+  test("request transmission future reports content-length mismatches", async () => {
+    const sendWithBody = async (contentLength, body) => {
+      const headers = new Fields();
+      headers.append("content-length", ENCODER.encode(String(contentLength)));
+
+      const { tx: bodyTx, rx: bodyRx } = stream();
+      const { tx: trailersTx, rx: trailersRx } = future();
+
+      const [req, transmit] = Request.new(headers, bodyRx, trailersRx);
+      req.setMethod("POST");
+      req.setAuthority(authority);
+      req.setPathWithQuery("/error");
+
+      const responsePromise = client.send(req);
+      await bodyTx.write(Buffer.from(body));
+      await bodyTx.close();
+      await trailersTx.write(null).catch(() => {});
+      await responsePromise.catch(() => {});
+
+      return transmit.read();
+    };
+
+    await expect(withTimeout(sendWithBody(11, "msg"), 1_000)).resolves.toEqual({
+      tag: "err",
+      val: { tag: "HTTP-request-body-size", val: 3n },
+    });
+
+    await expect(withTimeout(sendWithBody(11, "more than 11 bytes"), 1_000)).resolves.toEqual({
+      tag: "err",
+      val: { tag: "HTTP-request-body-size", val: 18n },
+    });
+  });
+
   test("handles server errors properly", async () => {
     const headers = new Fields();
     const { tx: trailersTx, rx: trailersRx } = future();


### PR DESCRIPTION
This fixes request `content-length` handling. Request bodies are now checked against the length from header before accepting oversized guest writes and while transmitting bytes to the worker, so short bodies and oversized bodies reports `HTTP-request-body-size` correctly.

The bindgen side of the fix adds a stream read option that lets the host reject a pending write before copying it, which is required for `write_all` to return the full over size buffer as remaining. The preview3-shim change uses that hook for http request bodies.