### PR TITLE
fix(p3-shim): align filesystem tcp and http edge cases

### DIFF
--- a/packages/preview3-shim/lib/nodejs/filesystem/descriptor.js
+++ b/packages/preview3-shim/lib/nodejs/filesystem/descriptor.js
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import nodePath from "node:path";
 import process from "node:process";
 
 import { StreamReader, readableByteStreamFromReader } from "../stream.js";
@@ -29,8 +30,10 @@ class Descriptor {
   #finalizer;
   /** Host filesystem path for preopened directories */
   #hostPreopen;
+  /** Whether this descriptor refers to a directory. */
+  #isDirectory = false;
 
-  static _create(handle, mode, fullPath) {
+  static _create(handle, mode, fullPath, isDirectory = false) {
     const {
       read = false,
       write = false,
@@ -52,6 +55,7 @@ class Descriptor {
     const desc = new Descriptor();
     desc.#handle = handle;
     desc.#fullPath = fullPath;
+    desc.#isDirectory = isDirectory;
     desc.#mode = merged;
     desc.#finalizer = registerDispose(desc, null, handle, (handle) => handle.close());
 
@@ -60,6 +64,15 @@ class Descriptor {
 
   static _createPreopen(hostPreopen) {
     const desc = new Descriptor();
+    desc.#isDirectory = true;
+    desc.#mode = {
+      read: true,
+      write: false,
+      fileIntegritySync: false,
+      dataIntegritySync: false,
+      requestedWriteSync: false,
+      mutateDirectory: true,
+    };
 
     if (hostPreopen.endsWith("/")) {
       desc.#hostPreopen = hostPreopen.slice(0, -1) || "/";
@@ -363,6 +376,7 @@ class Descriptor {
    * @throws {FSError} `payload.tag` contains mapped WASI error code.
    */
   async createDirectoryAt(path) {
+    await this.#ensureSandboxedPath(path);
     const full = this.#getFullPath(path, false);
     try {
       await fs.mkdir(full);
@@ -426,6 +440,7 @@ class Descriptor {
    * @throws {FSError} `payload.tag` contains mapped WASI error code.
    */
   async statAt(flags, path) {
+    await this.#ensureSandboxedPath(path);
     const full = this.#getFullPath(path, flags.symlinkFollow);
     try {
       const statFn = flags.symlinkFollow ? fs.stat : fs.lstat;
@@ -464,6 +479,7 @@ class Descriptor {
    * @throws {FSError} `payload.tag` contains mapped WASI error code.
    */
   async setTimesAt(flags, path, atimeDesc, mtimeDesc) {
+    await this.#ensureSandboxedPath(path);
     const { atime, mtime } = await this.#computeTimestamps(atimeDesc, mtimeDesc, path);
 
     if (!flags.symlinkFollow && !fs.lutimes) {
@@ -501,6 +517,8 @@ class Descriptor {
    * @throws {FSError} `payload.tag` contains mapped WASI error code.
    */
   async linkAt(oldFlags, oldPath, newDesc, newPath) {
+    await this.#ensureSandboxedPath(oldPath);
+    await newDesc.#ensureSandboxedPath(newPath);
     const src = this.#getFullPath(oldPath, oldFlags.symlinkFollow);
     const dst = newDesc.#getFullPath(newPath, false);
 
@@ -542,8 +560,15 @@ class Descriptor {
       throw new FSError("access");
     }
 
+    await this.#ensureSandboxedPath(path);
     const fullPath = this.#getFullPath(path, pf.symlinkFollow);
     const target = stripTrailingSlash(fullPath);
+
+    const mode = {
+      ...df,
+      read: df.read || !df.write,
+      write: df.write || of.create || of.truncate,
+    };
 
     const makeFsFlags = () => {
       let fsFlags = 0;
@@ -559,11 +584,11 @@ class Descriptor {
       if (of.truncate) {
         fsFlags |= fs.constants.O_TRUNC;
       }
-      if (df.read && df.write) {
+      if (mode.read && mode.write) {
         fsFlags |= fs.constants.O_RDWR;
-      } else if (df.write) {
+      } else if (mode.write) {
         fsFlags |= fs.constants.O_WRONLY;
-      } else if (df.read) {
+      } else if (mode.read) {
         fsFlags |= fs.constants.O_RDONLY;
       }
       if (df.fileIntegritySync) {
@@ -610,8 +635,9 @@ class Descriptor {
 
     try {
       const handle = await fs.open(target, fsFlags);
-      const desc = descriptorCreate(handle, df, fullPath);
-      const isDir = (await desc.getType()).tag === "directory";
+      const stats = await handle.stat();
+      const isDir = stats.isDirectory();
+      const desc = descriptorCreate(handle, mode, fullPath, isDir);
 
       if (fullPath.endsWith("/") && !isDir) {
         desc[symbolDispose]();
@@ -639,6 +665,7 @@ class Descriptor {
    * @throws {FSError} `payload.tag` contains mapped WASI error code.
    */
   async readlinkAt(path) {
+    await this.#ensureSandboxedPath(path);
     const full = this.#getFullPath(path, false);
     try {
       return await fs.readlink(full);
@@ -660,6 +687,10 @@ class Descriptor {
    * @throws {FSError} `payload.tag` contains mapped WASI error code.
    */
   async removeDirectoryAt(path) {
+    if (path === ".") {
+      throw new FSError("invalid");
+    }
+    await this.#ensureSandboxedPath(path);
     const full = this.#getFullPath(path, false);
     try {
       await fs.rmdir(full);
@@ -686,6 +717,8 @@ class Descriptor {
    * @throws {FSError} `payload.tag` contains mapped WASI error code.
    */
   async renameAt(oldPath, newDesc, newPath) {
+    await this.#ensureSandboxedPath(oldPath);
+    await newDesc.#ensureSandboxedPath(newPath);
     const src = this.#getFullPath(oldPath, false);
     const dst = newDesc.#getFullPath(newPath, false);
     try {
@@ -715,6 +748,7 @@ class Descriptor {
     if (target.startsWith("/")) {
       throw new FSError("not-permitted");
     }
+    await this.#ensureSandboxedPath(path);
     const full = this.#getFullPath(path, false);
 
     try {
@@ -750,6 +784,7 @@ class Descriptor {
    * @throws {FSError} `payload.tag` contains mapped WASI error code.
    */
   async unlinkFileAt(path) {
+    await this.#ensureSandboxedPath(path);
     const full = this.#getFullPath(path, false);
     if (full.endsWith("/")) {
       const isDir = (await fs.stat(full)).isDirectory();
@@ -787,7 +822,8 @@ class Descriptor {
    * @returns {Promise<boolean>}
    */
   async isSameObject(other) {
-    return other === this;
+    const [left, right] = await Promise.all([this.#statForIdentity(), other.#statForIdentity()]);
+    return left.dev === right.dev && left.ino === right.ino;
   }
 
   /**
@@ -802,11 +838,8 @@ class Descriptor {
    * @throws {FSError} `payload.tag` contains mapped WASI error code.
    */
   async metadataHash() {
-    if (this.#hostPreopen) {
-      return { upper: 0n, lower: BigInt(this._id) };
-    }
     try {
-      const s = await this.#handle.stat();
+      const s = await this.#statForIdentity();
       return { upper: s.mtimeNs, lower: s.ino };
     } catch (e) {
       throw FSError.from(e);
@@ -827,10 +860,11 @@ class Descriptor {
    * @throws {FSError} `payload.tag` contains mapped WASI error code.
    */
   async metadataHashAt(flags, path) {
+    await this.#ensureSandboxedPath(path);
     const full = this.#getFullPath(path, false);
     try {
       const statFn = flags.symlinkFollow ? fs.stat : fs.lstat;
-      const s = await statFn(full);
+      const s = await statFn(full, { bigint: true });
       return { upper: s.mtimeNs, lower: s.ino };
     } catch (e) {
       throw FSError.from(e);
@@ -896,6 +930,10 @@ class Descriptor {
   #getFullPath(subpath, _followSymlinks) {
     subpath = subpath.replaceAll("\\", "/").replace(/\/\/+/g, "/");
 
+    if (subpath === "") {
+      throw new FSError("no-entry");
+    }
+
     if (subpath.startsWith("/")) {
       throw new FSError("not-permitted");
     }
@@ -922,6 +960,59 @@ class Descriptor {
 
     const baseNormalized = stripTrailingSlash(base);
     return `${baseNormalized}/${segments.join("/")}`;
+  }
+
+  async #statForIdentity() {
+    if (this.#hostPreopen) {
+      return fs.stat(this.#hostPreopen, { bigint: true });
+    }
+    this.#ensureHandle();
+    return this.#handle.stat({ bigint: true });
+  }
+
+  // WASI paths are always relative to a directory descriptor. During path
+  // resolution, both `..` and symlinks must not escape that descriptor's base.
+  async #ensureSandboxedPath(subpath) {
+    if (!this.#isDirectory) {
+      throw new FSError("not-directory");
+    }
+
+    const base = this.#hostPreopen ?? this.#fullPath;
+    const baseResolved = nodePath.resolve(base);
+    const segments = subpath.replaceAll("\\", "/").replace(/\/\/+/g, "/").split("/");
+    let current = baseResolved;
+
+    for (const seg of segments) {
+      if (seg === "" || seg === ".") {
+        continue;
+      }
+      if (seg === "..") {
+        current = nodePath.dirname(current);
+        if (!isWithinPath(baseResolved, current)) {
+          throw new FSError("not-permitted");
+        }
+        continue;
+      }
+
+      current = nodePath.join(current, seg);
+      let stat;
+      try {
+        stat = await fs.lstat(current);
+      } catch (err) {
+        if (err.code === "ENOENT") {
+          return;
+        }
+        throw FSError.from(err);
+      }
+
+      if (stat.isSymbolicLink()) {
+        const target = await fs.readlink(current);
+        current = nodePath.resolve(nodePath.dirname(current), target);
+        if (!isWithinPath(baseResolved, current)) {
+          throw new FSError("not-permitted");
+        }
+      }
+    }
   }
 
   #ensureHandle() {
@@ -962,6 +1053,11 @@ function stripTrailingSlash(path) {
     return "/";
   }
   return path.replace(/\/+$/, "");
+}
+
+function isWithinPath(base, candidate) {
+  const relative = nodePath.relative(base, candidate);
+  return relative === "" || (!relative.startsWith("..") && !nodePath.isAbsolute(relative));
 }
 
 const preopenEntries = [];

--- a/packages/preview3-shim/lib/nodejs/http/fields.js
+++ b/packages/preview3-shim/lib/nodejs/http/fields.js
@@ -115,16 +115,19 @@ export class Fields {
     let bucket = this.#table.get(lowercased);
     if (bucket) {
       this.#entries = this.#entries.filter((e) => !bucket.includes(e));
-      bucket.splice(0, bucket.length);
-    } else {
-      bucket = [];
-      this.#table.set(lowercased, bucket);
+      this.#table.delete(lowercased);
     }
 
+    if (values.length === 0) {
+      return;
+    }
+
+    bucket = [];
+    this.#table.set(lowercased, bucket);
     for (const value of values) {
       const entry = [name, value];
       this.#entries.push(entry);
-      this.#table.get(lowercased).push(entry);
+      bucket.push(entry);
     }
   }
 
@@ -140,6 +143,7 @@ export class Fields {
    */
   delete(name) {
     this.#ensureMutable();
+    this.#validateName(name);
     const lowercased = name.toLowerCase();
     const tableEntries = this.#table.get(lowercased);
 
@@ -162,6 +166,7 @@ export class Fields {
    */
   getAndDelete(name) {
     this.#ensureMutable();
+    this.#validateName(name);
 
     const values = this.get(name);
     this.delete(name);
@@ -188,10 +193,11 @@ export class Fields {
     this.#validateValue(name, value);
 
     const lowercased = name.toLowerCase();
-    const entry = [name, value];
-    this.#entries.push(entry);
 
     const tableEntries = this.#table.get(lowercased);
+    const entryName = tableEntries?.[0]?.[0] ?? name;
+    const entry = [entryName, value];
+    this.#entries.push(entry);
     if (tableEntries) {
       tableEntries.push(entry);
     } else {
@@ -274,7 +280,7 @@ export class Fields {
 
   #validateValue(name, value) {
     try {
-      validateHeaderValue(name, new TextDecoder().decode(value));
+      validateHeaderValue(name, bytesToHeaderValueString(value));
     } catch {
       throw new HttpError("invalid-syntax", `Invalid header value for ${name}`);
     }
@@ -285,6 +291,14 @@ export class Fields {
       throw new HttpError("immutable", "Cannot modify immutable fields");
     }
   }
+}
+
+function bytesToHeaderValueString(value) {
+  let result = "";
+  for (let i = 0; i < value.length; i += 0x8000) {
+    result += String.fromCharCode(...value.subarray(i, i + 0x8000));
+  }
+  return result;
 }
 
 export function _fieldsLock(fields) {

--- a/packages/preview3-shim/lib/nodejs/http/request.js
+++ b/packages/preview3-shim/lib/nodejs/http/request.js
@@ -325,7 +325,7 @@ export class Request {
    */
   setPathWithQuery(pathWithQuery) {
     validateUrlPart(pathWithQuery, UrlPart.PATH_WITH_QUERY);
-    this.#pathWithQuery = pathWithQuery ?? undefined;
+    this.#pathWithQuery = pathWithQuery === "" ? "/" : (pathWithQuery ?? undefined);
   }
 
   /**
@@ -575,7 +575,7 @@ const UrlPart = {
 };
 
 function normalizeMethod(method) {
-  const VALUE_TOKEN_RE = /^[a-zA-Z-]+$/;
+  const VALUE_TOKEN_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
 
   if (typeof method === "string") {
     if (!VALUE_TOKEN_RE.test(method)) {
@@ -597,7 +597,10 @@ function normalizeMethod(method) {
   }
 
   if (method.tag === "other" && typeof method.val === "string" && VALUE_TOKEN_RE.test(method.val)) {
-    return { tag: "other", val: method.val.toLowerCase() };
+    const standard = method.val.toLowerCase();
+    return SUPPORTED_METHODS.includes(standard) && method.val === method.val.toUpperCase()
+      ? { tag: standard }
+      : { tag: "other", val: method.val };
   }
 
   throw new HttpError("invalid-syntax");
@@ -614,7 +617,7 @@ function normalizeScheme(scheme) {
     if (uppercase === "HTTP" || uppercase === "HTTPS") {
       return { tag: uppercase };
     }
-    return { tag: "other", val: scheme.toLowerCase() };
+    return { tag: "other", val: scheme };
   }
 
   if (typeof scheme !== "object" || typeof scheme.tag !== "string") {
@@ -627,7 +630,11 @@ function normalizeScheme(scheme) {
 
   if (scheme.tag === "other" && typeof scheme.val === "string") {
     validateUrlPart(scheme.val, UrlPart.SCHEME);
-    return { tag: "other", val: scheme.val.toLowerCase() };
+    const uppercase = scheme.val.toUpperCase();
+    if (uppercase === "HTTP" || uppercase === "HTTPS") {
+      return { tag: uppercase };
+    }
+    return { tag: "other", val: scheme.val };
   }
 
   throw new HttpError("invalid-syntax");
@@ -657,6 +664,10 @@ function validateUrlPart(value, part) {
 
   // URL parsing may normalize some raw control characters but wasi treats them as invalid syntax.
   if (/[\u0000-\u001f\u007f]/.test(value)) {
+    throw new HttpError("invalid-syntax", `Invalid ${part}: ${value}`);
+  }
+
+  if (part === UrlPart.PATH_WITH_QUERY && /[ <>`]/.test(value)) {
     throw new HttpError("invalid-syntax", `Invalid ${part}: ${value}`);
   }
 

--- a/packages/preview3-shim/lib/nodejs/sockets/tcp.js
+++ b/packages/preview3-shim/lib/nodejs/sockets/tcp.js
@@ -23,6 +23,16 @@ function token() {
   return (TCP_CREATE_TOKEN ??= Symbol("TcpCreateToken"));
 }
 
+function invalidRecv() {
+  const stream = new ReadableStream({
+    start(controller) {
+      controller.close();
+    },
+  });
+  const promise = Promise.reject(new SocketError("invalid-state"));
+  return [new StreamReader(stream, { preventCancel: false }), new FutureReader(promise)];
+}
+
 const STATE = {
   UNBOUND: "unbound",
   BOUND: "bound",
@@ -316,16 +326,10 @@ export class TcpSocket {
    */
   receive() {
     if (this.#state !== STATE.CONNECTED) {
-      throw new SocketError("invalid-state");
+      return invalidRecv();
     }
     if (this.#receiveStarted) {
-      const stream = new ReadableStream({
-        start(controller) {
-          controller.close();
-        },
-      });
-      const promise = Promise.reject(new SocketError("invalid-state"));
-      return [new StreamReader(stream, { preventCancel: false }), new FutureReader(promise)];
+      return invalidRecv();
     }
     this.#receiveStarted = true;
 

--- a/packages/preview3-shim/test/filesystem.test.js
+++ b/packages/preview3-shim/test/filesystem.test.js
@@ -219,6 +219,157 @@ describe("Descriptor with os.tmpdir()", () => {
     expect(entries.some((e) => e.name === entryName)).toBe(true);
   });
 
+  test("preopen descriptors expose directory mutation flags", async () => {
+    const virtualPath = `/preview3-test-flags-${path.basename(tmpDir)}`;
+    filesystem._addPreopen(virtualPath, tmpDir);
+    const [preopen] = filesystem.preopens
+      .getDirectories()
+      .find(([_desc, path]) => path === virtualPath);
+
+    await expect(preopen.getFlags()).resolves.toMatchObject({
+      read: true,
+      mutateDirectory: true,
+    });
+  });
+
+  test("openAt reports effective descriptor flags", async () => {
+    const defaultSub = `${relBase}/flags-default.txt`;
+    await fs.writeFile(path.join(tmpDir, "flags-default.txt"), "");
+    const defaultDesc = await rootDescriptor.openAt({}, defaultSub, {}, {});
+    await expect(defaultDesc.getFlags()).resolves.toMatchObject({
+      read: true,
+      write: false,
+    });
+    defaultDesc[Symbol.dispose]?.();
+
+    const createDefaultSub = `${relBase}/flags-create-default.txt`;
+    const createDefaultDesc = await rootDescriptor.openAt(
+      {},
+      createDefaultSub,
+      { create: true, exclusive: true },
+      {},
+    );
+    await expect(createDefaultDesc.getFlags()).resolves.toMatchObject({
+      read: true,
+      write: true,
+    });
+    createDefaultDesc[Symbol.dispose]?.();
+
+    const createReadSub = `${relBase}/flags-create-read.txt`;
+    const createReadDesc = await rootDescriptor.openAt(
+      {},
+      createReadSub,
+      { create: true, exclusive: true },
+      { read: true },
+    );
+    await expect(createReadDesc.getFlags()).resolves.toMatchObject({
+      read: true,
+      write: true,
+    });
+    createReadDesc[Symbol.dispose]?.();
+
+    const createWriteSub = `${relBase}/flags-create-write.txt`;
+    const createWriteDesc = await rootDescriptor.openAt(
+      {},
+      createWriteSub,
+      { create: true, exclusive: true },
+      { write: true },
+    );
+    await expect(createWriteDesc.getFlags()).resolves.toMatchObject({
+      read: false,
+      write: true,
+    });
+    createWriteDesc[Symbol.dispose]?.();
+  });
+
+  test("empty relative paths reject with no-entry", async () => {
+    const dirDesc = await rootDescriptor.openAt(
+      {},
+      relBase,
+      { directory: true },
+      { read: true, mutateDirectory: true },
+    );
+
+    await expect(dirDesc.openAt({}, "", {}, { read: true })).rejects.toMatchObject({
+      payload: { tag: "no-entry" },
+    });
+    await expect(dirDesc.createDirectoryAt("")).rejects.toMatchObject({
+      payload: { tag: "no-entry" },
+    });
+    await expect(dirDesc.unlinkFileAt("")).rejects.toMatchObject({
+      payload: { tag: "no-entry" },
+    });
+    await expect(dirDesc.linkAt({}, "", dirDesc, "x")).rejects.toMatchObject({
+      payload: { tag: "no-entry" },
+    });
+
+    dirDesc[Symbol.dispose]?.();
+  });
+
+  test("path operations reject symlink escapes from preopen", async () => {
+    const dirDesc = await rootDescriptor.openAt(
+      {},
+      relBase,
+      { directory: true },
+      { read: true, mutateDirectory: true },
+    );
+
+    await dirDesc.symlinkAt("..", "parent.cleanup");
+
+    await expect(dirDesc.createDirectoryAt("parent.cleanup/out")).rejects.toMatchObject({
+      payload: { tag: "not-permitted" },
+    });
+    await expect(dirDesc.statAt({ symlinkFollow: true }, "parent.cleanup")).rejects.toMatchObject({
+      payload: { tag: "not-permitted" },
+    });
+    await expect(dirDesc.linkAt({}, "parent.cleanup/out", dirDesc, "x")).rejects.toMatchObject({
+      payload: { tag: "not-permitted" },
+    });
+    await expect(dirDesc.renameAt("a.txt", dirDesc, "parent.cleanup/out")).rejects.toMatchObject({
+      payload: { tag: "not-permitted" },
+    });
+    await expect(dirDesc.unlinkFileAt("parent.cleanup/out")).rejects.toMatchObject({
+      payload: { tag: "not-permitted" },
+    });
+
+    await fs.unlink(path.join(tmpDir, "parent.cleanup"));
+    dirDesc[Symbol.dispose]?.();
+  });
+
+  test("path operations reject non-directory base descriptors", async () => {
+    const sub = `${relBase}/not-dir-base.txt`;
+    const child = await rootDescriptor.openAt(
+      {},
+      sub,
+      { create: true },
+      { read: true, write: true },
+    );
+
+    await expect(child.statAt({}, ".")).rejects.toMatchObject({
+      payload: { tag: "not-directory" },
+    });
+    await expect(child.openAt({}, ".", {}, { read: true })).rejects.toMatchObject({
+      payload: { tag: "not-directory" },
+    });
+
+    child[Symbol.dispose]?.();
+  });
+
+  test("removeDirectoryAt rejects current directory", async () => {
+    const dirDesc = await rootDescriptor.openAt(
+      {},
+      relBase,
+      { directory: true },
+      { read: true, mutateDirectory: true },
+    );
+
+    await expect(dirDesc.removeDirectoryAt(".")).rejects.toMatchObject({
+      payload: { tag: "invalid" },
+    });
+
+    dirDesc[Symbol.dispose]?.();
+  });
+
   test("isSameObject & metadataHash vs metadataHashAt", async () => {
     const sub = `${relBase}/file3.txt`;
     const child = await rootDescriptor.openAt(

--- a/packages/preview3-shim/test/http/fields.test.js
+++ b/packages/preview3-shim/test/http/fields.test.js
@@ -42,6 +42,16 @@ describe("Fields tests", () => {
     expect(result).toEqual(["a", "b"]);
   });
 
+  test("append preserves existing field name casing", () => {
+    const f = new Fields();
+    f.append("X-Custom", ENCODER.encode("a"));
+    f.append("x-custom", ENCODER.encode("b"));
+    expect(f.copyAll().map(([name, value]) => [name, DECODER.decode(value)])).toEqual([
+      ["X-Custom", "a"],
+      ["X-Custom", "b"],
+    ]);
+  });
+
   test("preserves insertion order in copyAll()", () => {
     const f = new Fields();
     f.append("A", ENCODER.encode("1"));
@@ -59,6 +69,27 @@ describe("Fields tests", () => {
     f.set("Tok", [ENCODER.encode("two"), ENCODER.encode("three")]);
     const vals = f.get("tok").map((v) => DECODER.decode(v));
     expect(vals).toEqual(["two", "three"]);
+  });
+
+  test("set with empty values clears previous values", () => {
+    const f = new Fields();
+    f.append("Tok", ENCODER.encode("one"));
+    f.set("Tok", []);
+    expect(f.has("tok")).toBe(false);
+    expect(f.get("tok")).toEqual([]);
+  });
+
+  test("allows obs-text field value bytes", () => {
+    const f = new Fields();
+    const value = Uint8Array.from([0x80, 0xff]);
+    f.set("Tok", [value]);
+    expect(f.get("tok")).toEqual([value]);
+  });
+
+  test("rejects invalid control bytes in field values", () => {
+    const f = new Fields();
+    expect(() => f.set("Tok", [Uint8Array.from([0x00])])).toThrow(HttpError);
+    expect(() => f.append("Tok", Uint8Array.from([0x7f]))).toThrow(HttpError);
   });
 
   test("delete removes the header entirely", () => {

--- a/packages/preview3-shim/test/http/request.test.js
+++ b/packages/preview3-shim/test/http/request.test.js
@@ -32,6 +32,23 @@ describe("Request", () => {
     expect(req.getAuthority()).toBeUndefined();
   });
 
+  test("setPathWithQuery normalizes an empty path to slash", () => {
+    const [req] = Request.new(headers, contents, trailers, options);
+
+    req.setPathWithQuery("");
+    expect(req.getPathWithQuery()).toBe("/");
+  });
+
+  test("setPathWithQuery rejects raw invalid URI characters", () => {
+    const [req] = Request.new(headers, contents, trailers, options);
+
+    for (const path of ["/ ", "/<", "/>", "/`"]) {
+      expect(() => req.setPathWithQuery(path)).toThrowError(
+        expect.objectContaining({ payload: { tag: "invalid-syntax" } }),
+      );
+    }
+  });
+
   test("new() accepts generated stream-like bodies and promise trailers", async () => {
     const body = { read: async () => null };
     const [req, fut] = Request.new(headers, body, Promise.resolve({ tag: "ok", val: null }));
@@ -69,6 +86,18 @@ describe("Request", () => {
 
     req.setMethod("X-CUSTOM");
     expect(req.getMethod()).toEqual({ tag: "other", val: "x-custom" });
+
+    req.setMethod({ tag: "other", val: "GET" });
+    expect(req.getMethod()).toEqual({ tag: "get" });
+
+    req.setMethod({ tag: "other", val: "get" });
+    expect(req.getMethod()).toEqual({ tag: "other", val: "get" });
+
+    req.setMethod({ tag: "other", val: "Custom" });
+    expect(req.getMethod()).toEqual({ tag: "other", val: "Custom" });
+
+    req.setMethod({ tag: "other", val: "!*+-.^_`|~09" });
+    expect(req.getMethod()).toEqual({ tag: "other", val: "!*+-.^_`|~09" });
   });
 
   test("setMethod rejects invalid syntax", () => {
@@ -84,6 +113,15 @@ describe("Request", () => {
 
     req.setScheme({ tag: "HTTPS" });
     expect(req.getScheme()).toEqual({ tag: "HTTPS" });
+
+    req.setScheme({ tag: "other", val: "https" });
+    expect(req.getScheme()).toEqual({ tag: "HTTPS" });
+
+    req.setScheme({ tag: "other", val: "http" });
+    expect(req.getScheme()).toEqual({ tag: "HTTP" });
+
+    req.setScheme({ tag: "other", val: "Custom" });
+    expect(req.getScheme()).toEqual({ tag: "other", val: "Custom" });
 
     req.setScheme(undefined);
     expect(req.getScheme()).toBeUndefined();


### PR DESCRIPTION
This patch fixes some of the wasi semantics that wasi-testsuite tests. This make the following tests from wasi-testsuite pass:

 - filesystem-hard-links
 - filesystem-is-same-object
 - filesystem-metadata-hash
 - filesystem-mkdir-rmdir
 - filesystem-open-errors
 - filesystem-rename
 - filesystem-unlink-errors
 - http-fields
 - http-request
 - http-response
 - sockets-tcp-receive
 - sockets-udp-send