### PR TITLE
fix(bindgen): generate ASYNC_BLOCKED_CODE for futures

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -1549,6 +1549,12 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
         || args
             .intrinsics
             .contains(&Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamRead))
+        || args
+            .intrinsics
+            .contains(&Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureWrite))
+        || args
+            .intrinsics
+            .contains(&Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureRead))
     {
         args.intrinsics.extend([
             &Intrinsic::GlobalBufferManager,


### PR DESCRIPTION
This fixes: `ReferenceError: ASYNC_BLOCKED_CODE is not defined`

This can be triggered in the code that uses futures only and without ever referencing streams.