### PR TITLE
fix(bindgen): restore storageLen budget after a list field in records and tuples

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/lift.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lift.rs
@@ -745,12 +745,26 @@ impl LiftIntrinsic {
                                     fieldPtr = ctx.storagePtr;
                                 }}
 
+                                // A field occupies exactly size32 bytes of the record's
+                                // flat storage. Capture the remaining storage budget before
+                                // lifting the field and restore it afterwards: a field's own
+                                // lift fn may repurpose storageLen internally (e.g. a list
+                                // sets it to the element-buffer length while reading
+                                // out-of-line data and never restores it), which would
+                                // otherwise corrupt the budget the next field sees.
+                                // See https://github.com/bytecodealliance/jco/issues/1585.
+                                let fieldLen;
+                                if (ctx.storageLen !== undefined) {{ fieldLen = ctx.storageLen; }}
+
                                 let [val, newCtx] = liftFn(ctx);
                                 res[key] = val;
                                 ctx = newCtx;
 
                                 if (fieldPtr !== undefined) {{
                                     ctx.storagePtr = Math.max(ctx.storagePtr, fieldPtr + size32);
+                                }}
+                                if (fieldLen !== undefined) {{
+                                    ctx.storageLen = fieldLen - size32;
                                 }}
                             }}
 
@@ -992,12 +1006,24 @@ impl LiftIntrinsic {
                                     elemPtr = ctx.storagePtr;
                                 }}
 
+                                // As in _liftFlatRecord: an element occupies exactly size32
+                                // bytes of the tuple's flat storage, so capture and restore
+                                // the storage budget around the element lift to stop a
+                                // field's internal storageLen use (e.g. lists) leaking into
+                                // the next element.
+                                // See https://github.com/bytecodealliance/jco/issues/1585.
+                                let elemLen;
+                                if (ctx.storageLen !== undefined) {{ elemLen = ctx.storageLen; }}
+
                                 const [newValue, newCtx] = liftFn(ctx);
                                 val.push(newValue);
                                 ctx = newCtx;
 
                                 if (elemPtr !== undefined) {{
                                     ctx.storagePtr = Math.max(ctx.storagePtr, elemPtr + size32);
+                                }}
+                                if (elemLen !== undefined) {{
+                                    ctx.storageLen = elemLen - size32;
                                 }}
                             }}
 

