### PR TITLE
fix(p3-shim): serialize errors from worker

### DIFF
--- a/packages/preview3-shim/lib/nodejs/sockets/error.js
+++ b/packages/preview3-shim/lib/nodejs/sockets/error.js
@@ -20,7 +20,6 @@ export const ERROR_MAP = {
   ENONET: "remote-unreachable",
   ECONNREFUSED: "connection-refused",
   EPIPE: "connection-broken",
-  "write EPIPE": "connection-broken",
   ECONNRESET: "connection-reset",
   ECONNABORTED: "connection-aborted",
   EMSGSIZE: "datagram-too-large",

--- a/packages/preview3-shim/lib/nodejs/workers/resource-worker.js
+++ b/packages/preview3-shim/lib/nodejs/workers/resource-worker.js
@@ -46,7 +46,7 @@ export class ResourceWorker {
         port1.close();
 
         if (error) {
-          reject(error);
+          reject(deserializeError(error));
           return;
         }
         resolve(result);
@@ -77,7 +77,7 @@ export class ResourceWorker {
     const { result, error } = message;
 
     if (error) {
-      throw error;
+      throw deserializeError(error);
     }
     return result;
   }
@@ -118,7 +118,7 @@ export function Router() {
         result = outcome;
       }
     } catch (err) {
-      error = err;
+      error = serializeError(err);
     }
 
     _reply.postMessage({ result, error }, transfer);
@@ -142,6 +142,50 @@ export function Router() {
       return this;
     },
   };
+}
+
+function serializeError(err) {
+  if (!(err instanceof Error)) {
+    return err;
+  }
+
+  const serialized = {
+    __resourceWorkerError: true,
+    name: err.name,
+    message: err.message,
+    stack: err.stack,
+  };
+
+  for (const key of Reflect.ownKeys(err)) {
+    serialized[key] = err[key];
+  }
+
+  if (err.cause !== undefined) {
+    serialized.cause = serializeError(err.cause);
+  }
+
+  return serialized;
+}
+
+function deserializeError(err) {
+  if (!err || typeof err !== "object" || err.__resourceWorkerError !== true) {
+    return err;
+  }
+
+  const error = new Error(err.message);
+  error.name = err.name;
+  if (err.stack) {
+    error.stack = err.stack;
+  }
+
+  for (const key of Reflect.ownKeys(err)) {
+    if (key === "__resourceWorkerError" || key === "name" || key === "message" || key === "stack") {
+      continue;
+    }
+    error[key] = key === "cause" ? deserializeError(err[key]) : err[key];
+  }
+
+  return error;
 }
 
 function notify(condvar) {

--- a/packages/preview3-shim/test/nop-worker.js
+++ b/packages/preview3-shim/test/nop-worker.js
@@ -6,4 +6,11 @@ Router()
   })
   .op("err", () => {
     throw "err";
+  })
+  .op("err-code", () => {
+    const err = new Error("read ECONNRESET");
+    err.code = "ECONNRESET";
+    err.errno = -54;
+    err.syscall = "read";
+    throw err;
   });

--- a/packages/preview3-shim/test/resource-worker.test.js
+++ b/packages/preview3-shim/test/resource-worker.test.js
@@ -16,7 +16,30 @@ describe("ResourceWorker round-trip", () => {
     await expect(_worker.run({ op: "err" })).rejects.toThrow("err");
   });
 
+  test("async run err preserves code", async () => {
+    await expect(_worker.run({ op: "err-code" })).rejects.toMatchObject({
+      message: "read ECONNRESET",
+      code: "ECONNRESET",
+      errno: -54,
+      syscall: "read",
+    });
+  });
+
   test("sync run err", () => {
     expect(() => _worker.runSync({ op: "err" })).toThrow("err");
+  });
+
+  test("sync run err preserves code", () => {
+    try {
+      _worker.runSync({ op: "err-code" });
+      throw new Error("expected err-code to throw");
+    } catch (err) {
+      expect(err).toMatchObject({
+        message: "read ECONNRESET",
+        code: "ECONNRESET",
+        errno: -54,
+        syscall: "read",
+      });
+    }
   });
 });


### PR DESCRIPTION
This allows preserve error code when corssing worker boundary and allow correct error mapping on the main thread.