### PR TITLE
fix(bindgen): avoid spread calls for host stream buffers

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -588,9 +588,8 @@ impl Intrinsic {
                                 values = [...new Array(count)].map(() => null);
                             }} else {{
                                 if (this.isHostOwned()) {{
-                                    const remainingItems = this.#hostOnlyData.slice(count);
-                                    values.push(...this.#hostOnlyData.slice(0, count));
-                                    this.#hostOnlyData = remainingItems;
+                                    values = this.#hostOnlyData.slice(0, count);
+                                    this.#hostOnlyData = this.#hostOnlyData.slice(count);
                                 }} else if (this.#elemMeta.payloadTypeName === 'U8') {{
                                     values = Array.from(new Uint8Array(this.#memory.buffer, this.#ptr, count));
                                     this.#ptr += count;
@@ -635,7 +634,7 @@ impl Intrinsic {
                                 }}
                             }} else {{
                                 if (this.isHostOwned()) {{
-                                    this.#hostOnlyData.push(...values);
+                                    this.#hostOnlyData = this.#hostOnlyData.concat(values);
                                 }} else if (this.#elemMeta.payloadTypeName === 'U8') {{
                                     new Uint8Array(this.#memory.buffer, this.#ptr, values.length).set(values);
                                     this.#ptr += values.length;

--- a/packages/jco/test/p3/helpers/fixtures.js
+++ b/packages/jco/test/p3/helpers/fixtures.js
@@ -24,6 +24,7 @@ export const P3_CLI_RUN_FIXTURES = [
     { path: "http/p3-http-outbound-request-invalid-header.wasm" },
     { path: "http/p3-http-outbound-request-invalid-port.wasm" },
     { path: "http/p3-http-outbound-request-invalid-version.wasm" },
+    { path: "http/p3-http-outbound-request-large-post.wasm" },
     { path: "http/p3-http-outbound-request-missing-path-and-query.wasm" },
     { path: "http/p3-http-outbound-request-post.wasm" },
     { path: "http/p3-http-outbound-request-put.wasm" },
@@ -47,8 +48,6 @@ export const P3_CLI_RUN_FIXTURES = [
     { path: "sockets/p3-sockets-udp-send.wasm" },
     { path: "sockets/p3-sockets-udp-sockopts.wasm" },
     { path: "sockets/p3-sockets-udp-states.wasm" },
-    // currently failing
-    { path: "http/p3-http-outbound-request-large-post.wasm", failing: true },
 ];
 
 function withExtraHeaders(payload, headers) {


### PR DESCRIPTION
This fixes RangeError: Maximum call stack size exceeded error when running large post fixture test.