### PR TITLE
Fix js component bindgen helper emission

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/lift.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lift.rs
@@ -724,7 +724,7 @@ impl LiftIntrinsic {
 
                         if (ctx.useDirectParams) {{
                             if (ctx.params.length < 2) {{ throw new Error('expected at least two u32 arguments'); }}
-                            const offset = ctx.params[0];
+                            let offset = ctx.params[0];
                             if (typeof offset === 'bigint') {{ offset = Number(offset); }}
                             if (!Number.isSafeInteger(offset)) {{  throw new Error('invalid offset'); }}
                             const len = ctx.params[1];

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -1360,7 +1360,7 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
             .contains(&Intrinsic::Lift(LiftIntrinsic::LiftFlatOption))
         | args
             .intrinsics
-            .contains(&Intrinsic::Lift(LiftIntrinsic::LiftFlatOption))
+            .contains(&Intrinsic::Lift(LiftIntrinsic::LiftFlatEnum))
     {
         args.intrinsics
             .extend([&Intrinsic::Lift(LiftIntrinsic::LiftFlatVariant)]);

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -1551,6 +1551,12 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
         ]);
     }
 
+    if args.intrinsics.contains(&Intrinsic::AsyncStream(
+        AsyncStreamIntrinsic::ExternalStreamClass,
+    )) {
+        args.intrinsics.insert(Intrinsic::SymbolResourceRep);
+    }
+
     if args
         .intrinsics
         .contains(&Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamWrite))


### PR DESCRIPTION
## Summary

This fixes three small generated-JS correctness issues in `js-component-bindgen`.

1. UTF-16 string lifting now emits a mutable `offset` binding.
   - `_liftFlatStringUTF16` reassigns `offset` when normalizing bigint direct params.
   - The generated helper now uses `let offset`, matching the UTF-8 helper.
   - Fixes #1644

2. Enum lifting now emits its variant helper dependency.
   - `_liftFlatEnum` delegates to `_liftFlatVariant`.
   - `LiftFlatEnum` now requests `LiftFlatVariant`.
   - Fixes #1643

3. External stream generation now emits the resource-rep symbol dependency.
   - The generated external `Stream` class stores `args.globalRep` using `symbolRscRep`.
   - `SymbolResourceRep` is added after all paths that can request `ExternalStreamClass`.
   - This covers both lifted streams and streams created from lift.
   - Fixes #1645

## Verification

- `cargo check -p js-component-bindgen`
- Local generated-output checks for:
  - string-only UTF-16 helper
  - enum-only import lifting
  - stream export/import shapes