### PR TITLE
fix(bindgen): export result handling, stricter resolution check

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -1611,6 +1611,7 @@ impl Bindgen for FunctionBindgen<'_> {
                                   err,
                               }});
                               task.setErrored(err);
+                              task.reject(err);
                               task.exit();
                               return task.completionPromise();
                             "#
@@ -1627,6 +1628,7 @@ impl Bindgen for FunctionBindgen<'_> {
                                   err,
                               }});
                               task.setErrored(err);
+                              task.reject(err);
                               task.exit();
                               throw err;
                             "#
@@ -1855,6 +1857,7 @@ impl Bindgen for FunctionBindgen<'_> {
                                   err,
                               }});
                               task.setErrored(err);
+                              task.reject(err);
                               task.exit();
                               return task.completionPromise();
                             "#
@@ -1872,6 +1875,7 @@ impl Bindgen for FunctionBindgen<'_> {
                                   err,
                               }});
                               task.setErrored(err);
+                              task.reject(err);
                               task.exit();
                               throw err;
                             "#

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -903,9 +903,11 @@ impl AsyncTaskIntrinsic {
                                reject: rejectCompletionPromise,
                            }} = {promise_with_resolvers_fn}();
                            this.#completionPromise = completionPromise;
-                           this.#completionPromise.catch(err => {{}});
 
                            this.#onResolveHandlers.push((results) => {{
+                               if (this.#parentSubtask !== null) {{ return; }}
+                               if (!this.#isAsync) {{ return; }}
+
                                if (this.#errored !== null) {{
                                    rejectCompletionPromise(this.#errored);
                                    return;
@@ -913,6 +915,7 @@ impl AsyncTaskIntrinsic {
                                    rejectCompletionPromise(results);
                                    return;
                                }}
+
                                resolveCompletionPromise(results);
                            }});
 
@@ -922,7 +925,6 @@ impl AsyncTaskIntrinsic {
                                reject: rejectExitPromise,
                            }} = {promise_with_resolvers_fn}();
                            this.#exitPromise = exitPromise;
-                           exitPromise.catch(err => {{}});
 
                            this.#onExitHandlers.push(() => {{
                                resolveExitPromise();
@@ -1340,10 +1342,6 @@ impl AsyncTaskIntrinsic {
 
                             if (this.isResolvedState() || this.#rejected) {{ return; }}
 
-                            for (const subtask of this.#subtasks) {{
-                                subtask.reject(taskErr);
-                            }}
-
                             this.#rejected = true;
                             this.cancelRequested = true;
                             this.#state = {task_class}.State.PENDING_CANCEL;
@@ -1401,20 +1399,7 @@ impl AsyncTaskIntrinsic {
                             if (this.#exited)  {{ throw new Error("task has already exited"); }}
 
                             if (this.#state !== {task_class}.State.RESOLVED) {{
-                                // If we've hit a task exit with the task in an errored state due to some
-                                // error during execution, we need to reject the task before exiting
-                                if (this.isErrored()) {{
-                                    this.reject(this.#errored);
-                                }} else {{
-                                    throw new Error(`(component [${{this.#componentIdx}}]) task [${{this.#id}}] exited without resolution`);
-                                    {debug_log_fn}('[{task_class}#exit()] task exited without resolution', {{
-                                        componentIdx: this.#componentIdx,
-                                        taskID: this.#id,
-                                        subtask: this.getParentSubtask(),
-                                        subtaskID: this.getParentSubtask()?.id(),
-                                    }});
-                                    this.#state = {task_class}.State.RESOLVED;
-                                }}
+                                throw new Error(`(component [${{this.#componentIdx}}]) task [${{this.#id}}] exited without resolution`);
                             }}
 
                             if (this.borrowedHandles > 0) {{

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2695,12 +2695,13 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   glob@13.0.6:


### PR DESCRIPTION
This commit re-adds some previous task rejections and fixes a bug in the sync throw case, ensuring that sync tasks do not reject the relevant completion promise to avoid triggering an uncaught exception.