### PR TITLE
fix(p3-shim): handle sub milisecond waits

### DIFF
--- a/packages/preview3-shim/lib/nodejs/clocks.js
+++ b/packages/preview3-shim/lib/nodejs/clocks.js
@@ -27,6 +27,7 @@ export const systemClock = {
 const { subscribeInstant, subscribeDuration, ...baseMonotonicClock } = monotonicClockV2;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const nsToTimeoutMs = (ns) => (ns + 999_999n) / 1_000_000n;
 
 export const monotonicClock = {
   ...baseMonotonicClock,
@@ -58,19 +59,21 @@ export const monotonicClock = {
    * @throws {TypeError} If targetNs is not a bigint
    */
   async waitUntil(targetNs) {
-    const nowNs = monotonicClock.now();
-    const diffNs = targetNs - nowNs;
+    while (true) {
+      const nowNs = monotonicClock.now();
+      const diffNs = targetNs - nowNs;
 
-    if (diffNs <= 0n) {
-      return;
+      if (diffNs <= 0n) {
+        return;
+      }
+
+      const ms = nsToTimeoutMs(diffNs);
+      if (ms > BigInt(Number.MAX_SAFE_INTEGER)) {
+        throw new TypeError(`Cannot wait for ${targetNs} ns, exceeds maximum safe integer`);
+      }
+
+      await sleep(Number(ms));
     }
-
-    const ms = diffNs / 1_000_000n;
-    if (ms > BigInt(Number.MAX_SAFE_INTEGER)) {
-      throw new TypeError(`Cannot wait for ${targetNs} ns, exceeds maximum safe integer`);
-    }
-
-    await sleep(Number(ms));
   },
 
   /**
@@ -90,11 +93,6 @@ export const monotonicClock = {
       return;
     }
 
-    const ms = durationNs / 1_000_000n;
-    if (ms > BigInt(Number.MAX_SAFE_INTEGER)) {
-      throw new TypeError(`Cannot wait for ${durationNs} ns, exceeds maximum safe integer`);
-    }
-
-    await sleep(Number(ms));
+    await monotonicClock.waitUntil(monotonicClock.now() + durationNs);
   },
 };

--- a/packages/preview3-shim/test/clocks.test.js
+++ b/packages/preview3-shim/test/clocks.test.js
@@ -14,6 +14,10 @@ describe("monotonic clock tests", () => {
 
   test("waits for the correct timeout in waitFor", async () => {
     const waitForSpy = vi.fn(monotonicClock.waitFor);
+    vi.spyOn(monotonicClock, "now")
+      .mockReturnValueOnce(0n)
+      .mockReturnValueOnce(0n)
+      .mockReturnValue(250_000_000n);
     const promise = waitForSpy(250_000_000n); // 250ms
 
     vi.advanceTimersByTime(249);
@@ -40,7 +44,7 @@ describe("monotonic clock tests", () => {
 
   test("waits until target time in waitUntil", async () => {
     const waitUntilSpy = vi.fn(monotonicClock.waitUntil.bind(monotonicClock));
-    vi.spyOn(monotonicClock, "now").mockReturnValue(100n);
+    vi.spyOn(monotonicClock, "now").mockReturnValueOnce(100n).mockReturnValue(350_000_000n);
     const promise = waitUntilSpy(350_000_000n); // 350 ms target
 
     vi.advanceTimersByTime(349);
@@ -49,6 +53,37 @@ describe("monotonic clock tests", () => {
     vi.advanceTimersByTime(1);
     await promise;
     expect(waitUntilSpy).toHaveResolved();
+  });
+
+  test("waitUntil rounds positive sub-millisecond waits up", async () => {
+    const waitUntilSpy = vi.fn(monotonicClock.waitUntil.bind(monotonicClock));
+    vi.spyOn(monotonicClock, "now").mockReturnValueOnce(1n).mockReturnValue(1_000_000n);
+    const promise = waitUntilSpy(1_000_000n);
+
+    vi.advanceTimersByTime(0);
+    await Promise.resolve();
+    expect(waitUntilSpy).not.toHaveResolved();
+
+    vi.advanceTimersByTime(1);
+    await promise;
+    expect(waitUntilSpy).toHaveResolved();
+  });
+
+  test("waitFor rounds positive sub-millisecond waits up", async () => {
+    const waitForSpy = vi.fn(monotonicClock.waitFor);
+    vi.spyOn(monotonicClock, "now")
+      .mockReturnValueOnce(0n)
+      .mockReturnValueOnce(0n)
+      .mockReturnValue(1n);
+    const promise = waitForSpy(1n);
+
+    vi.advanceTimersByTime(0);
+    await Promise.resolve();
+    expect(waitForSpy).not.toHaveResolved();
+
+    vi.advanceTimersByTime(1);
+    await promise;
+    expect(waitForSpy).toHaveResolved();
   });
 
   test("throws if duration exceeds MAX_SAFE_INTEGER in waitFor", async () => {


### PR DESCRIPTION
Add recheck `monotonicClock.now()` after each wake in wait functions and continue waiting until the target is reached.