### PR TITLE
fix(p2-shim): coerce browser file read bounds to numbers

### DIFF
--- a/packages/preview2-shim/lib/browser/filesystem.js
+++ b/packages/preview2-shim/lib/browser/filesystem.js
@@ -43,6 +43,22 @@ const timeZero = {
   nanoseconds: 0,
 };
 
+/** Coerce the given object to a safe integer */
+function coerceToSafeIntegerNumber(obj) {
+  let n;
+  if (typeof obj === "number") {
+    n = obj;
+  } else if (typeof obj == "bigint") {
+    n = Number(obj);
+  } else {
+    throw new TypeError(`unexpected non-numeric type: ${obj}`);
+  }
+  if (n > Number.MAX_SAFE_INTEGER) {
+    throw new TypeError(`excessively large number: ${n}`);
+  }
+  return n;
+}
+
 function getChildEntry(parentEntry, subpath, openFlags) {
   if (subpath === "." && _rootPreopen && descriptorGetEntry(_rootPreopen[0]) === parentEntry) {
     subpath = _getCwd();
@@ -188,8 +204,8 @@ class Descriptor {
 
   read(length, offset) {
     const source = getSource(this.#entry);
-    const off = typeof offset === "bigint" ? Number(offset) : offset;
-    const len = typeof length === "bigint" ? Number(length) : length;
+    const off = coerceToSafeIntegerNumber(offset);
+    const len = coerceToSafeIntegerNumber(length);
     return [source.slice(off, off + len), off + len >= source.byteLength];
   }
 

--- a/packages/preview2-shim/lib/browser/filesystem.js
+++ b/packages/preview2-shim/lib/browser/filesystem.js
@@ -188,7 +188,9 @@ class Descriptor {
 
   read(length, offset) {
     const source = getSource(this.#entry);
-    return [source.slice(offset, offset + length), offset + length >= source.byteLength];
+    const off = typeof offset === "bigint" ? Number(offset) : offset;
+    const len = typeof length === "bigint" ? Number(length) : length;
+    return [source.slice(off, off + len), off + len >= source.byteLength];
   }
 
   write(buffer, offset) {


### PR DESCRIPTION
Fixes #1573

wasi-filesystem `read` takes `filesize` (`u64`) arguments, which the canonical-ABI binding passes as `BigInt`. `Uint8Array.slice` rejects `BigInt` and throws `Cannot convert a BigInt value to a number` on the first read against any file in the browser implementation.

Coerce both arguments to `Number` on entry. Safe up to `Number.MAX_SAFE_INTEGER` bytes.

Reproducer and before/after evidence are in #1573.