--- a/crates/test-components/src/bin/lift_list_before_fixed.rs
+++ b/crates/test-components/src/bin/lift_list_before_fixed.rs
@@ -1,0 +1,42 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "lift-list-before-fixed",
+    });
+    export!(Component);
+}
+
+use bindings::Blob;
+
+struct Component;
+
+impl bindings::Guest for Component {
+    /// A record whose first field is a list, followed by a fixed-width `u32`
+    /// and a `string`. Lifting `count` used to fail (jco#1585).
+    async fn get_blob() -> Blob {
+        Blob {
+            data: vec![1, 2, 3, 4, 5],
+            count: 42,
+            label: "hello".into(),
+        }
+    }
+
+    /// Same shape with an empty leading list: the element-buffer length is 0,
+    /// so a naive "restore storageLen to the element length" fix would still
+    /// leave the next field's budget at 0 and throw.
+    async fn get_empty_blob() -> Blob {
+        Blob {
+            data: Vec::new(),
+            count: 7,
+            label: "empty".into(),
+        }
+    }
+
+    /// Tuple variant of the same shape (list before a fixed-width field).
+    async fn get_list_then_u32() -> (Vec<u8>, u32) {
+        (vec![9, 8, 7], 1234)
+    }
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -504,3 +504,20 @@ world resource-incrementing-id {
     import resources;
     export local-run;
 }
+
+// Regression coverage for https://github.com/bytecodealliance/jco/issues/1585:
+// lifting a record (and a tuple) whose first field is a `list` immediately
+// followed by a fixed-width field, over the async flat ABI. The list lift
+// repurposes the storage-length budget while reading out-of-line data; the
+// following fixed-width field must still see the correct remaining budget.
+world lift-list-before-fixed {
+    record blob {
+        data: list<u8>,
+        count: u32,
+        label: string,
+    }
+
+    export get-blob: async func() -> blob;
+    export get-empty-blob: async func() -> blob;
+    export get-list-then-u32: async func() -> tuple<list<u8>, u32>;
+}

--- a/packages/jco/test/p3/lift-list-before-fixed.js
+++ b/packages/jco/test/p3/lift-list-before-fixed.js
@@ -1,0 +1,47 @@
+import { join } from "node:path";
+
+import { suite, test, assert } from "vitest";
+
+import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
+
+import { setupAsyncTest } from "../helpers.js";
+import { LOCAL_TEST_COMPONENTS_DIR } from "../common.js";
+
+suite("List-before-fixed-field lift (WASI P3)", () => {
+    // Regression for https://github.com/bytecodealliance/jco/issues/1585:
+    // lifting a record/tuple whose first field is a `list` followed by a
+    // fixed-width field. The list lift repurposes the storage-length budget
+    // while reading out-of-line data; the following field must still see the
+    // correct remaining budget. Before the fix these calls threw while lifting
+    // the `count: u32` field.
+    test("record & tuple with a list before a fixed-width field lift correctly", async () => {
+        const name = "lift-list-before-fixed";
+        const { instance, cleanup } = await setupAsyncTest({
+            component: {
+                name,
+                path: join(LOCAL_TEST_COMPONENTS_DIR, `${name}.wasm`),
+                imports: new WASIShim().getImportObject(),
+            },
+        });
+
+        assert.deepStrictEqual(await instance.getBlob(), {
+            data: new Uint8Array([1, 2, 3, 4, 5]),
+            count: 42,
+            label: "hello",
+        });
+
+        // Empty leading list: the element buffer is zero-length, so the
+        // following fixed-width field's budget must be restored from the
+        // record's remaining storage rather than from the (empty) element list.
+        assert.deepStrictEqual(await instance.getEmptyBlob(), {
+            data: new Uint8Array([]),
+            count: 7,
+            label: "empty",
+        });
+
+        // Tuple variant of the same shape.
+        assert.deepStrictEqual(await instance.getListThenU32(), [new Uint8Array([9, 8, 7]), 1234]);
+
+        await cleanup();
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #1585 — transpiling a component that returns or streams a `record`/`tuple` whose first field is a `list` immediately followed by a fixed-width field throws while lifting the field after the list.

`_liftFlatList`'s `readValuesAndReset` sets `ctx.storageLen` to the element-buffer length while reading the out-of-line elements and restores `ctx.storagePtr` but **not** `ctx.storageLen`. `_liftFlatRecord` / `_liftFlatTuple` already normalize `storagePtr` per field via `ctx.storagePtr = Math.max(ctx.storagePtr, fieldPtr + size32)` but don't track `storageLen`, so the field *after* a list sees `storageLen === 0` and its guard throws:

```
insufficient storage ([0] bytes) for lift (u32 requires 4 bytes)
```

## Fix

Mirror the existing per-field `storagePtr` normalization for `storageLen`: capture the remaining budget before each field/element and set it to `fieldLen - size32` afterwards. A field occupies exactly `size32` bytes of the composite's flat storage regardless of how its own lift fn manipulates `storageLen` internally. This:

- is a **no-op** for fields that already account for their own bytes (primitives do `storageLen -= size`);
- correctly handles a **zero-length leading list** — a "restore to element-buffer length" variant would leave `storageLen` at `0` for an empty list and still throw;
- needs no magic numbers, and covers tuples as well as records.

## Test plan

- New `lift-list-before-fixed` test component (record + tuple with a list before a fixed-width field, plus an empty-list case) and a P3 regression test `test/p3/lift-list-before-fixed.js`.
- Before the fix the same component throws on all three exports; after, all lift correctly.
- Full P3 suite (239 passed) and the classic runtime suite (15 passed) stay green; `cargo fmt` / `clippy` and `oxlint` / `oxfmt` are clean.

## Note

While in `lift.rs` I noticed a separate, likely-unrelated typo in the UTF-8 string lift (~line 689): `ctx.storagelen -= 8` (lowercase `l`) where the UTF-16 path uses `ctx.storageLen`. It's guard-weakening rather than fatal, so I left it out of this PR — happy to address separately if useful.
