### PR TITLE
testjco): add regression test for subtask leak

### DIFF
--- a/crates/test-components/src/bin/host_call_loop_sync.rs
+++ b/crates/test-components/src/bin/host_call_loop_sync.rs
@@ -1,0 +1,23 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "host-call-loop-sync",
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::local_run_n;
+use bindings::jco::test_components::tick;
+
+struct Component;
+
+impl local_run_n::Guest for Component {
+    fn run(n: u32) {
+        for _ in 0..n {
+            tick::tick();
+        }
+    }
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -8,6 +8,10 @@ interface local-run {
     run: func();
 }
 
+interface local-run-n {
+    run: func(n: u32);
+}
+
 interface local-run-string {
     run: func() -> string;
 }
@@ -49,7 +53,8 @@ interface example-types {
         float(f32),
         float64(f64),
         maybe-u32(option<u32>),
-    }
+
+}
 
     variant layout-variant {
         empty,
@@ -569,4 +574,13 @@ interface throw {
 world host-instant-throw {
     import throw;
     export local-run;
+}
+
+interface tick {
+    tick: func();
+}
+
+world host-call-loop-sync {
+    import tick;
+    export local-run-n;
 }

--- a/packages/jco/package.json
+++ b/packages/jco/package.json
@@ -73,7 +73,7 @@
     "dependencies": {
         "@bytecodealliance/componentize-js": "^0.21.0",
         "@bytecodealliance/componentize-js-0-19-3": "npm:@bytecodealliance/componentize-js@^0.19.3",
-        "@bytecodealliance/jco-transpile": "^0.3.6",
+        "@bytecodealliance/jco-transpile": "^0.3.8",
         "@bytecodealliance/preview2-shim": "^0.17.9",
         "@bytecodealliance/preview3-shim": "^0.1.2",
         "binaryen": "^130.0.0",

--- a/packages/jco/test/imports.js
+++ b/packages/jco/test/imports.js
@@ -23,13 +23,13 @@ suite("imports", () => {
                     },
                 },
             },
-            jco: {
-                transpile: {
-                    extraArgs: {
-                        minify: false,
-                    },
-                },
-            },
+            // jco: {
+            //     transpile: {
+            //         extraArgs: {
+            //             minify: false,
+            //         },
+            //     },
+            // },
         });
 
         expect(instance["jco:test-components/local-run"].run).toThrow(42);

--- a/packages/jco/test/memory.js
+++ b/packages/jco/test/memory.js
@@ -1,20 +1,23 @@
-import { fileURLToPath, URL } from "node:url";
-import { version } from "node:process";
-import { tmpdir } from "node:os";
-import { mkdir, writeFile, mkdtemp } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import { fileURLToPath, URL } from "node:url";
+import { memoryUsage } from "node:process";
+import { mkdir, writeFile, mkdtemp } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { version } from "node:process";
 
 import { suite, test, assert } from "vitest";
+import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
 
 import { transpile } from "../src/api.js";
 
-import { readComponentBytes, exec } from "./helpers.js";
+import { LOCAL_TEST_COMPONENTS_DIR } from "./common.js";
+import { readComponentBytes, exec, setupAsyncTest } from "./helpers.js";
 
 const ADDER_COMPONENT_PATH = fileURLToPath(new URL("./fixtures/components/adder.component.wasm", import.meta.url));
 
 const CALL_COUNT = 1_000_000;
 
