### PR TITLE
fix(bindgen): let host provided imports enter immediately

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -1068,11 +1068,16 @@ impl AsyncTaskIntrinsic {
 
                             const cstate = {get_or_create_async_state_fn}(this.#componentIdx);
 
+                            if (opts?.isHost) {{
+                                this.#entered = true;
+                                return this.#entered;
+                            }}
+
                             await cstate.nextTaskExecutionSlot({{ task: this }});
 
-                            // If a task is either synchronous or host-provided (e.g. a host import, whether sync or async)
-                            // then we can avoid component-relevant tracking and immediately enter
-                            if (this.isSync() || opts?.isHost) {{
+                            // If a task is synchronous then we can avoid component-relevant
+                            // tracking and immediately enter.
+                            if (this.isSync()) {{
                                 this.#entered = true;
 
                                 // TODO(breaking): remove once manually-specifying async fns is removed

--- a/crates/test-components/src/bin/host_import_concurrency.rs
+++ b/crates/test-components/src/bin/host_import_concurrency.rs
@@ -1,0 +1,25 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "host-import-concurrency",
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::local_run_async;
+use bindings::jco::test_components::host_import_concurrency_host;
+
+struct Component;
+
+impl local_run_async::Guest for Component {
+    async fn run() {
+        let (value, ()) = futures::join!(
+            async { host_import_concurrency_host::wait().await },
+            async { host_import_concurrency_host::signal().await },
+        );
+
+        assert_eq!(value, 42);
+    }
+}
+
+fn main() {}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -317,6 +317,16 @@ world future-concurrency {
   export local-run-async;
 }
 
+interface host-import-concurrency-host {
+  wait: async func() -> u32;
+  signal: async func();
+}
+
+world host-import-concurrency {
+  import host-import-concurrency-host;
+  export local-run-async;
+}
+
 interface stream-concurrency-host {
   signal: func();
   zero-read-complete: func();

--- a/packages/jco/test/p3/deadlock-regressions.js
+++ b/packages/jco/test/p3/deadlock-regressions.js
@@ -8,6 +8,38 @@ import { setupAsyncTest } from "../helpers.js";
 import { LOCAL_TEST_COMPONENTS_DIR, toTypedArrayChunks } from "../common.js";
 
 suite("async scheduling regressions", () => {
+    test("host import can be unblocked by a host import sibling", async () => {
+        const signaled = Promise.withResolvers();
+        let signalCalled = false;
+
+        const { instance, cleanup } = await setupAsyncTest({
+            asyncMode: "jspi",
+            component: {
+                path: join(LOCAL_TEST_COMPONENTS_DIR, "host-import-concurrency.wasm"),
+                imports: {
+                    ...new WASIShim().getImportObject(),
+                    "jco:test-components/host-import-concurrency-host": {
+                        wait: async () => {
+                            await signaled.promise;
+                            return 42;
+                        },
+                        signal: async () => {
+                            signalCalled = true;
+                            signaled.resolve();
+                        },
+                    },
+                },
+            },
+        });
+
+        try {
+            await instance["jco:test-components/local-run-async"].run();
+            assert.isTrue(signalCalled);
+        } finally {
+            await cleanup();
+        }
+    });
+
     test("host future can be completed by a guest sibling task", async () => {
         const { instance, cleanup } = await setupAsyncTest({
             asyncMode: "jspi",


### PR DESCRIPTION
The patch makes host provided imports bypass task queue. Also add regression based on wasi-testsuite `udp-receive` test.