### PR TITLE
fix(jco-transpile): don't rebuild jco in debug during the vendor step

### DIFF
--- a/packages/jco-transpile/package.json
+++ b/packages/jco-transpile/package.json
@@ -51,7 +51,7 @@
     "scripts": {
         "setup:jco:build": "pnpm run --filter '@bytecodealliance/jco' build",
         "setup:jco:build:release": "pnpm run --filter '@bytecodealliance/jco' build:release",
-        "setup:jco:vendor": "pnpm run setup:jco:build && cp ../jco/obj/*.core*.wasm vendor && cp ../jco/obj/*.js vendor && cp ../jco/obj/*.ts vendor && cp -r ../jco/obj/interfaces vendor",
+        "setup:jco:vendor": "cp ../jco/obj/*.core*.wasm vendor && cp ../jco/obj/*.js vendor && cp ../jco/obj/*.ts vendor && cp -r ../jco/obj/interfaces vendor",
         "build:vendor": "pnpm run setup:jco:build && pnpm run setup:jco:vendor",
         "build:vendor:release": "pnpm run setup:jco:build:release && pnpm run setup:jco:vendor",
         "fmt": "oxfmt",


### PR DESCRIPTION
`setup:jco:vendor` began by running `setup:jco:build` (the debug jco build), then copied `../jco/obj/*` into `vendor/`. On the release path (`prepack` -> `build:release` -> `build:vendor:release`), that rebuild overwrote the freshly-built release `obj/` with a debug build before vendoring — so every publish shipped the ~133 MB debug `js-component-bindgen-component.core.wasm` (full DWARF) instead of the release build (~24 MB, ~4.6 MB gzipped). For jco-transpile's in-browser consumers that means a much larger download and a slower (opt-level 0) transpiler.

The vendor step should only copy; its callers (`build:vendor` / `build:vendor:release`) already build the correct profile. Drop the debug rebuild so the release path vendors the release artifacts.