### PR TITLE
fix(bindgen): complete host stream reads after partial progress

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -2190,6 +2190,7 @@ impl AsyncStreamIntrinsic {
                                   if (readEnd.hasPendingEvent()) {{ return bail(); }}
                                   if (!hasPendingReadBuffer()) {{ return bail(); }}
                                   drainPendingValues();
+                                  if (values.length > 0) {{ break; }}
                                   if (appended === 0 && !pendingValues.done) {{ count -= 1; }}
                                   if (pendingValues.done) {{ break; }}
                               }}

--- a/crates/test-components/src/bin/stream_lower.rs
+++ b/crates/test-components/src/bin/stream_lower.rs
@@ -6,7 +6,7 @@ mod bindings {
     export!(Component);
 }
 
-use wit_bindgen::{FutureReader, StreamReader};
+use wit_bindgen::{FutureReader, StreamReader, StreamResult};
 
 use bindings::exports::jco::test_components::stream_lower_async;
 use bindings::exports::jco::test_components::stream_lower_sync;
@@ -52,6 +52,12 @@ impl stream_lower_async::Guest for Component {
 
     async fn read_stream_values_u32(rx: StreamReader<u32>) -> Vec<u32> {
         read_async_values(rx).await
+    }
+
+    async fn read_stream_values_u32_oversized_read(mut rx: StreamReader<u32>) -> Vec<u32> {
+        let (result, vals) = rx.read(Vec::with_capacity(100)).await;
+        assert_eq!(result, StreamResult::Complete(vals.len()));
+        vals
     }
 
     async fn read_stream_values_s32(rx: StreamReader<i32>) -> Vec<i32> {

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -378,6 +378,7 @@ interface stream-lower-async {
     read-stream-values-s16: async func(s: stream<s16>) -> list<s16>;
 
     read-stream-values-u32: async func(s: stream<u32>) -> list<u32>;
+    read-stream-values-u32-oversized-read: async func(s: stream<u32>) -> list<u32>;
     read-stream-values-s32: async func(s: stream<s32>) -> list<s32>;
 
     read-stream-values-u64: async func(s: stream<u64>) -> list<u64>;

--- a/packages/jco/test/p3/stream-lowers.js
+++ b/packages/jco/test/p3/stream-lowers.js
@@ -207,6 +207,10 @@ suite("stream<T> lowers", () => {
         test.concurrent("u32/s32", async () => {
             const instance = await getInstance();
             assert.instanceOf(instance["jco:test-components/stream-lower-async"].readStreamValuesU32, AsyncFunction);
+            assert.instanceOf(
+                instance["jco:test-components/stream-lower-async"].readStreamValuesU32OversizedRead,
+                AsyncFunction,
+            );
             assert.instanceOf(instance["jco:test-components/stream-lower-async"].readStreamValuesS32, AsyncFunction);
 
             let vals = [10, 5, 0];
@@ -214,6 +218,17 @@ suite("stream<T> lowers", () => {
                 createReadableStreamFromValues(vals),
             );
             assert.deepEqual(returnedVals, toTypedArray(Uint32Array, vals));
+
+            const openStream = new ReadableStream({
+                start(ctrl) {
+                    ctrl.enqueue(10);
+                },
+            });
+            returnedVals = await Promise.race([
+                instance["jco:test-components/stream-lower-async"].readStreamValuesU32OversizedRead(openStream),
+                new Promise((_, reject) => setTimeout(() => reject(new Error("stream read timed out")), 1_000)),
+            ]);
+            assert.deepEqual(returnedVals, toTypedArray(Uint32Array, [10]));
 
             vals = [-32, 90001, 3200000];
             returnedVals = await instance["jco:test-components/stream-lower-async"].readStreamValuesS32(


### PR DESCRIPTION
Host stream reads should return once any values have been copied, even when the guest buffer has remaining capacity.

This was found in wasi-testsuite socket-echo test:

```rust
 let (result, data) = recv_stream.read(Vec::with_capacity(100)).await;
 assert_eq!(result, StreamResult::Complete(data.len()));
```

and the test config sends only "Hello, world".