### PR TITLE
fix(bindgen): lower async flag results with js field names

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/lower.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lower.rs
@@ -846,10 +846,14 @@ impl LowerIntrinsic {
 
                             let flagObj = ctx.vals[0];
                             let flagValue = 0;
-                            for (const [idx, name] of names.entries()) {{
-                                if (flagObj[name] === true) {{
-                                    flagValue |= 1 << idx;
+                            if (typeof flagObj === 'object' && flagObj !== null) {{
+                                for (const [idx, name] of names.entries()) {{
+                                    if (flagObj[name] === true) {{
+                                        flagValue |= 1 << idx;
+                                    }}
                                 }}
+                            }} else if (flagObj !== null && flagObj !== undefined) {{
+                                throw new TypeError('only an object, undefined or null can be converted to flags');
                             }}
 
                             const rem = ctx.storagePtr % align32;

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -5110,7 +5110,7 @@ pub fn gen_flat_lift_fn_js_expr(
                 flags_ty
                     .names
                     .iter()
-                    .map(|s| format!("'{s}'"))
+                    .map(|s| format!("'{}'", s.to_lower_camel_case()))
                     .collect::<Vec<_>>()
                     .join(",")
             );
@@ -5669,7 +5669,7 @@ pub fn gen_flat_lower_fn_js_expr(
                 flags_ty
                     .names
                     .iter()
-                    .map(|s| format!("'{s}'"))
+                    .map(|s| format!("'{}'", s.to_lower_camel_case()))
                     .collect::<Vec<_>>()
                     .join(",")
             );

--- a/crates/test-components/src/bin/async_lower_result_pointer.rs
+++ b/crates/test-components/src/bin/async_lower_result_pointer.rs
@@ -19,6 +19,13 @@ impl local_run_async::Guest for Component {
 
         let result = async_lower_result_pointer_host::add_five(1, 2, 3, 4, 5).await;
         assert_eq!(result, Ok(15));
+
+        let flags = async_lower_result_pointer_host::get_flags().await;
+        assert_eq!(
+            flags,
+            Ok(async_lower_result_pointer_host::TestFlags::FIRST
+                | async_lower_result_pointer_host::TestFlags::THIRD_FLAG,),
+        );
     }
 }
 

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -21,7 +21,14 @@ interface async-add-s32 {
 }
 
 interface async-lower-result-pointer-host {
+    flags test-flags {
+        first,
+        second-flag,
+        third-flag,
+    }
+
     add-five: async func(a: u32, b: u32, c: u32, d: u32, e: u32) -> result<u32, string>;
+    get-flags: async func() -> result<test-flags, string>;
 }
 
 interface sync-lower-result-pointer-host {

--- a/packages/jco/test/p3/async.js
+++ b/packages/jco/test/p3/async.js
@@ -45,6 +45,7 @@ suite("Async (WASI P3)", () => {
                     ...new WASIShim().getImportObject(),
                     "jco:test-components/async-lower-result-pointer-host": {
                         addFive: async (a, b, c, d, e) => a + b + c + d + e,
+                        getFlags: async () => ({ first: true, thirdFlag: true }),
                     },
                     "jco:test-components/sync-lower-result-pointer-host": {
                         addPair: (a, b, c, d, e) => [a + b + c + d + e, a * b * c * d * e],


### PR DESCRIPTION
 Normalize flag names when lowering so async result accepts js camel fields and not only raw wit kebab case names. This was found when using name like `mutate-directory` from wasi-testsuite.