### PR TITLE
fix(js-component-bindgen): treat `undefined` as `none` when lowering options

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/lower.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lower.rs
@@ -918,7 +918,7 @@ impl LowerIntrinsic {
                             {debug_log_fn}('[{lower_flat_option_fn}()] args', {{ ctx }});
 
                             const v = ctx.vals[0];
-                            if (v === null) {{
+                            if (v === null || v === undefined) {{
                                 ctx.vals[0] = {{ tag: 'none' }};
                             }} else {{
                                 const isNotOptionObject = typeof v !== 'object'


### PR DESCRIPTION
`_lowerFlatOption` mapped only JS `null` to the option `none` case, but jco's own generated TypeScript types model `option<T>` none as `T | undefined`. A value of `undefined` was therefore lowered as `some(undefined)`; when `T` contains an `own<resource>`, `_lowerFlatOwn` then throws `missing resource` and aborts the task.

This surfaced with wasi:http p3 `response.consume-body`, whose trailers future is typed `Result<Trailers | undefined, ErrorCode>`: an empty-trailers `Ok(None)` (`{ tag: 'ok', val: undefined }`) crashed lowering at body completion, leaving the enclosing streaming result's `.next()` unresolved.

Widen the none check to accept `undefined`, consistent with the generated types.