### PR TITLE
fix(transpile): stop the debug bootstrap clobbering the release bindgen

### DIFF
--- a/crates/js-component-bindgen-component/src/lib.rs
+++ b/crates/js-component-bindgen-component/src/lib.rs
@@ -169,7 +169,7 @@ impl bindings::Guest for JsComponentBindgenComponent {
             .build();
 
         let files = js_component_bindgen::generate_types(&name, resolve, world, opts)
-            .with_context(|| format!("generating types for [{}]", &name))
+            .with_context(|| format!("generating types for [{}]", name))
             .map_err(|e| e.to_string())?;
 
         Ok(files)

--- a/crates/js-component-bindgen/src/esm_bindgen.rs
+++ b/crates/js-component-bindgen/src/esm_bindgen.rs
@@ -57,9 +57,9 @@ impl EsmBindgen {
                 ImportBinding::Local(local) => {
                     panic!(
                         "Internal bindgen error: Import '{}' cannot be both an interface '{}' and a function '{}'",
-                        &path[0..i + 1].join("."),
-                        &path[i + 1..].join("."),
-                        &local[0],
+                        path[0..i + 1].join("."),
+                        path[i + 1..].join("."),
+                        local[0],
                     );
                 }
             };

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -3056,7 +3056,7 @@ impl<'a> Instantiator<'a, '_> {
                             "import:{import}-{maybe_iface_member}-{func_name}",
                             import = import_specifier,
                             maybe_iface_member = maybe_iface_member.as_deref().unwrap_or(""),
-                            func_name = &func.name
+                            func_name = func.name
                         ),
                         &func.name,
                     )
@@ -3073,7 +3073,7 @@ impl<'a> Instantiator<'a, '_> {
                             "import:async-{import}-{maybe_iface_member}-{func_name}",
                             import = import_specifier,
                             maybe_iface_member = maybe_iface_member.as_deref().unwrap_or(""),
-                            func_name = &func.name
+                            func_name = func.name
                         ),
                         &func.name,
                     )

--- a/crates/xtask/src/build/jco.rs
+++ b/crates/xtask/src/build/jco.rs
@@ -144,6 +144,13 @@ fn transpile(args: TranspileArgs) -> Result<()> {
             transpile_components(BuildType::Debug).context("transpiling all components (debug)")?;
         }
 
+        // The debug bootstrap above transpiles *all* components (including this
+        // one) into the same `obj/<name>.component.wasm` paths, overwriting the
+        // release component written earlier with the debug build. Re-write ours
+        // so that `jco opt` (and the transpile below) operates on the release
+        // component, not the debug one.
+        fs::write(&component_path, &adapted_component)?;
+
         let jco_script_path = format!(
             "{}",
             WORKSPACE_DIR.join("packages/jco/src/jco.js").display()


### PR DESCRIPTION
`transpile()` writes the componentized module to
`obj/<name>.component.wasm`, then, on a clean `obj/`, runs a debug bootstrap (`transpile_components(BuildType::Debug)`) to build the `wasm-tools` transpiler that `jco opt` needs. That bootstrap transpiles *all* components, including the one currently being built, into the same `obj/*.component.wasm` paths, overwriting the release component with the 132 MiB debug build. `jco opt` and the final transpile then run on the debug component, so `build:release` emits the debug bindgen (wasm-opt'd to ~8.9 MiB / 17,688 funcs) instead of the release one (~3.1 MiB / 7,836 funcs).

Re-write the release component to `component_path` after the bootstrap so `jco opt` operates on the release build. The bootstrap only runs when `obj/wasm-tools.js` is absent (a clean checkout), which is exactly how the release workflow builds, so every published js-component-bindgen bindgen was the debug one.