### PR TITLE
fix(bindgen): avoid using task.reject

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1611,7 +1611,6 @@ impl Bindgen for FunctionBindgen<'_> {
                                   err,
                               }});
                               task.setErrored(err);
-                              task.reject(err);
                               task.exit();
                               return task.completionPromise();
                             "#
@@ -1628,7 +1627,6 @@ impl Bindgen for FunctionBindgen<'_> {
                                   err,
                               }});
                               task.setErrored(err);
-                              task.reject(err);
                               task.exit();
                               throw err;
                             "#
@@ -1857,7 +1855,6 @@ impl Bindgen for FunctionBindgen<'_> {
                                   err,
                               }});
                               task.setErrored(err);
-                              task.reject(err);
                               task.exit();
                               return task.completionPromise();
                             "#
@@ -1875,7 +1872,6 @@ impl Bindgen for FunctionBindgen<'_> {
                                   err,
                               }});
                               task.setErrored(err);
-                              task.reject(err);
                               task.exit();
                               throw err;
                             "#


### PR DESCRIPTION
This commit fixes the unhandled rejections caused by `task.reject`ing failed executions (especially in the case of host calls).