-suite("Memory", () => {
+suite("memory", () => {
     // see: https://github.com/bytecodealliance/jco/issues/937
     test("does not leak during numerous transpile calls", async () => {
         let nodeMajorVersion = parseInt(version.replace("v", "").split(".")[0]);
@@ -67,5 +70,42 @@ process.stdout.write(JSON.stringify({ runs, memoryUsage: { before, after } }));
             afterUsageRSS < beforeUsageRSS + expectedUsageMB,
             `< 30MB used for extra memory (actual ${actualUsageMB}MB)`,
         );
+    });
+
+    // see: https://github.com/bytecodealliance/jco/issues/1675
+    test("host call loop", async () => {
+        let ticks = 1_000;
+        let memGrowthLimitMB = 1000 * 1000 * 10;
+
+        const name = "host-call-loop-sync";
+        const { instance, cleanup } = await setupAsyncTest({
+            component: {
+                path: join(LOCAL_TEST_COMPONENTS_DIR, `${name}.wasm`),
+                imports: {
+                    ...new WASIShim().getImportObject(),
+                    "jco:test-components/tick": {
+                        tick: () => {
+                            ticks -= 1;
+                        },
+                    },
+                },
+            },
+            // jco: {
+            //     transpile: {
+            //         extraArgs: {
+            //             minify: false,
+            //         },
+            //     },
+            // },
+        });
+
+        const before = memoryUsage();
+        instance["jco:test-components/local-run-n"].run(ticks);
+        assert.strictEqual(ticks, 0);
+        const after = memoryUsage();
+        const bytesUsed = after.rss - before.rss;
+        assert.isBelow(bytesUsed, memGrowthLimitMB, "no more than 1MB should be additionally used");
+
+        await cleanup();
     });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,8 +259,8 @@ importers:
         specifier: npm:@bytecodealliance/componentize-js@^0.19.3
         version: '@bytecodealliance/componentize-js@0.19.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)'
       '@bytecodealliance/jco-transpile':
-        specifier: ^0.3.6
-        version: 0.3.6
+        specifier: ^0.3.8
+        version: 0.3.8
       '@bytecodealliance/preview2-shim':
         specifier: ^0.17.9
         version: 0.17.9
@@ -458,8 +458,8 @@ packages:
   '@bytecodealliance/jco-transpile@0.1.3':
     resolution: {integrity: sha512-SiEcmlbzOzd00v6XwfO+80B6lgc1KjWt8irykadbJWP00RMJrPMopY9FEXE689HNrx/PeBUCCWwgDEnrgn2uBg==}
 
-  '@bytecodealliance/jco-transpile@0.3.6':
-    resolution: {integrity: sha512-BMwNRxeXvTHLKQPkEAi4Zhx8Qje0oc8R5IZNhOkqpEmIObzkqSTgvV4DOSCEwn3gd8klIvr9C8u872+W0r2a4A==}
+  '@bytecodealliance/jco-transpile@0.3.8':
+    resolution: {integrity: sha512-DZ7jTGT9Fdh79uiqx2TyV9GZ2CVftm8mfKF/T4Yf05/dQX28ZnpNFgRcvMVAkzA8MVuDQJALm3K/bKKnjKC4/w==}
 
   '@bytecodealliance/jco@1.20.0':
     resolution: {integrity: sha512-E3CNiV+yFEMIE69RnzOgN0vvCGr90+32rX7VBeerxadcAONnclFrXLba243XIuLuiUHQIa9IFcWkiq6dhF5pVw==}
@@ -3882,7 +3882,7 @@ snapshots:
       '@bytecodealliance/preview2-shim': 0.17.9
       terser: 5.48.0
 
-  '@bytecodealliance/jco-transpile@0.3.6':
+  '@bytecodealliance/jco-transpile@0.3.8':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.9
       binaryen: 130.0.0
@@ -3952,7 +3952,7 @@ snapshots:
     dependencies:
       '@bytecodealliance/componentize-js': 0.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3'
-      '@bytecodealliance/jco-transpile': 0.3.6
+      '@bytecodealliance/jco-transpile': 0.3.8
       '@bytecodealliance/preview2-shim': 0.17.9
       '@bytecodealliance/preview3-shim': 0.1.2
       binaryen: 130.0.0
@@ -3968,7 +3968,7 @@ snapshots:
     dependencies:
       '@bytecodealliance/componentize-js': 0.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3'
-      '@bytecodealliance/jco-transpile': 0.3.6
+      '@bytecodealliance/jco-transpile': 0.3.8
       '@bytecodealliance/preview2-shim': 0.17.9
       '@bytecodealliance/preview3-shim': 0.1.2
       binaryen: 130.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,7 +35,7 @@ catalog:
 
 minimumReleaseAgeExclude:
   - '@bytecodealliance/componentize-js@0.21.0'
-  - '@bytecodealliance/jco-transpile@0.3.6'
+  - '@bytecodealliance/jco-transpile@0.3.7 || 0.3.8'
   - '@bytecodealliance/preview2-shim@0.19.0'
   - '@bytecodealliance/preview3-shim@0.1.2'
   - '@puppeteer/browsers@3.0.4'


### PR DESCRIPTION
This PR adds a regression test to the Jco memory leak tests to cover #1675 

This can't be merged until #1700 is merged and a new version of the import chain (`js-component-bindgen` > `jco-transpile`) have absorbed the fix and `jco` can update to a released `jco-transpile` version that includes the fix.