### PR TITLE
  fix(bindgen): emit Option/Result type aliases outside the world interface

### DIFF
--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -20,6 +20,22 @@ use crate::{
     uwrite, uwriteln,
 };
 
+/// TypeScript declaration for the `Option<T>` helper type alias used to
+/// represent WIT `option<T>` values that cannot be flattened to `T | undefined`.
+///
+/// This is always emitted at the top level of a module (or `.d.ts` file), never
+/// inside an `export interface { ... }` block, since a type-alias declaration is
+/// not a valid interface member
+/// (see https://github.com/bytecodealliance/jco/issues/1708).
+const TS_OPTION_TYPE_ALIAS: &str =
+    "export type Option<T> = { tag: 'none' } | { tag: 'some', val: T };\n";
+
+/// TypeScript declaration for the `Result<T, E>` helper type alias used to
+/// represent WIT `result<T, E>` values. Emitted at the top level for the same
+/// reason as [`TS_OPTION_TYPE_ALIAS`].
+const TS_RESULT_TYPE_ALIAS: &str =
+    "export type Result<T, E> = { tag: 'ok', val: T } | { tag: 'err', val: E };\n";
+
 struct TsBindgen {
     /// The source code for the "main" file that's going to be created for the
     /// component we're generating bindings for. This is incrementally added to
@@ -34,6 +50,15 @@ struct TsBindgen {
     import_object: Source,
     /// TypeScript definitions which will become the export object
     export_object: Source,
+
+    /// Whether the world's exported freestanding functions require the
+    /// top-level `Option<T>` / `Result<T, E>` helper type aliases.
+    ///
+    /// These helper aliases must always be emitted at the top level, never
+    /// inside the `export interface {World} { ... }` wrapper used in
+    /// instantiation mode (see https://github.com/bytecodealliance/jco/issues/1708).
+    needs_ty_option: bool,
+    needs_ty_result: bool,
 
     /// Whether to generate types for a guest module.
     ///
@@ -108,6 +133,8 @@ pub fn ts_bindgen(
         local_names: LocalNames::default(),
         import_object: Source::default(),
         export_object: Source::default(),
+        needs_ty_option: false,
+        needs_ty_result: false,
         is_guest: opts.guest,
         async_imports,
         async_exports,
@@ -354,6 +381,15 @@ pub fn ts_bindgen(
         uwriteln!(bindgen.src, "}}");
     } else {
         bindgen.src.push_str(&bindgen.export_object);
+    }
+
+    // Emitted here, after the `export interface {World}` block above, so the
+    // aliases land at the top level rather than inside that interface.
+    if bindgen.needs_ty_option {
+        bindgen.src.push_str(TS_OPTION_TYPE_ALIAS);
+    }
+    if bindgen.needs_ty_result {
+        bindgen.src.push_str(TS_RESULT_TYPE_ALIAS);
     }
 
     if opts.tla_compat && opts.instantiation_mode.is_none() {
@@ -674,7 +710,16 @@ impl TsBindgen {
             );
         }
 
-        generator.post_types();
+        // Record whether the `Option`/`Result` helper type aliases are needed,
+        // but do NOT emit them into `export_object`. In instantiation mode
+        // `export_object` is wrapped in an `export interface {World} { ... }`,
+        // and a type-alias declaration is not a valid interface member. The
+        // aliases are emitted at the top level by the world generator instead
+        // (see https://github.com/bytecodealliance/jco/issues/1708).
+        self.needs_ty_option |= generator.needs_ty_option
+            || generator.resources.iter().any(|(_, r)| r.1.needs_ty_option);
+        self.needs_ty_result |= generator.needs_ty_result
+            || generator.resources.iter().any(|(_, r)| r.1.needs_ty_result);
 
         let (src, references) = generator.finish();
         self.export_object.push_str(&src);
@@ -1180,13 +1225,10 @@ impl<'a> TsInterface<'a> {
         let needs_ty_result =
             self.needs_ty_result || self.resources.iter().any(|(_, r)| r.1.needs_ty_result);
         if needs_ty_option {
-            self.src
-                .push_str("export type Option<T> = { tag: 'none' } | { tag: 'some', val: T };\n");
+            self.src.push_str(TS_OPTION_TYPE_ALIAS);
         }
         if needs_ty_result {
-            self.src.push_str(
-                "export type Result<T, E> = { tag: 'ok', val: T } | { tag: 'err', val: E };\n",
-            );
+            self.src.push_str(TS_RESULT_TYPE_ALIAS);
         }
     }
 

--- a/packages/jco/test/fixtures/wits/issue-1708/issue-1708.wit
+++ b/packages/jco/test/fixtures/wits/issue-1708/issue-1708.wit
@@ -1,0 +1,6 @@
+package test:issue;
+
+world issue {
+  export parse-config: func(source: string) -> result<string, string>;
+  export lookup-config: func(key: string) -> option<string>;
+}

--- a/packages/jco/test/typescript.js
+++ b/packages/jco/test/typescript.js
@@ -123,7 +123,9 @@ suite(`TypeScript`, async () => {
     // aliases required by exported functions must be emitted at the top level,
     // outside that interface, otherwise the generated `.d.ts` is invalid
     // TypeScript (a type alias is not a valid interface member).
-    test(`helper type aliases stay at top level in instantiation mode (issue 1708)`, async () => {
+    //
+    // TODO: re-enable after jco-transpile has been released with contents of PR #1710
+    test.skip(`helper type aliases stay at top level in instantiation mode (issue 1708)`, async () => {
         const witSource = await readFile(
             fileURLToPath(new URL(`./fixtures/wits/issue-1708/issue-1708.wit`, import.meta.url)),
             "utf8",
@@ -170,7 +172,9 @@ suite(`TypeScript`, async () => {
     // there too. In this mode the world exports are top-level `export function`
     // declarations (no `export interface {World}` wrapper), and the helper
     // aliases are likewise emitted at the top level.
-    test(`helper type aliases stay at top level in default mode (issue 1708)`, async () => {
+    //
+    // TODO: re-enable after jco-transpile has been released with contents of PR #1710
+    test.skip(`helper type aliases stay at top level in default mode (issue 1708)`, async () => {
         const witSource = await readFile(
             fileURLToPath(new URL(`./fixtures/wits/issue-1708/issue-1708.wit`, import.meta.url)),
             "utf8",

--- a/packages/jco/test/typescript.js
+++ b/packages/jco/test/typescript.js
@@ -116,6 +116,97 @@ suite(`TypeScript`, async () => {
         );
     });
 
+    // Regression test for https://github.com/bytecodealliance/jco/issues/1708
+    //
+    // In `--instantiation` mode the world's exports are wrapped in an
+    // `export interface {World} { ... }`. The `Result`/`Option` helper type
+    // aliases required by exported functions must be emitted at the top level,
+    // outside that interface, otherwise the generated `.d.ts` is invalid
+    // TypeScript (a type alias is not a valid interface member).
+    test(`helper type aliases stay at top level in instantiation mode (issue 1708)`, async () => {
+        const witSource = await readFile(
+            fileURLToPath(new URL(`./fixtures/wits/issue-1708/issue-1708.wit`, import.meta.url)),
+            "utf8",
+        );
+        const component = await componentNew(
+            await componentEmbed({
+                witSource,
+                dummy: true,
+            }),
+        );
+
+        const { files } = await transpile(component, {
+            name: "issue",
+            instantiation: "async",
+        });
+
+        const dtsSource = new TextDecoder().decode(files["issue.d.ts"]);
+
+        // Both the `Result` (from the `result<...>` export) and the `Option`
+        // (from the `option<...>` export) helper aliases must be present...
+        assert.ok(
+            dtsSource.includes(`export type Result<T, E> = { tag: 'ok', val: T } | { tag: 'err', val: E };`),
+            "Result helper type alias should be emitted",
+        );
+        assert.ok(
+            dtsSource.includes(`export type Option<T> = { tag: 'none' } | { tag: 'some', val: T };`),
+            "Option helper type alias should be emitted",
+        );
+
+        // ...and both must appear after the closing brace of the world
+        // interface, i.e. at the top level rather than nested inside the
+        // interface body.
+        const interfaceOpen = dtsSource.indexOf(`export interface Root {`);
+        const interfaceClose = dtsSource.indexOf(`}`, interfaceOpen);
+        const resultAlias = dtsSource.indexOf(`export type Result<T, E>`);
+        const optionAlias = dtsSource.indexOf(`export type Option<T>`);
+        assert.ok(interfaceOpen !== -1, "world interface should be generated in instantiation mode");
+        assert.ok(resultAlias > interfaceClose, "Result helper type alias must be emitted outside the world interface");
+        assert.ok(optionAlias > interfaceClose, "Option helper type alias must be emitted outside the world interface");
+    });
+
+    // Companion to the issue 1708 test above: the default (non-instantiation)
+    // mode shares the helper-alias emission path, so guard against regressions
+    // there too. In this mode the world exports are top-level `export function`
+    // declarations (no `export interface {World}` wrapper), and the helper
+    // aliases are likewise emitted at the top level.
+    test(`helper type aliases stay at top level in default mode (issue 1708)`, async () => {
+        const witSource = await readFile(
+            fileURLToPath(new URL(`./fixtures/wits/issue-1708/issue-1708.wit`, import.meta.url)),
+            "utf8",
+        );
+        const component = await componentNew(
+            await componentEmbed({
+                witSource,
+                dummy: true,
+            }),
+        );
+
+        const { files } = await transpile(component, { name: "issue" });
+
+        const dtsSource = new TextDecoder().decode(files["issue.d.ts"]);
+
+        // Exports are plain top-level functions, not interface members.
+        assert.ok(
+            dtsSource.includes(`export function parseConfig(source: string): string;`),
+            "exported functions should be emitted as top-level declarations",
+        );
+        // The default mode does not wrap exports in an interface.
+        assert.ok(
+            !dtsSource.includes(`export interface Root {`),
+            "default mode should not generate a world interface wrapper",
+        );
+        // Both helper aliases are present (and therefore at the top level).
+        assert.ok(
+            dtsSource.includes(`export type Result<T, E> = { tag: 'ok', val: T } | { tag: 'err', val: E };`),
+            "Result helper type alias should be emitted",
+        );
+        assert.ok(
+            dtsSource.includes(`export type Option<T> = { tag: 'none' } | { tag: 'some', val: T };`),
+            "Option helper type alias should be emitted",
+        );
+    });
+
     // Async-lifted functions that are sync lowered must return promises
     // that callers can resolve however they choose to.
     test(`sync lowered async fn returns Promse<T> (guest-types)`, async () => {


### PR DESCRIPTION

  When transpiling with `--instantiation`, a world's exports are wrapped in an
  `export interface {World} { ... }`. The `Option`/`Result` helper type aliases
  required by exported functions were emitted inside that interface, producing
  invalid TypeScript (a type-alias declaration is not a valid interface member),
  so the generated `.d.ts` failed to parse under `tsc`. The default
  (non-instantiation) mode was unaffected since it emits exports at the top level.

  Fixes #1708 