### PR TITLE
fix(bindgen): async host import stream/future result lowering

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -2597,6 +2597,25 @@ impl Bindgen for FunctionBindgen<'_> {
             }
 
             Instruction::FutureLower { ty, .. } => {
+                let future_arg = operands
+                    .first()
+                    .expect("unexpectedly missing FutureLower arg");
+
+                // Lowering is only performed inline for sync functions, and for async
+                // functions when the operand is an incoming parameter (e.g. an async
+                // export lowering a host-provided `Promise` param before `CallWasm`).
+                //
+                // For async host *imports* the operand is the host function's return
+                // value (i.e. produced by `CallInterface`): lowering of async import
+                // results is performed by the async return-handling machinery
+                // (see `AsyncTaskIntrinsic::LowerImport` and `task.resolve`), so
+                // lowering the value inline here as well would consume/settle the
+                // `Promise` and double-lower it.
+                if self.is_async && self.for_import.unwrap_or_default() {
+                    results.push(future_arg.clone());
+                    return;
+                }
+
                 let debug_log_fn = self.intrinsic(Intrinsic::DebugLog);
                 let get_or_create_async_state_fn = self.intrinsic(Intrinsic::Component(
                     ComponentIntrinsic::GetOrCreateAsyncState,
@@ -2610,10 +2629,6 @@ impl Bindgen for FunctionBindgen<'_> {
                 let nested_future_symbol = self.intrinsic(Intrinsic::AsyncFuture(
                     AsyncFutureIntrinsic::NestedFutureSymbol,
                 ));
-
-                let future_arg = operands
-                    .first()
-                    .expect("unexpectedly missing ErrorContextLower arg");
 
                 // Build the lowering function for the type produced by the future
                 let type_id = &crate::dealias(self.resolve, *ty);
@@ -2942,10 +2957,26 @@ impl Bindgen for FunctionBindgen<'_> {
             }
 
             Instruction::StreamLower { ty, .. } => {
-                let debug_log_fn = self.intrinsic(Intrinsic::DebugLog);
                 let stream_arg = operands
                     .first()
                     .expect("unexpectedly missing StreamLower arg");
+
+                // Lowering is only performed inline for sync functions, and for async
+                // functions when the operand is an incoming parameter (e.g. an async
+                // export lowering a host-provided stream param before `CallWasm`).
+                //
+                // For async host *imports* the operand is the host function's return
+                // value (i.e. produced by `CallInterface`): lowering of async import
+                // results is performed by the async return-handling machinery
+                // (see `AsyncTaskIntrinsic::LowerImport` and `task.resolve`), so
+                // lowering the value inline here as well would consume/lock the
+                // stream (e.g. a host `ReadableStream`) and double-lower it.
+                if self.is_async && self.for_import.unwrap_or_default() {
+                    results.push(stream_arg.clone());
+                    return;
+                }
+
+                let debug_log_fn = self.intrinsic(Intrinsic::DebugLog);
                 let async_iterator_symbol = self.intrinsic(Intrinsic::SymbolAsyncIterator);
                 let iterator_symbol = self.intrinsic(Intrinsic::SymbolIterator);
                 let symbol_dispose = self.intrinsic(Intrinsic::SymbolDispose);

--- a/crates/js-component-bindgen/src/intrinsics/lower.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lower.rs
@@ -1039,7 +1039,7 @@ impl LowerIntrinsic {
                         return function {lower_flat_future_fn}Inner(ctx) {{
                             {debug_log_fn}('[{lower_flat_future_fn}()] args', {{ ctx }});
 
-                            const future = ctx.vals[0];
+                            let future = ctx.vals[0];
                             if (!future) {{ throw new Error("missing external future value"); }}
 
                             // As NodeJS will collapse `Promise<Promise<T>>` to `Promise<T>`, enable handling of ordinary values
@@ -1067,10 +1067,8 @@ impl LowerIntrinsic {
                                 elemMeta.stringEncoding = 'utf8';
 
                                 let outermostReadEnd;
-                                let futuresList;
-                                while (futureNestingLevel > 0) {{
-                                    futuresList.push(future);
-
+                                let nestingLevel = futureNestingLevel;
+                                while (nestingLevel >= 0) {{
                                     const {{ writeEnd, writeEndWaitableIdx, readEnd, readEndWaitableIdx }} = cstate.createFuture({{
                                         tableIdx: futureTableIdx,
                                         elemMeta,
@@ -1078,7 +1076,7 @@ impl LowerIntrinsic {
 
                                     const hostInjectFn = {gen_future_host_inject_fn}({{
                                         promise: future,
-                                        stringEncoding,
+                                        stringEncoding: elemMeta.stringEncoding,
                                         hostWriteEnd: writeEnd,
                                     }});
                                     readEnd.setHostInjectFn(hostInjectFn);
@@ -1092,7 +1090,7 @@ impl LowerIntrinsic {
                                         componentIdx,
                                     }};
 
-                                    futureNestingLevel--;
+                                    nestingLevel--;
                                 }}
 
                                 waitableIdx = outermostReadEnd.waitableIdx();

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -6167,7 +6167,7 @@ pub fn gen_flat_lower_fn_js_expr(
             }
 
             format!(
-                r#"{f}.bind(null, {{
+                r#"{f}({{
                        futureTableIdx: {table_idx},
                        futureNestingLevel: {future_nesting_level},
                        componentIdx: {component_idx},

--- a/crates/test-components/src/bin/return_host_async_value.rs
+++ b/crates/test-components/src/bin/return_host_async_value.rs
@@ -1,0 +1,50 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "return-host-async-value",
+    });
+    export!(Component);
+}
+
+use wit_bindgen::{FutureReader, StreamReader, StreamResult};
+
+use bindings::wit_future;
+use bindings::{compress, delay};
+
+struct Component;
+
+impl bindings::Guest for Component {
+    async fn compress_passthrough(data: StreamReader<u8>) -> StreamReader<u8> {
+        // Return the host import's result stream directly -- the export never
+        // reads or re-emits the result bytes itself
+        compress(data).await
+    }
+
+    async fn compress_collect(data: StreamReader<u8>) -> Vec<u8> {
+        let mut rx = compress(data).await;
+        let mut vals = Vec::new();
+        loop {
+            let (result, mut chunk) = rx.read(Vec::with_capacity(64)).await;
+            vals.append(&mut chunk);
+            if matches!(result, StreamResult::Dropped) {
+                break;
+            }
+        }
+        vals
+    }
+
+    async fn delay_roundtrip(v: u32) -> u32 {
+        delay(future_value_async(v)).await.await
+    }
+}
+
+fn future_value_async(v: u32) -> FutureReader<u32> {
+    let (tx, rx) = wit_future::new(|| unreachable!("default value should not be used"));
+    wit_bindgen::spawn_local(async move {
+        let _ = tx.write(v).await;
+    });
+    rx
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -552,6 +552,24 @@ world pass-back-host-resolved-future-value {
     export local-run-async;
 }
 
+// Regression coverage for the "lower" side of
+// https://github.com/bytecodealliance/jco/issues/1601: the `stream`/`future`
+// return value of an async host import is lowered by the async
+// return-handling machinery (i.e. `task.resolve`); it must not *also* be
+// lowered inline, which consumes/locks the host value (e.g. `TypeError:
+// ReadableStream is locked`) before the real lowering runs.
+world return-host-async-value {
+    import compress: async func(data: stream<u8>) -> stream<u8>;
+    import delay: async func(f: future<u32>) -> future<u32>;
+
+    // Returns the imported `compress` fn's result stream directly
+    export compress-passthrough: async func(data: stream<u8>) -> stream<u8>;
+    // Reads the imported `compress` fn's result stream within the guest
+    export compress-collect: async func(data: stream<u8>) -> list<u8>;
+
+    export delay-roundtrip: async func(v: u32) -> u32;
+}
+
 
 // see: https://github.com/bytecodealliance/jco/issues/1633
 interface byte-batch-example {

--- a/packages/jco-transpile/test/p3/import-result-lowers.ts
+++ b/packages/jco-transpile/test/p3/import-result-lowers.ts
@@ -1,0 +1,102 @@
+import { join } from 'node:path';
+import { ReadableStream } from 'node:stream/web';
+
+import { suite, test, assert } from 'vitest';
+
+import { WASIShim } from '@bytecodealliance/preview2-shim/instantiation';
+
+import { setupAsyncTest } from '../helpers.js';
+import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR, createReadableStreamFromValues } from '../common.js';
+
+// Regression coverage for the "lower" side of
+// https://github.com/bytecodealliance/jco/issues/1601: the `stream`/`future`
+// return value of an async host import is lowered by the async
+// return-handling machinery (i.e. `task.resolve`); it must not *also* be
+// lowered inline, which consumes/locks the host value (e.g. `TypeError:
+// ReadableStream is locked`) before the real lowering runs.
+suite('async host import stream/future results', () => {
+    async function setup() {
+        return await setupAsyncTest({
+            asyncMode: 'jspi',
+            component: {
+                path: join(LOCAL_TEST_COMPONENTS_DIR, 'return-host-async-value.wasm'),
+                imports: {
+                    ...new WASIShim().getImportObject(),
+                    // A host adapter in the style of `CompressionStream`: the
+                    // incoming (lowered) stream is driven by the host, and a
+                    // brand new host `ReadableStream` is returned.
+                    compress: {
+                        default: async (data) => {
+                            return new ReadableStream({
+                                async start(ctrl) {
+                                    for await (const chunk of data) {
+                                        ctrl.enqueue(chunk);
+                                    }
+                                    ctrl.close();
+                                },
+                            });
+                        },
+                    },
+                    delay: {
+                        default: async (f) => {
+                            const v = await f;
+                            return (async () => v)();
+                        },
+                    },
+                },
+            },
+        });
+    }
+
+    test.concurrent('import result stream returned directly by an export', async () => {
+        const { instance, cleanup } = await setup();
+        try {
+            assert.instanceOf(instance.compressPassthrough, AsyncFunction);
+
+            const vals = [1, 2, 3, 255];
+            const stream = await Promise.race([
+                instance.compressPassthrough(createReadableStreamFromValues(vals)),
+                new Promise((_, reject) => setTimeout(() => reject(new Error('export call timed out')), 5_000)),
+            ]);
+
+            const returnedVals = [];
+            for await (const chunk of stream) {
+                returnedVals.push(...chunk);
+            }
+            assert.deepEqual(returnedVals, vals);
+        } finally {
+            await cleanup();
+        }
+    });
+
+    test.concurrent('import result stream read by the guest', async () => {
+        const { instance, cleanup } = await setup();
+        try {
+            assert.instanceOf(instance.compressCollect, AsyncFunction);
+
+            const vals = [4, 5, 6];
+            const returnedVals = await Promise.race([
+                instance.compressCollect(createReadableStreamFromValues(vals)),
+                new Promise((_, reject) => setTimeout(() => reject(new Error('export call timed out')), 5_000)),
+            ]);
+            assert.deepEqual(returnedVals, new Uint8Array(vals));
+        } finally {
+            await cleanup();
+        }
+    });
+
+    test.concurrent('import result future read by the guest', async () => {
+        const { instance, cleanup } = await setup();
+        try {
+            assert.instanceOf(instance.delayRoundtrip, AsyncFunction);
+
+            const returned = await Promise.race([
+                instance.delayRoundtrip(42),
+                new Promise((_, reject) => setTimeout(() => reject(new Error('export call timed out')), 5_000)),
+            ]);
+            assert.strictEqual(returned, 42);
+        } finally {
+            await cleanup();
+        }
+    });
+});


### PR DESCRIPTION
Async host imports returning stream/future were double-lowered: the async return machinery (LowerImport -> subtask.onResolve -> resultLowerFns) lowers the result, but StreamLower/FutureLower also lowered it inline in the trampoline, consuming/locking the host value.

- Skip the inline lower for async imports via is_async && for_import, mirroring the existing StreamLift/FutureLift dispatch.
- Fix _lowerFlatFuture's host-promise branch (never-run while loop, uninitialized list, undefined stringEncoding, const reassignment) to mirror the inline FutureLower codegen.
- Fix gen_flat_lower_fn_js_expr emitting _lowerFlatFuture.bind(null, meta) instead of invoking the factory, matching the stream path.

Adds return-host-async-value test component/world and test/p3/import-result-lowers.ts regression coverage.