### PR TITLE
fix(bindgen): plug subtask memory leak during sync host calls

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -758,6 +758,7 @@ impl Intrinsic {
                 output.push_str(&format!(r#"
                     class {rep_table_class} {{
                         #data = [0, null];
+                        #size = 0;
                         #target;
 
                         constructor(args) {{
@@ -774,6 +775,7 @@ impl Intrinsic {
                                 this.#data.push(null);
                                 const rep = (this.#data.length >> 1) - 1;
                                 {debug_log_fn}('[{rep_table_class}#insert()] inserted', {{ val, target: this.target, rep }});
+                                this.#size += 1;
                                 return rep;
                             }}
                             this.#data[0] = this.#data[freeIdx << 1];
@@ -781,6 +783,7 @@ impl Intrinsic {
                             this.#data[placementIdx] = val;
                             this.#data[placementIdx + 1] = null;
                             {debug_log_fn}('[{rep_table_class}#insert()] inserted', {{ val, target: this.target, rep: freeIdx }});
+                            this.#size += 1;
                             return freeIdx;
                         }}
 
@@ -811,9 +814,12 @@ impl Intrinsic {
 
                             this.#data[baseIdx] = this.#data[0];
                             this.#data[0] = rep;
+                            this.#size -= 1;
 
                             return val;
                         }}
+
+                        size() {{ return this.#size; }}
 
                         clear() {{
                             {debug_log_fn}('[{rep_table_class}#clear()] args', {{ rep, target: this.target }});

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -547,19 +547,22 @@ impl AsyncTaskIntrinsic {
                 let subtask_drop_fn = Self::SubtaskDrop.name();
                 let get_or_create_async_state_fn =
                     Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
-                output.push_str(&format!("
+                uwriteln!(
+                    output,
+                    r#"
                     function {subtask_drop_fn}(componentIdx, subtaskWaitableRep) {{
                         {debug_log_fn}('[{subtask_drop_fn}()] args', {{ componentIdx, subtaskWaitableRep }});
 
                         const cstate = {get_or_create_async_state_fn}(componentIdx);
                         if (!cstate.mayLeave) {{ throw new Error('component is not marked as may leave, cannot be cancelled'); }}
 
-                        const subtask =  cstate.handles.remove(subtaskWaitableRep);
+                        const subtask = cstate.handles.remove(subtaskWaitableRep);
                         if (!subtask) {{ throw new Error('missing/invalid subtask specified for drop in component instance'); }}
 
                         subtask.drop();
                     }}
-                "));
+                "#
+                );
             }
 
             Self::Yield => {
@@ -1463,7 +1466,6 @@ impl AsyncTaskIntrinsic {
                             newSubtask.setTarget(`subtask (internal ID [${{newSubtask.id()}}], waitable [${{waitable.idx()}}], component [${{componentIdx}}])`);
                             waitable.setIdx(cstate.handles.insert(newSubtask));
                             waitable.setTarget(`waitable for subtask (waitable id [${{waitable.idx()}}], subtask internal ID [${{newSubtask.id()}}])`);
-
                             return newSubtask;
                         }}
 
@@ -1483,7 +1485,9 @@ impl AsyncTaskIntrinsic {
                         }}
 
                         removeSubtask(subtask) {{
-                            if (this.#subtasks.length === 0) {{ throw new Error('cannot end current subtask: no current subtask'); }}
+                            if (this.#subtasks.length === 0) {{
+                                throw new Error('cannot end current subtask: no current subtask');
+                            }}
                             this.#subtasks = this.#subtasks.filter(t => t !== subtask);
                             return subtask;
                         }}
@@ -1745,6 +1749,18 @@ impl AsyncTaskIntrinsic {
 
                             this.#resolved = true;
                             this.#parentTask.removeSubtask(this);
+
+                            if (!this.isAsync) {{
+                                this.deliverResolve();
+                                const rep = this.waitableRep();
+                                if (rep) {{
+                                    const removed = this.#getComponentState().handles.remove(rep);
+                                    if (removed !== this) {{
+                                        throw new Error("unexpectedly received non-self Subtask from handle removal");
+                                    }}
+                                }}
+                                this.drop();
+                            }}
                         }}
 
                         getStateNumber() {{ return this.#state; }}


### PR DESCRIPTION
This commit fixes a memory leak that occurred during host calls, as they do not call `subtask.drop` similar to async calls. Subtask objects accumulated in the `RepTable` class that tracks them (via `cstate.handles`) and were not being removed when a subtask itself would resolve.

Resolves #1675 