### PR TITLE
chore(bindgen): update upstream deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,9 +142,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0111d110b72b4efad69a372e29e21628652fd0bcab66967e5c8350ab679affd5"
+checksum = "03b4982ef9fa54ec9eee841e891e7ddc5434be1250e88de31572e000c888f30b"
 dependencies = [
  "cranelift-entity",
  "wasmtime-internal-core",
@@ -152,9 +152,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf01ecc92fc5499789d79c3b817299d5a8ddd828d31dcf0f9cc3cc66f38dbb36"
+checksum = "529143118c4eeb58c39ecb02319557d512be6c61348486422974ab8e3906b8a8"
 dependencies = [
  "serde",
  "serde_derive",
@@ -163,9 +163,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-entity"
-version = "0.132.3"
+version = "0.133.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eea22522144ba08c7e7ef94bfc25d474ef016c2771974b8ab1986734ac85965"
+checksum = "a5300c49cf940526fe771517b3b3eabd5d0ff164ee61698579cf403fe8d3af3c"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -541,12 +541,12 @@ dependencies = [
  "heck 0.5.0",
  "log",
  "semver",
- "wasm-encoder 0.251.0",
- "wasmparser 0.251.0",
+ "wasm-encoder 0.253.0",
+ "wasmparser 0.253.0",
  "wasmtime-environ",
  "wit-bindgen-core",
  "wit-component",
- "wit-parser 0.251.0",
+ "wit-parser 0.253.0",
 ]
 
 [[package]]
@@ -1020,16 +1020,6 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasm-encoder"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
-dependencies = [
- "leb128fmt",
- "wasmparser 0.248.0",
-]
-
-[[package]]
-name = "wasm-encoder"
 version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a879a421bd17c528b74721b2abf4c62e8f1d1889c2ba8c3c50d02deaf2ce395"
@@ -1040,19 +1030,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-encoder"
-version = "0.252.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8185ae345fa5687c054626ff9a50e7089797a343d9904d1dc9820eb4c4d3196f"
+checksum = "59972d6cd272259de647b7c1f1912e45e289c75ffd4be04e10695507cd7e1b59"
 dependencies = [
  "leb128fmt",
- "wasmparser 0.252.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.251.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f998ccc6e012f7b86865eb2a106c8a0422017a1a88977ce01a69f2244be2e57"
+checksum = "b3f45816ef616806f48498bcd831377de578c4fa51db0c83ab8ceb78cc13523b"
 dependencies = [
  "anyhow",
  "auditable-serde",
@@ -1063,8 +1053,8 @@ dependencies = [
  "serde_json",
  "spdx",
  "url",
- "wasm-encoder 0.251.0",
- "wasmparser 0.251.0",
+ "wasm-encoder 0.253.0",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -1072,14 +1062,14 @@ name = "wasm-tools-js"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "wasm-encoder 0.251.0",
+ "wasm-encoder 0.253.0",
  "wasm-metadata",
- "wasmparser 0.251.0",
- "wasmprinter 0.251.0",
+ "wasmparser 0.253.0",
+ "wasmprinter 0.253.0",
  "wat",
  "wit-bindgen",
  "wit-component",
- "wit-parser 0.251.0",
+ "wit-parser 0.253.0",
 ]
 
 [[package]]
@@ -1095,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.248.0"
+version = "0.251.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.1",
@@ -1108,36 +1098,14 @@ dependencies = [
 
 [[package]]
 name = "wasmparser"
-version = "0.251.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "437970b35b1a85cfde9c74b2398352d8d653f3bd8e3a3db0c063ea8f5b4b36ff"
+checksum = "19db11f87d2486580e1e8b6f494c54df7e0566b87d0b599db843c24019667339"
 dependencies = [
  "bitflags 2.13.0",
  "hashbrown 0.17.1",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.252.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3eb099dcadcde5be9eef55e3a337128efd4e44b4c93122487e4d2e4e1c6627c"
-dependencies = [
- "bitflags 2.13.0",
- "indexmap",
- "semver",
-]
-
-[[package]]
-name = "wasmprinter"
-version = "0.248.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
-dependencies = [
- "anyhow",
- "termcolor",
- "wasmparser 0.248.0",
 ]
 
 [[package]]
@@ -1152,10 +1120,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmtime-environ"
-version = "45.0.3"
+name = "wasmprinter"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439686d3deb38525c86b88bbc90f7ba669f70c8edc7d6b35147c738bbef5ff76"
+checksum = "cafccdb2ba2cffd9c4f96b88a9710651d63266e858d54be262a141b528b26dac"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.253.0",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "46.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d45863de41977ec6453e859cf843d456fa3fcb45a659b66d16e794f90ec4f5b7"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -1175,24 +1154,24 @@ dependencies = [
  "sha2",
  "smallvec",
  "target-lexicon",
- "wasm-encoder 0.248.0",
- "wasmparser 0.248.0",
- "wasmprinter 0.248.0",
+ "wasm-encoder 0.251.0",
+ "wasmparser 0.251.0",
+ "wasmprinter 0.251.0",
  "wasmtime-internal-component-util",
  "wasmtime-internal-core",
 ]
 
 [[package]]
 name = "wasmtime-internal-component-util"
-version = "45.0.3"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ed79c4e9ab416dcc5e46b9d1ec9b7c2e3c730deab525996b0de45a35fc8b2c3"
+checksum = "819ad5abd5822a22dbf4014475cdfd1fe790707761cd732d74aaa3ba4d5ba489"
 
 [[package]]
 name = "wasmtime-internal-core"
-version = "45.0.3"
+version = "46.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3073c03f97f871fe6400e68621c863b93ba79296f8e570285231952d23fcc804"
+checksum = "3fc28372e36eaf8cf70faa83b5779137f7e99c8d18569a125d1580e735cc9e4d"
 dependencies = [
  "hashbrown 0.17.1",
  "libm",
@@ -1201,37 +1180,24 @@ dependencies = [
 
 [[package]]
 name = "wast"
-version = "251.0.0"
+version = "253.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc7467dda0a96142eb2c980329dfb62480b1e1d3622fdeb1a44e2bca6ceed74"
+checksum = "d3264542f8965c5d84fb1085d924bfba9a6314bb228eff13a2de14d7627664d0"
 dependencies = [
  "bumpalo",
  "leb128fmt",
  "memchr",
  "unicode-width 0.2.2",
- "wasm-encoder 0.251.0",
-]
-
-[[package]]
-name = "wast"
-version = "252.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "942a3449d6a593fccc111a6241c8df52bda168af30e40bf9580d4394d7374c65"
-dependencies = [
- "bumpalo",
- "leb128fmt",
- "memchr",
- "unicode-width 0.2.2",
- "wasm-encoder 0.252.0",
+ "wasm-encoder 0.253.0",
 ]
 
 [[package]]
 name = "wat"
-version = "1.252.0"
+version = "1.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c72a4ba7088f7bac94cf516e49882bdf97068904a563768cf249efc839ec42cb"
+checksum = "4bfc5ce906144200c972ec617470aa35bd847472e170b26dde3e80541c674055"
 dependencies = [
- "wast 252.0.0",
+ "wast",
 ]
 
 [[package]]
@@ -1284,29 +1250,29 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a43552cfa071f246cfd99e5dbb23710dfe7336b3259e09339818483359470749"
+checksum = "94c5e45f6d4cfaca727c1c48989ab3e05bb289bf84fbad226e1cfbbef2c04b7f"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4738d1c9a78e97bc7f664bfafd5d8e67d7bb26faa5c41e6d628e8bbdad3ec351"
+checksum = "05cf25dc4bb1981c16aa549ec66c6762b7752bfb8b7c3b3936ae13100298dc72"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "wit-parser 0.251.0",
+ "wit-parser 0.253.0",
 ]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1130ce1f531bc9f9a75922244aa773bf5e2117fda1ef4a86b9f98d6b8135eb46"
+checksum = "407ee2b474af1a366766fe91b8255b7935e5e3c3afb9c304e91ac3d154287ff1"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
@@ -1320,9 +1286,9 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.58.0"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07296369e4d598e7e79b64eef66f724d83324ea671bcf677d78fc5cf92604ae5"
+checksum = "37386eba32427684ffe37a0f765f63ce2ece03efb1ad28c23cf69562fdc67ec0"
 dependencies = [
  "anyhow",
  "prettyplease",
@@ -1335,9 +1301,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.251.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a5e60173c413659c689f0581b0cf5d1a2404077568f9ffdce748a9eb2fc913"
+checksum = "dbbd2500ac3488489ee8c6e59b79d7e47e6da5bfb019efd35d5dca57b78af624"
 dependencies = [
  "anyhow",
  "bitflags 2.13.0",
@@ -1346,11 +1312,11 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "wasm-encoder 0.251.0",
+ "wasm-encoder 0.253.0",
  "wasm-metadata",
- "wasmparser 0.251.0",
+ "wasmparser 0.253.0",
  "wat",
- "wit-parser 0.251.0",
+ "wit-parser 0.253.0",
 ]
 
 [[package]]
@@ -1392,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.251.0"
+version = "0.253.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e960732e824fab95099971a09e638979347c94ca48568d3c854c945729196947"
+checksum = "4d997b8e5920fcbeec742b58e583325d6419a6aca617ae8075c406a61c65ba8a"
 dependencies = [
  "anyhow",
  "hashbrown 0.17.1",
@@ -1405,8 +1371,8 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "unicode-xid",
- "wasmparser 0.251.0",
+ "unicode-ident",
+ "wasmparser 0.253.0",
 ]
 
 [[package]]
@@ -1438,7 +1404,7 @@ dependencies = [
  "js-component-bindgen",
  "semver",
  "structopt",
- "wast 251.0.0",
+ "wast",
  "webidl2wit",
  "weedle",
  "wit-component",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,21 +44,21 @@ tokio = { version = "1.50.0", default-features = false }
 webidl2wit = { version = "0.1.1", default-features = false }
 xshell = { version = "0.2.7", default-features = false }
 
-wasmtime = { version = "45.0.1", default-features = false }
-wasmtime-environ = { version = "45.0.1", features= [ "component-model", "compile" ] }
+wasmtime = { version = "46.0.1", default-features = false }
+wasmtime-environ = { version = "46.0.1", features= [ "component-model", "compile" ] }
 
-wasm-encoder = { version = "0.251.0", default-features = false }
-wasm-metadata = { version = "0.251.0", default-features = false }
-wasmparser = { version = "0.251.0", default-features = false }
-wasmprinter = { version = "0.251.0", default-features = false }
-wit-component = { version = "0.251.0", features = ["dummy-module"] }
-wit-parser = { version = "0.251.0", default-features = false }
+wasm-encoder = { version = "0.253.0", default-features = false }
+wasm-metadata = { version = "0.253.0", default-features = false }
+wasmparser = { version = "0.253.0", default-features = false }
+wasmprinter = { version = "0.253.0", default-features = false }
+wit-component = { version = "0.253.0", features = ["dummy-module"] }
+wit-parser = { version = "0.253.0", default-features = false }
 
-wat = { version = "1.251.0", default-features = false }
+wat = { version = "1.253.0", default-features = false }
 
-wit-bindgen = { version = "0.58.0", default-features = false }
-wit-bindgen-core = { version = "0.58.0", default-features = false }
+wit-bindgen = { version = "0.59.0", default-features = false }
+wit-bindgen-core = { version = "0.59.0", default-features = false }
 
-wast = { version = "251.0.0", default-features = false, features = [ "component-model" ] }
+wast = { version = "253.0.0", default-features = false, features = [ "component-model" ] }
 
 js-component-bindgen = { version = "2.0.11", path = "./crates/js-component-bindgen" }

--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -3560,6 +3560,7 @@ mod tests {
             stability: Default::default(),
             owner,
             span: Default::default(),
+            external_id: None,
         });
 
         let ty_ = Type::Id(ty_id);

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -9,11 +9,12 @@ use base64::engine::general_purpose;
 use heck::{ToKebabCase, ToLowerCamelCase, ToUpperCamelCase};
 use semver::Version;
 use wasmtime_environ::component::{
-    CanonicalOptions, CanonicalOptionsDataModel, Component, ComponentTranslation, ComponentTypes,
-    CoreDef, CoreExport, Export, ExportItem, FixedEncoding, GlobalInitializer, InstantiateModule,
-    InterfaceType, LinearMemoryOptions, LoweredIndex, ResourceIndex, RuntimeComponentInstanceIndex,
-    RuntimeImportIndex, RuntimeInstanceIndex, StaticModuleIndex, Trampoline, TrampolineIndex,
-    TypeDef, TypeFuncIndex, TypeFutureTableIndex, TypeResourceTableIndex, TypeStreamTableIndex,
+    CanonicalOptions, CanonicalOptionsDataModel, Component, ComponentExtern, ComponentTranslation,
+    ComponentTypes, CoreDef, CoreExport, Export, ExportItem, FixedEncoding, GlobalInitializer,
+    InstantiateModule, InterfaceType, LinearMemoryOptions, LoweredIndex, ResourceIndex,
+    RuntimeComponentInstanceIndex, RuntimeImportIndex, RuntimeInstanceIndex, StaticModuleIndex,
+    Trampoline, TrampolineIndex, TypeDef, TypeFuncIndex, TypeFutureTableIndex,
+    TypeResourceTableIndex, TypeStreamTableIndex,
 };
 use wasmtime_environ::component::{
     ExtractCallback, NameMapNoIntern, Transcode, TypeComponentLocalErrorContextTableIndex,
@@ -358,13 +359,13 @@ pub fn transpile_bindgen(
                 } else {
                     canon_export_name.to_kebab_case()
                 };
-            let export = instantiator
+            let (export_idx, _extern_data) = instantiator
                 .component
                 .exports
                 .get(&expected_export_name, &NameMapNoIntern)
                 .unwrap_or_else(|| panic!("failed to find component export [{expected_export_name}] (original '{canon_export_name}')"));
 
-            let export_kind = match &instantiator.component.export_items[*export] {
+            let export_kind = match &instantiator.component.export_items[*export_idx] {
                 wasmtime_environ::component::Export::LiftedFunction { .. } => {
                     ExportKind::LiftedFunction
                 }
@@ -737,35 +738,48 @@ impl<'a> Instantiator<'a, '_> {
             };
             match item {
                 WorldItem::Interface { id, .. } => {
-                    let TypeDef::ComponentInstance(instance) = import else {
+                    let TypeDef::ComponentInstance(instance) = &import.ty else {
                         unreachable!("unexpectedly non-component instance import in interface")
                     };
                     let import_ty = &self.types[*instance];
                     let iface = &self.resolve.interfaces[*id];
                     for (ty_name, ty) in &iface.types {
                         match &import_ty.exports.get(ty_name) {
-                            Some(TypeDef::Resource(resource_table_idx)) => {
+                            None => {}
+                            Some(ComponentExtern {
+                                ty: TypeDef::Resource(resource_table_idx),
+                                ..
+                            }) => {
                                 let ty = crate::dealias(self.resolve, *ty);
                                 let resource_table_ty = &self.types[*resource_table_idx];
                                 let concrete_ty = resource_table_ty.unwrap_concrete_ty();
                                 self.imports_resource_types.insert(ty, concrete_ty);
                                 self.imports_resource_index_types.insert(concrete_ty, ty);
                             }
-                            Some(TypeDef::Interface(_)) | None => {}
+                            Some(ComponentExtern {
+                                ty: TypeDef::Interface(_),
+                                ..
+                            }) => {}
                             Some(_) => unreachable!("unexpected type in interface"),
                         }
                     }
                 }
                 WorldItem::Function(_) => {}
                 WorldItem::Type { id, .. } => match import {
-                    TypeDef::Resource(resource) => {
+                    ComponentExtern {
+                        ty: TypeDef::Resource(resource),
+                        ..
+                    } => {
                         let ty = crate::dealias(self.resolve, *id);
                         let resource_table_ty = &self.types[*resource];
                         let concrete_ty = resource_table_ty.unwrap_concrete_ty();
                         self.imports_resource_types.insert(ty, concrete_ty);
                         self.imports_resource_index_types.insert(concrete_ty, ty);
                     }
-                    TypeDef::Interface(_) => {}
+                    ComponentExtern {
+                        ty: TypeDef::Interface(_),
+                        ..
+                    } => {}
                     _ => unreachable!("unexpected type in import world item"),
                 },
             }
@@ -775,7 +789,7 @@ impl<'a> Instantiator<'a, '_> {
 
         for (key, item) in &self.resolve.worlds[self.world].exports {
             let name = &self.resolve.name_world_key(key);
-            let (_, export_idx) = self
+            let (_, (export_idx, _extern_data)) = self
                 .component
                 .exports
                 .raw_iter()
@@ -789,9 +803,9 @@ impl<'a> Instantiator<'a, '_> {
                         unreachable!("unexpectedly non export instance item")
                     };
                     for (ty_name, ty) in &iface.types {
-                        match self.component.export_items
-                            [*exports.get(ty_name, &NameMapNoIntern).unwrap()]
-                        {
+                        let (export_idx, _exern_data) =
+                            exports.get(ty_name, &NameMapNoIntern).unwrap();
+                        match self.component.export_items[*export_idx] {
                             Export::Type(TypeDef::Resource(resource)) => {
                                 let ty = crate::dealias(self.resolve, *ty);
                                 let resource_table_ty = &self.types[resource];
@@ -4311,9 +4325,14 @@ impl<'a> Instantiator<'a, '_> {
                     // relevant resources
                     for (fn_name, iface_fn) in iface.functions.iter() {
                         match import_type_def {
-                            TypeDef::ComponentInstance(instance_ty) => {
-                                if let Some(TypeDef::ComponentFunc(type_func_index)) =
-                                    &self.types[*instance_ty].exports.get(fn_name)
+                            ComponentExtern {
+                                ty: TypeDef::ComponentInstance(instance_ty),
+                                ..
+                            } => {
+                                if let Some(ComponentExtern {
+                                    ty: TypeDef::ComponentFunc(type_func_index),
+                                    ..
+                                }) = &self.types[*instance_ty].exports.get(fn_name)
                                 {
                                     self.create_resource_fn_map(
                                         iface_fn,
@@ -4322,7 +4341,10 @@ impl<'a> Instantiator<'a, '_> {
                                     );
                                 }
                             }
-                            TypeDef::ComponentFunc(type_func_idx) => {
+                            ComponentExtern {
+                                ty: TypeDef::ComponentFunc(type_func_idx),
+                                ..
+                            } => {
                                 self.create_resource_fn_map(
                                     iface_fn,
                                     *type_func_idx,
@@ -4336,8 +4358,7 @@ impl<'a> Instantiator<'a, '_> {
 
                 // Process imported functions directly to build resource maps
                 WorldItem::Function(func) => {
-                    // TODO: get func type index
-                    let TypeDef::ComponentFunc(func_ty_idx) = import_type_def else {
+                    let TypeDef::ComponentFunc(func_ty_idx) = &import_type_def.ty else {
                         unreachable!("invalid fn export");
                     };
                     self.create_resource_fn_map(func, *func_ty_idx, &mut import_resource_map);
@@ -4356,7 +4377,7 @@ impl<'a> Instantiator<'a, '_> {
         self.resource_exports.extend(self.resource_imports.clone());
 
         // Process individual component exports
-        for (export_name, export_idx) in self.component.exports.raw_iter() {
+        for (export_name, (export_idx, _extern_data)) in self.component.exports.raw_iter() {
             let export_name = export_name.as_ref().to_string();
             let export = &self.component.export_items[*export_idx];
             let world_key = &self.exports[&export_name];
@@ -4447,7 +4468,7 @@ impl<'a> Instantiator<'a, '_> {
                     };
 
                     // Process exported instances
-                    for (func_name, export_idx) in exports.raw_iter() {
+                    for (func_name, (export_idx, _extern_data)) in exports.raw_iter() {
                         let func_name = func_name.as_ref().to_string();
                         let export = &self.component.export_items[*export_idx];
 

--- a/examples/components/add/package.json
+++ b/examples/components/add/package.json
@@ -9,6 +9,6 @@
     "all": "pnpm run build && pnpm run transpile && pnpm run transpiled-js"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.20.0"
+    "@bytecodealliance/jco": "^1.25.2"
   }
 }

--- a/examples/components/adder/package.json
+++ b/examples/components/adder/package.json
@@ -9,6 +9,6 @@
     "all": "pnpm run build && pnpm run transpile && pnpm run transpiled-js"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.20.0"
+    "@bytecodealliance/jco": "^1.25.2"
   }
 }

--- a/examples/components/fs-write-file/package.json
+++ b/examples/components/fs-write-file/package.json
@@ -9,9 +9,9 @@
         "all": "pnpm run build; pnpm run transpile; pnpm run transpiled-js"
     },
     "devDependencies": {
-        "@bytecodealliance/jco": "^1.20.0"
+        "@bytecodealliance/jco": "^1.25.2"
     },
     "dependencies": {
-        "@bytecodealliance/preview2-shim": "^0.18.1"
+        "@bytecodealliance/preview2-shim": "^0.19.0"
     }
 }

--- a/examples/components/host-logging/package.json
+++ b/examples/components/host-logging/package.json
@@ -9,6 +9,6 @@
     "all": "pnpm run build; pnpm run transpile; pnpm run transpiled-js"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.20.0"
+    "@bytecodealliance/jco": "^1.25.2"
   }
 }

--- a/examples/components/http-hello-world/package.json
+++ b/examples/components/http-hello-world/package.json
@@ -10,7 +10,7 @@
     "all": "npm run build && npm run demo"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.20.0"
+    "@bytecodealliance/jco": "^1.25.2"
   },
   "devDependencies": {
     "terminate": "^2.8.0"

--- a/examples/components/http-server-fetch-handler/package.json
+++ b/examples/components/http-server-fetch-handler/package.json
@@ -11,6 +11,6 @@
     "all": "pnpm run build && pnpm run demo"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.20.0"
+    "@bytecodealliance/jco": "^1.25.2"
   }
 }

--- a/examples/components/http-server-hono-with-bindings/package.json
+++ b/examples/components/http-server-hono-with-bindings/package.json
@@ -20,7 +20,7 @@
     "hono": "^4.12.24"
   },
   "devDependencies": {
-    "@bytecodealliance/jco": "^1.20.0",
+    "@bytecodealliance/jco": "^1.25.2",
     "rolldown": "^1.1.0",
     "terminate": "^2.8.0",
     "typescript": "^6.0.3"

--- a/examples/components/http-server-hono/package.json
+++ b/examples/components/http-server-hono/package.json
@@ -20,7 +20,7 @@
     "hono": "^4.12.24"
   },
   "devDependencies": {
-    "@bytecodealliance/jco": "^1.20.0",
+    "@bytecodealliance/jco": "^1.25.2",
     "rolldown": "^1.1.0",
     "terminate": "^2.8.0",
     "typescript": "^6.0.3"

--- a/examples/components/node-compat/package.json
+++ b/examples/components/node-compat/package.json
@@ -14,7 +14,7 @@
   },
   "keywords": [],
   "dependencies": {
-    "@bytecodealliance/jco": "^1.20.0",
+    "@bytecodealliance/jco": "^1.25.2",
     "rolldown": "^1.1.0",
     "unenv": "^2.0.0-rc.24"
   }

--- a/examples/components/node-fetch/package.json
+++ b/examples/components/node-fetch/package.json
@@ -9,6 +9,6 @@
     "all": "pnpm run build:component && pnpm run transpile && pnpm run demo"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.20.0"
+    "@bytecodealliance/jco": "^1.25.2"
   }
 }

--- a/examples/components/string-reverse-upper/package.json
+++ b/examples/components/string-reverse-upper/package.json
@@ -11,6 +11,6 @@
     "all": "pnpm run build:dep ; pnpm run build ; pnpm run compose ; pnpm run transpile ; pnpm run transpiled-js"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.20.0"
+    "@bytecodealliance/jco": "^1.25.2"
   }
 }

--- a/examples/components/string-reverse/package.json
+++ b/examples/components/string-reverse/package.json
@@ -9,6 +9,6 @@
     "all": "pnpm run build; pnpm run transpile; pnpm run transpiled-js"
   },
   "dependencies": {
-    "@bytecodealliance/jco": "^1.20.0"
+    "@bytecodealliance/jco": "^1.25.2"
   }
 }

--- a/examples/components/webidl-book-library/package.json
+++ b/examples/components/webidl-book-library/package.json
@@ -10,6 +10,6 @@
     "all": "pnpm run generate:wit && pnpm run generate:types && pnpm run build && pnpm run transpile && node demo.js"
   },
   "devDependencies": {
-    "@bytecodealliance/jco": "1.20.0"
+    "@bytecodealliance/jco": "1.25.2"
   }
 }

--- a/packages/jco-transpile/package.json
+++ b/packages/jco-transpile/package.json
@@ -78,7 +78,6 @@
         "@types/node": "^24.12.4",
         "mime": "catalog:",
         "puppeteer": "catalog:",
-        "smol-toml": "catalog:",
         "typescript": "catalog:",
         "vite": "^7.1.5",
         "vitest": "^4.0.7",

--- a/packages/jco-transpile/test/helpers.ts
+++ b/packages/jco-transpile/test/helpers.ts
@@ -9,7 +9,6 @@ import { URL, fileURLToPath, pathToFileURL } from 'node:url';
 import { promisify } from 'node:util';
 
 import mime from 'mime';
-import { parse } from 'smol-toml';
 import ts from 'typescript';
 import which from 'which';
 
@@ -713,22 +712,6 @@ export function runTSCodegen(args) {
     tsCodegen(args);
     TS_CODEGEN_PROMISE = Promise.resolve();
     return TS_CODEGEN_PROMISE;
-}
-
-/** Get the current version of `wit-component` which is reflected in WAT output and used for tests */
-let CURRENT_WIT_COMPONENT_VERSION;
-export async function getCurrentWitComponentVersion() {
-    if (CURRENT_WIT_COMPONENT_VERSION) {
-        return CURRENT_WIT_COMPONENT_VERSION;
-    }
-    const cargoLockPath = fileURLToPath(new URL('../../../Cargo.lock', import.meta.url));
-    const cargoLock = parse(await readFile(cargoLockPath, 'utf8'));
-    const version = cargoLock.package.find((p) => p.name === 'wit-component')?.version;
-    if (!version) {
-        throw new Error(`Failed to find/parse wit-version in [${cargoLockPath}]`);
-    }
-    CURRENT_WIT_COMPONENT_VERSION = version;
-    return CURRENT_WIT_COMPONENT_VERSION;
 }
 
 export async function fileExists(p) {

--- a/packages/jco/package.json
+++ b/packages/jco/package.json
@@ -90,7 +90,6 @@
         "oxfmt": "^0.28.0",
         "puppeteer": "catalog:",
         "semver": "^7.7.1",
-        "smol-toml": "^1.4.2",
         "typescript": "^5.9.2",
         "vite": "^7.1.5",
         "vitest": "^4.1.0",

--- a/packages/jco/test/api.js
+++ b/packages/jco/test/api.js
@@ -16,7 +16,7 @@ import {
     preview1AdapterReactorPath,
 } from "../src/api.js";
 
-import { readComponentBytes, getCurrentWitComponentVersion } from "./helpers.js";
+import { readComponentBytes } from "./helpers.js";
 
 const isWindows = platform === "win32";
 
@@ -157,7 +157,7 @@ suite("API", () => {
             [
                 "processed-by",
                 [
-                    ["wit-component", await getCurrentWitComponentVersion()],
+                    ["wit-component", "0.251.0"],
                     ["dummy-gen", "test"],
                 ],
             ],
@@ -198,7 +198,8 @@ suite("API", () => {
             [
                 "processed-by",
                 [
-                    ["wit-component", await getCurrentWitComponentVersion()],
+                    // NOTE: this is the current version *in the released jco-transpile* jco uses
+                    ["wit-component", "0.251.0"],
                     ["dummy-gen", "test"],
                 ],
             ],

--- a/packages/jco/test/cli.js
+++ b/packages/jco/test/cli.js
@@ -7,14 +7,7 @@ import { preview1AdapterCommandPath } from "@bytecodealliance/jco";
 import { componentNew } from "@bytecodealliance/jco-transpile/wasm-tools";
 
 import { AsyncFunction } from "./common.js";
-import {
-    exec,
-    jcoPath,
-    getTmpDir,
-    readComponentBytes,
-    getCurrentWitComponentVersion,
-    setupTestWithLocalShims,
-} from "./helpers.js";
+import { exec, jcoPath, getTmpDir, readComponentBytes, setupTestWithLocalShims } from "./helpers.js";
 
 import { suite, test, assert } from "vitest";
 
@@ -550,7 +543,7 @@ suite("CLI", () => {
                 [
                     "processed-by",
                     [
-                        ["wit-component", await getCurrentWitComponentVersion()],
+                        ["wit-component", "0.251.0"],
                         ["dummy-gen", "test"],
                     ],
                 ],

--- a/packages/jco/test/helpers.js
+++ b/packages/jco/test/helpers.js
@@ -8,7 +8,6 @@ import { tmpdir } from "node:os";
 import { URL, fileURLToPath, pathToFileURL } from "node:url";
 
 import mime from "mime";
-import { parse } from "smol-toml";
 
 import { transpile } from "../src/api.js";
 import { componentize } from "../src/cmd/componentize.js";
@@ -573,22 +572,6 @@ export async function readComponentBytes(componentPath) {
     }
     componentBytes = COMPONENT_BYTES_CACHE[componentPath];
     return componentBytes;
-}
-
-/** Get the current version of `wit-component` which is reflected in WAT output and used for tests */
-let CURRENT_WIT_COMPONENT_VERSION;
-export async function getCurrentWitComponentVersion() {
-    if (CURRENT_WIT_COMPONENT_VERSION) {
-        return CURRENT_WIT_COMPONENT_VERSION;
-    }
-    const cargoLockPath = fileURLToPath(new URL("../../../Cargo.lock", import.meta.url));
-    const cargoLock = parse(await readFile(cargoLockPath, "utf8"));
-    const version = cargoLock.package.find((p) => p.name === "wit-component")?.version;
-    if (!version) {
-        throw new Error(`Failed to find/parse wit-version in [${cargoLockPath}]`);
-    }
-    CURRENT_WIT_COMPONENT_VERSION = version;
-    return CURRENT_WIT_COMPONENT_VERSION;
 }
 
 export async function fileExists(p) {

--- a/packages/preview2-shim/package.json
+++ b/packages/preview2-shim/package.json
@@ -69,7 +69,7 @@
   },
   "devDependencies": {
     "@bytecodealliance/componentize-js": "0.21.0",
-    "@bytecodealliance/jco": "1.20.0",
+    "@bytecodealliance/jco": "1.25.2",
     "@types/node": "^24.12.4",
     "mime": "^4.0.7",
     "puppeteer": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,9 +15,6 @@ catalogs:
     puppeteer:
       specifier: ^25.1.0
       version: 25.1.0
-    smol-toml:
-      specifier: ^1.4.2
-      version: 1.6.1
     typescript:
       specifier: ^6.0.3
       version: 6.0.3
@@ -72,36 +69,36 @@ importers:
   examples/components/add:
     dependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
 
   examples/components/adder:
     dependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
 
   examples/components/fs-write-file:
     dependencies:
       '@bytecodealliance/preview2-shim':
-        specifier: ^0.18.1
-        version: 0.18.1
+        specifier: ^0.19.0
+        version: 0.19.0
     devDependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
 
   examples/components/host-logging:
     dependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
 
   examples/components/http-hello-world:
     dependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
     devDependencies:
       terminate:
         specifier: ^2.8.0
@@ -110,8 +107,8 @@ importers:
   examples/components/http-server-fetch-handler:
     dependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
 
   examples/components/http-server-hono:
     dependencies:
@@ -123,8 +120,8 @@ importers:
         version: 4.12.24
     devDependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       rolldown:
         specifier: ^1.1.0
         version: 1.1.0
@@ -145,8 +142,8 @@ importers:
         version: 4.12.24
     devDependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       rolldown:
         specifier: ^1.1.0
         version: 1.1.0
@@ -160,8 +157,8 @@ importers:
   examples/components/node-compat:
     dependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       rolldown:
         specifier: ^1.1.0
         version: 1.1.0
@@ -172,20 +169,20 @@ importers:
   examples/components/node-fetch:
     dependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
 
   examples/components/string-reverse:
     dependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
 
   examples/components/string-reverse-upper:
     dependencies:
       '@bytecodealliance/jco':
-        specifier: ^1.20.0
-        version: 1.21.0
+        specifier: ^1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
 
   examples/components/ts-resource-export:
     devDependencies:
@@ -194,7 +191,7 @@ importers:
         version: 0.20.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@bytecodealliance/jco':
         specifier: file:../../../packages/jco
-        version: file:packages/jco(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+        version: link:../../../packages/jco
       '@bytecodealliance/preview2-shim':
         specifier: file:../../../packages/preview2-shim
         version: link:../../../packages/preview2-shim
@@ -257,8 +254,8 @@ importers:
   examples/components/webidl-book-library:
     devDependencies:
       '@bytecodealliance/jco':
-        specifier: 1.20.0
-        version: 1.20.0
+        specifier: 1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
 
   packages/bare-jco: {}
 
@@ -316,9 +313,6 @@ importers:
       semver:
         specifier: ^7.7.1
         version: 7.8.0
-      smol-toml:
-        specifier: ^1.4.2
-        version: 1.6.1
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -336,10 +330,10 @@ importers:
     devDependencies:
       '@bytecodealliance/componentize-js':
         specifier: ^0.21.0
-        version: 0.21.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+        version: 0.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@bytecodealliance/componentize-js-0-19-3':
         specifier: npm:@bytecodealliance/componentize-js@^0.19.3
-        version: '@bytecodealliance/componentize-js@0.19.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)'
+        version: '@bytecodealliance/componentize-js@0.19.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)'
       '@bytecodealliance/jco-transpile':
         specifier: ^0.1.1
         version: 0.1.3
@@ -392,9 +386,6 @@ importers:
       puppeteer:
         specifier: 'catalog:'
         version: 25.1.0
-      smol-toml:
-        specifier: 'catalog:'
-        version: 1.6.1
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -414,8 +405,8 @@ importers:
         specifier: 0.21.0
         version: 0.21.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@bytecodealliance/jco':
-        specifier: 1.20.0
-        version: 1.20.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+        specifier: 1.25.2
+        version: 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@types/node':
         specifier: ^24.12.4
         version: 24.12.4
@@ -488,33 +479,15 @@ packages:
   '@bytecodealliance/jco-transpile@0.1.3':
     resolution: {integrity: sha512-SiEcmlbzOzd00v6XwfO+80B6lgc1KjWt8irykadbJWP00RMJrPMopY9FEXE689HNrx/PeBUCCWwgDEnrgn2uBg==}
 
-  '@bytecodealliance/jco-transpile@0.3.9':
-    resolution: {integrity: sha512-UFRNTdJJdHdPU3lUdXlnVGm8XTSYY49feehzXxansUWESMeJES3VO2NuocJ8BJ1wW5r2dYBNUyR9qXgjPoBnhg==}
-
   '@bytecodealliance/jco-transpile@0.4.2':
     resolution: {integrity: sha512-45aeQsUSJsrru1FY1EU47T6kREUkQ7QC1EwIqb5Vi3yakrl6cyqOTRG005k/BWq/fNR0i0n3QtTZQRoF4fi88g==}
 
-  '@bytecodealliance/jco@1.20.0':
-    resolution: {integrity: sha512-E3CNiV+yFEMIE69RnzOgN0vvCGr90+32rX7VBeerxadcAONnclFrXLba243XIuLuiUHQIa9IFcWkiq6dhF5pVw==}
-    hasBin: true
-
-  '@bytecodealliance/jco@1.21.0':
-    resolution: {integrity: sha512-XFW7ZAmoTfUa/OTGFnHWbTv63pO80n4cU/56sQUIHvkPlEnW7epDvnzBYzG4gCBekiUPWnHd30S1XNdl4n1Ccg==}
-    hasBin: true
-
-  '@bytecodealliance/jco@1.24.6':
-    resolution: {integrity: sha512-cb0Ofo2wBIz7TB1rxaydb/BD5j/qmRKt5ThrXespOUfpN2/Ded639pASdmm1o2cwsfAxKfB6fj4CHi9ZDLjfKw==}
-    hasBin: true
-
-  '@bytecodealliance/jco@file:packages/jco':
-    resolution: {directory: packages/jco, type: directory}
+  '@bytecodealliance/jco@1.25.2':
+    resolution: {integrity: sha512-r9ch8vqtDkBxXtN5KzAEYpz+hjGCW+cQhc2b71U21DMuewE5HrTCI7X826gfL/1oU0ibsSpGodJV5YkwolH9Jg==}
     hasBin: true
 
   '@bytecodealliance/preview2-shim@0.17.9':
     resolution: {integrity: sha512-i0R3eQBe6PA/o/1EFE3Owe4In2rcccb6QxnjpntM/lPe3/duJ0bRQTVZM2Ufpo99X4eofGeltQUkape1C91FFA==}
-
-  '@bytecodealliance/preview2-shim@0.18.1':
-    resolution: {integrity: sha512-8+QEByJTHusG1JkYQNUwOZO0ZvP3zQJD7UVYcyRh8OedKfVls1VuPw/HfSuK0ustslzAkGz7uQCkaBbW+fal9w==}
 
   '@bytecodealliance/preview2-shim@0.19.0':
     resolution: {integrity: sha512-OSUlcM62fXLuzYP0DjBn/SwjKMZ/y/2PMXZ8v5cRiiFcroauntlPRl/oCnx0xYjYiqdYvE0PY50VCNutll0xOw==}
@@ -950,49 +923,42 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/lzma-linux-arm64-musl@1.4.5':
     resolution: {integrity: sha512-yWjcPDgJ2nIL3KNvi4536dlT/CcCWO0DUyEOlBs/SacG7BeD6IjGh6yYzd3/X1Y3JItCbZoDoLUH8iB1lTXo3w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/lzma-linux-ppc64-gnu@1.4.5':
     resolution: {integrity: sha512-0XRhKuIU/9ZjT4WDIG/qnX7Xz7mSQHYZo9Gb3MP2gcvBgr6BA4zywQ9k3gmQaPn9ECE+CZg2V7DV7kT+x2pUMQ==}
     engines: {node: '>= 10'}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/lzma-linux-riscv64-gnu@1.4.5':
     resolution: {integrity: sha512-QrqDIPEUUB23GCpyQj/QFyMlr8SGxxyExeZz9OWFnHfb70kXdTLWrHS/hEI1Ru+lSbQ/6xRqeoGyQ4Aqdg+/RA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/lzma-linux-s390x-gnu@1.4.5':
     resolution: {integrity: sha512-k8RVM5aMhW86E9H0QXdquwojew4H3SwPxbRVbl49/COJQWCUjGi79X6mYruMnMPEznZinUiT1jgKbFo2A00NdA==}
     engines: {node: '>= 10'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/lzma-linux-x64-gnu@1.4.5':
     resolution: {integrity: sha512-6rMtBgnIq2Wcl1rQdZsnM+rtCcVCbws1nF8S2NzaUsVaZv8bjrPiAa0lwg4Eqnn1d9lgwqT+cZgm5m+//K08Kw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@napi-rs/lzma-linux-x64-musl@1.4.5':
     resolution: {integrity: sha512-eiadGBKi7Vd0bCArBUOO/qqRYPHt/VQVvGyYvDFt6C2ZSIjlD+HuOl+2oS1sjf4CFjK4eDIog6EdXnL0NE6iyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@napi-rs/lzma-wasm32-wasi@1.4.5':
     resolution: {integrity: sha512-+VyHHlr68dvey6fXc2hehw9gHVFIW3TtGF1XkcbAu65qVXsA9D/T+uuoRVqhE+JCyFHFrO0ixRbZDRK1XJt1sA==}
@@ -1151,56 +1117,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-arm64-musl@0.136.0':
     resolution: {integrity: sha512-T+u/CGKW0UXemJeVux4ix6rK+ug3bQCUEbu5hFlX9K61KQNd44rOcrM15mDK99L7USaXwmiwHeIkEDvmmyDMSA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-minify/binding-linux-ppc64-gnu@0.136.0':
     resolution: {integrity: sha512-WNPTN2F448tb49BoqjV9IMRzZWa0WB8GHzrB+bnxKQPOyzz07T6rmDKrr4Hjl81ADGjDYSsr1fgXcjyLQFdMdw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-gnu@0.136.0':
     resolution: {integrity: sha512-MvcCfu8OeabrmNN9wqhh8Gqizg68RQ3iOvXBJmlLMy5p1PC6az9bAwqOk98lsCmKI4I5LpULekOlfxRYh3o5Kw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-riscv64-musl@0.136.0':
     resolution: {integrity: sha512-rwJXFUFFA0egAULtOOgfW8YhhLhtWrr2qFxftvZ7/U6Xtxiev8i+eCwSNW1RpHiX74QMsJVpRE3ykoefqb1MtQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-minify/binding-linux-s390x-gnu@0.136.0':
     resolution: {integrity: sha512-qizAxHmj7VHm5/D5qiIlvzxAS2tlmadDOJ5XFI7zx/wfnk/+fdk5iVaHOv+C4tDE/4wLQyMoBYVIs6R1LeN91w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-gnu@0.136.0':
     resolution: {integrity: sha512-gcyLAad0UblkEhGjVfx5Mwq63OSx8r04IbcfwzpZYpHisO/vioMsrs4GkDsQZ2Ejc8cdUk6YMIrf9FwNBzh+Dw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-minify/binding-linux-x64-musl@0.136.0':
     resolution: {integrity: sha512-QAK6kwBjljX6luYzeppVdRP3gTaFNFfp9iS/V0cCvU43wUZay5xFXBgmzBHYrzZV2MhzURNnXfEZRo9poAxyvA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-minify/binding-openharmony-arm64@0.136.0':
     resolution: {integrity: sha512-nIGxkTOnN9GwslmooxbZ3Ti2RgbX9QLHy0X9uO0pslOT+4dsNVUawBU/6r4M5cWM+ZdRD2tOF4V+n0l8tS59nQ==}
@@ -1272,42 +1230,36 @@ packages:
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-arm64-musl@0.76.0':
     resolution: {integrity: sha512-wi9zQPMDHrBuRuT7Iurfidc9qlZh7cKa5vfYzOWNBCaqJdgxmNOFzvYen02wVUxSWGKhpiPHxrPX0jdRyJ8Npg==}
     engines: {node: '>=20.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-linux-riscv64-gnu@0.76.0':
     resolution: {integrity: sha512-0tqqu1pqPee2lLGY8vtYlX1L415fFn89e0a3yp4q5N9f03j1rRs0R31qesTm3bt/UK8HYjECZ+56FCVPs2MEMQ==}
     engines: {node: '>=20.0.0'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-s390x-gnu@0.76.0':
     resolution: {integrity: sha512-y36Hh1a5TA+oIGtlc8lT7N9vdHXBlhBetQJW0p457KbiVQ7jF7AZkaPWhESkjHWAsTVKD2OjCa9ZqfaqhSI0FQ==}
     engines: {node: '>=20.0.0'}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-gnu@0.76.0':
     resolution: {integrity: sha512-7/acaG9htovp3gp/J0kHgbItQTuHctl+rbqPPqZ9DRBYTz8iV8kv3QN8t8Or8i/hOmOjfZp9McDoSU1duoR4/A==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-parser/binding-linux-x64-musl@0.76.0':
     resolution: {integrity: sha512-AxFt0reY6Q2rfudABmMTFGR8tFFr58NlH2rRBQgcj+F+iEwgJ+jMwAPhXd2y1I2zaI8GspuahedUYQinqxWqjA==}
     engines: {node: '>=20.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-parser/binding-wasm32-wasi@0.76.0':
     resolution: {integrity: sha512-wHdkHdhf6AWBoO8vs5cpoR6zEFY1rB+fXWtq6j/xb9j/lu1evlujRVMkh8IM/M/pOUIrNkna3nzST/mRImiveQ==}
@@ -1385,56 +1337,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-arm64-musl@0.32.0':
     resolution: {integrity: sha512-UYiqO9MlipntFbdbUKOIo84vuyzrK4TVIs7Etat91WNMFSW54F6OnHq08xa5ZM+K9+cyYMgQPXvYCopuP+LyKw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-ppc64-gnu@0.32.0':
     resolution: {integrity: sha512-IDH/fxMv+HmKsMtsjEbXqhScCKDIYp38sgGEcn0QKeXMxrda67PPZA7HMfoUwEtFUG+jsO1XJxTrQsL+kQ90xQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-gnu@0.32.0':
     resolution: {integrity: sha512-bQFGPDa0buYWJFeK2I7ah8wRZjrAgamaG2OAGv+Ua5UMYEnHxmHcv+r8lWUUrwP2oqQGvp1SB8JIVtBbYuAueQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-riscv64-musl@0.32.0':
     resolution: {integrity: sha512-3vFp9DW1ItEKWltADzCFqG5N7rYFToT4ztlhg8wALoo2E2VhveLD88uAF4FF9AxD9NhgHDGmPCV+WZl/Qlj8cQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-linux-s390x-gnu@0.32.0':
     resolution: {integrity: sha512-Fub2y8S9ImuPzAzpbgkoz/EVTWFFBolxFZYCMRhRZc8cJZI2gl/NlZswqhvJd/U0Jopnwgm/OJ2x128vVzFFWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-gnu@0.32.0':
     resolution: {integrity: sha512-XufwsnV3BF81zO2ofZvhT4FFaMmLTzZEZnC9HpFz/quPeg9C948+kbLlZnsfjmp+1dUxKMCpfmRMqOfF4AOLsA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/binding-linux-x64-musl@0.32.0':
     resolution: {integrity: sha512-u2f9tC2qYfikKmA2uGpnEJgManwmk0ZXWs5BB4ga4KDu2JNLdA3i634DGHeMLK9wY9+iRf3t7IYpgN3OVFrvDw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/binding-openharmony-arm64@0.32.0':
     resolution: {integrity: sha512-5ZXb1wrdbZ1YFXuNXNUCePLlmLDy4sUt4evvzD4Cgumbup5wJgS9PIe5BOaLywUg9f1wTH6lwltj3oT7dFpIGA==}
@@ -1474,25 +1418,21 @@ packages:
     resolution: {integrity: sha512-TfJkMZjePbLiskmxFXVAbGI/OZtD+y+fwS0wyW8O6DWG0ARTf0AipY9zGwGoOdpFuXOJceXvN4SHGLbYNDMY4Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/linux-arm64-musl@0.28.0':
     resolution: {integrity: sha512-7fyQUdW203v4WWGr1T3jwTz4L7KX9y5DeATryQ6fLT6QQp9GEuct8/k0lYhd+ys42iTV/IkJF20e3YkfSOOILg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/linux-x64-gnu@0.28.0':
     resolution: {integrity: sha512-sRKqAvEonuz0qr1X1ncUZceOBJerKzkO2gZIZmosvy/JmqyffpIFL3OE2tqacFkeDhrC+dNYQpusO8zsfHo3pw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxfmt/linux-x64-musl@0.28.0':
     resolution: {integrity: sha512-fW6czbXutX/tdQe8j4nSIgkUox9RXqjyxwyWXUDItpoDkoXllq17qbD7GVc0whrEhYQC6hFE1UEAcDypLJoSzw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxfmt/win32-arm64@0.28.0':
     resolution: {integrity: sha512-D/HDeQBAQRjTbD9OLV6kRDcStrIfO+JsUODDCdGmhRfNX8LPCx95GpfyybpZfn3wVF8Jq/yjPXV1xLkQ+s7RcA==}
@@ -1551,56 +1491,48 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-arm64-musl@1.64.0':
     resolution: {integrity: sha512-00QQ0h0Y7u0G69BgiH3+ky2aaq/QvkDL6DYok8htIuJHxybiux5aQ8jwmg8qIk9wha6UagUP2BAwAzbemcJbpg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-ppc64-gnu@1.64.0':
     resolution: {integrity: sha512-2GaimTV6EMW+s5HS0An3oGbQme3BgHswvfVdGk3EB57Xe9+/gyT+Qd7lNVzb3rtir52vbIPzXfaYArzs5b5zcw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-gnu@1.64.0':
     resolution: {integrity: sha512-H46AtFb9wypjoVwGdlxrm0DsD809NGmtiK9HiyPKTxkSte2YjhC4S+00rOIrwCaxcyPiGid3Y3OMXp5KMAkGZw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-riscv64-musl@1.64.0':
     resolution: {integrity: sha512-HEgsidjjvvyzdg82icYkuFCf7REDV7B9JFwbIMbVwrKLBY0MrXX+bku3POn/hduZ2yW91IyVDUMq0Bf02KwXQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-linux-s390x-gnu@1.64.0':
     resolution: {integrity: sha512-Axvm8qryotmKN00P5w4JapaSjvP2LOSbdbBJiX+2SuHd3QzhW7TUc8skqgw+ahQZ5DmzEYeHCqauvW8f32Ns6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-gnu@1.64.0':
     resolution: {integrity: sha512-cR60vSd7+m+KRZ3GQGfDxWwahW5RMXg0qlGvAluZr0fTUYvw0H9N9AXAF/M/PMqgytyqvVNmBAkJG9l7U30Y1g==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxlint/binding-linux-x64-musl@1.64.0':
     resolution: {integrity: sha512-2u/aPZ9pEg7HnvZPDsHxUGNnrpr4qaHi+mCgLgpt+LYRzPrS4Px4wPfkIdRdr2GvKnaYyt+XSlto0Vm5sbStTg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxlint/binding-openharmony-arm64@1.64.0':
     resolution: {integrity: sha512-kfhkGfCdoXLSxEkrhDlJrvBYajGmq+ma4EMc53dsOWTq+rIBOlI0vTBmpZNnM5oH2LY/K/w1HAK+UQEgjgpVUg==}
@@ -1736,126 +1668,108 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.0.3':
     resolution: {integrity: sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-gnu@1.1.0':
     resolution: {integrity: sha512-+tog7T66i+yFyIuuAnjL6xmW182W/qTBOUt6BtQ6lBIM1Eikh/fSMz4HGgvuCp5uU0zuIVWng7kDYthjCMOHcg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0':
     resolution: {integrity: sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-arm64-musl@1.1.0':
     resolution: {integrity: sha512-4b7yruLIIj/oZ3GpcLOvxcLCLDMraohn3IhQfN2hBP4w9UekG0DTIajWguJosRGfySf/+h/NwRUiMKoCpxCrqQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0':
     resolution: {integrity: sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-ppc64-gnu@1.1.0':
     resolution: {integrity: sha512-QRDOVZd0bhQ5jLsUsCC3dUxDWdTSVY9WMznowZgCGOrZfLLgctWpelhUASEiBwsXfat/JwYnVd1EaxMhqyT+UQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0':
     resolution: {integrity: sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.1.0':
     resolution: {integrity: sha512-ypxT+Hq76NFG7woFbNbySnGEajFuYuIXeKz/jfCU+lXUoxfi3zLE6OG/ZQNeK3RpZSYJlAe2bokpsQ046CaieQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0':
     resolution: {integrity: sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.1.0':
     resolution: {integrity: sha512-IdovCmfROFmpTLahdecTDFL74aLERVYN68F/mLZjfVh6LfoplPfI6deyHNMTcVujbokDV5k05XrFO22zfv+qjg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0':
     resolution: {integrity: sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-linux-x64-musl@1.1.0':
     resolution: {integrity: sha512-pcA8xlFp2tyk9T2R6Fi/rPe3bQ1MA+sSMDNUU5Ogu80GHOatkE4P8YCreGAvZErm5Ho2YRXnyvNrWiRncfVysQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0':
     resolution: {integrity: sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==}
@@ -2027,157 +1941,131 @@ packages:
     resolution: {integrity: sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
     resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.3':
     resolution: {integrity: sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.61.1':
     resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.3':
     resolution: {integrity: sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.61.1':
     resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.3':
     resolution: {integrity: sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.61.1':
     resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.3':
     resolution: {integrity: sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.61.1':
     resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.3':
     resolution: {integrity: sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.61.1':
     resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.3':
     resolution: {integrity: sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.61.1':
     resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.3':
     resolution: {integrity: sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.61.1':
     resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.3':
     resolution: {integrity: sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.61.1':
     resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.3':
     resolution: {integrity: sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.61.1':
     resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.3':
     resolution: {integrity: sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.61.1':
     resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.3':
     resolution: {integrity: sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.61.1':
     resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.3':
     resolution: {integrity: sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.61.1':
     resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.3':
     resolution: {integrity: sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==}
@@ -2431,10 +2319,6 @@ packages:
 
   before-after-hook@2.2.3:
     resolution: {integrity: sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==}
-
-  binaryen@123.0.0:
-    resolution: {integrity: sha512-/hls/a309aZCc0itqP6uhoR+5DsKSlJVfB8Opd2BY9Ndghs84IScTunlyidyF4r2Xe3lQttnfBNIDjaNpj6mTw==}
-    hasBin: true
 
   binaryen@130.0.0:
     resolution: {integrity: sha512-XDrb+zql0RbFPKgj7MuH9zOc78R3Fa/P/VSGnnpdwYsvNZPWjcMYMdAkKCOQEL2A7yqgjSMTDRFp6gfSDW+/QQ==}
@@ -3107,28 +2991,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -3563,10 +3443,6 @@ packages:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
 
-  smol-toml@1.6.1:
-    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
-    engines: {node: '>= 18'}
-
   socks-proxy-agent@8.0.5:
     resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
     engines: {node: '>= 14'}
@@ -3999,9 +3875,9 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.28.5': {}
 
-  '@bytecodealliance/componentize-js@0.19.3':
+  '@bytecodealliance/componentize-js@0.19.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@bytecodealliance/jco': 1.20.0
+      '@bytecodealliance/jco': 1.25.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@bytecodealliance/wizer': 10.0.0
       es-module-lexer: 1.7.0
       oxc-parser: 0.76.0
@@ -4011,7 +3887,7 @@ snapshots:
 
   '@bytecodealliance/componentize-js@0.19.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@bytecodealliance/jco': 1.20.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@bytecodealliance/jco': 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@bytecodealliance/wizer': 10.0.0
       es-module-lexer: 1.7.0
       oxc-parser: 0.76.0
@@ -4021,19 +3897,8 @@ snapshots:
 
   '@bytecodealliance/componentize-js@0.20.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@bytecodealliance/jco': 1.24.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@bytecodealliance/jco': 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@bytecodealliance/weval': 0.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      '@bytecodealliance/wizer': 10.0.0
-      es-module-lexer: 1.7.0
-      oxc-parser: 0.76.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
-  '@bytecodealliance/componentize-js@0.21.0':
-    dependencies:
-      '@bytecodealliance/jco': 1.20.0
-      '@bytecodealliance/weval': 0.4.1
       '@bytecodealliance/wizer': 10.0.0
       es-module-lexer: 1.7.0
       oxc-parser: 0.76.0
@@ -4043,7 +3908,7 @@ snapshots:
 
   '@bytecodealliance/componentize-js@0.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
-      '@bytecodealliance/jco': 1.20.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@bytecodealliance/jco': 1.25.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@bytecodealliance/weval': 0.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       '@bytecodealliance/wizer': 10.0.0
       es-module-lexer: 1.7.0
@@ -4054,7 +3919,7 @@ snapshots:
 
   '@bytecodealliance/componentize-js@0.21.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
-      '@bytecodealliance/jco': 1.20.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+      '@bytecodealliance/jco': 1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@bytecodealliance/weval': 0.4.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
       '@bytecodealliance/wizer': 10.0.0
       es-module-lexer: 1.7.0
@@ -4070,12 +3935,6 @@ snapshots:
       '@bytecodealliance/preview2-shim': 0.17.9
       terser: 5.48.0
 
-  '@bytecodealliance/jco-transpile@0.3.9':
-    dependencies:
-      '@bytecodealliance/preview2-shim': 0.17.9
-      binaryen: 130.0.0
-      terser: 5.48.0
-
   '@bytecodealliance/jco-transpile@0.4.2':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.19.0
@@ -4083,101 +3942,25 @@ snapshots:
       binaryen: 130.0.0
       oxc-minify: 0.136.0
 
-  '@bytecodealliance/jco@1.20.0':
-    dependencies:
-      '@bytecodealliance/componentize-js': 0.21.0
-      '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3'
-      '@bytecodealliance/preview2-shim': 0.17.9
-      '@bytecodealliance/preview3-shim': 0.1.2
-      binaryen: 123.0.0
-      commander: 14.0.3
-      mkdirp: 3.0.1
-      ora: 8.2.0
-      terser: 5.48.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
-  '@bytecodealliance/jco@1.20.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+  '@bytecodealliance/jco@1.25.2(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@bytecodealliance/componentize-js': 0.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3'
-      '@bytecodealliance/preview2-shim': 0.17.9
-      '@bytecodealliance/preview3-shim': 0.1.2
-      binaryen: 123.0.0
-      commander: 14.0.3
-      mkdirp: 3.0.1
-      ora: 8.2.0
-      terser: 5.48.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
-  '@bytecodealliance/jco@1.20.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@bytecodealliance/componentize-js': 0.21.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3'
-      '@bytecodealliance/preview2-shim': 0.17.9
-      '@bytecodealliance/preview3-shim': 0.1.2
-      binaryen: 123.0.0
-      commander: 14.0.3
-      mkdirp: 3.0.1
-      ora: 8.2.0
-      terser: 5.48.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
-  '@bytecodealliance/jco@1.21.0':
-    dependencies:
-      '@bytecodealliance/componentize-js': 0.21.0
-      '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3'
-      '@bytecodealliance/preview2-shim': 0.17.9
-      '@bytecodealliance/preview3-shim': 0.1.2
-      binaryen: 123.0.0
-      commander: 14.0.3
-      mkdirp: 3.0.1
-      ora: 8.2.0
-      terser: 5.48.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
-  '@bytecodealliance/jco@1.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@bytecodealliance/componentize-js': 0.21.0(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
-      '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3'
-      '@bytecodealliance/preview2-shim': 0.17.9
-      '@bytecodealliance/preview3-shim': 0.1.2
-      binaryen: 123.0.0
-      commander: 14.0.3
-      mkdirp: 3.0.1
-      ora: 8.2.0
-      terser: 5.48.0
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-
-  '@bytecodealliance/jco@1.24.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
-    dependencies:
-      '@bytecodealliance/componentize-js': 0.21.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3'
-      '@bytecodealliance/jco-transpile': 0.3.9
+      '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)'
+      '@bytecodealliance/jco-transpile': 0.4.2
       '@bytecodealliance/preview2-shim': 0.17.9
       '@bytecodealliance/preview3-shim': 0.1.2
       binaryen: 130.0.0
       commander: 14.0.3
       mkdirp: 3.0.1
       ora: 8.2.0
-      terser: 5.48.0
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
-  '@bytecodealliance/jco@file:packages/jco(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
+  '@bytecodealliance/jco@1.25.2(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)':
     dependencies:
       '@bytecodealliance/componentize-js': 0.21.0(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
-      '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3'
+      '@bytecodealliance/componentize-js-0-19-3': '@bytecodealliance/componentize-js@0.19.3(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)'
       '@bytecodealliance/jco-transpile': 0.4.2
       '@bytecodealliance/preview2-shim': 0.17.9
       '@bytecodealliance/preview3-shim': 0.1.2
@@ -4191,8 +3974,6 @@ snapshots:
 
   '@bytecodealliance/preview2-shim@0.17.9': {}
 
-  '@bytecodealliance/preview2-shim@0.18.1': {}
-
   '@bytecodealliance/preview2-shim@0.19.0': {}
 
   '@bytecodealliance/preview3-shim@0.1.2':
@@ -4202,16 +3983,6 @@ snapshots:
   '@bytecodealliance/preview3-shim@0.2.0':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.19.0
-
-  '@bytecodealliance/weval@0.4.1':
-    dependencies:
-      '@napi-rs/lzma': 1.4.5
-      decompress: 4.2.1
-      decompress-tar: 4.1.1
-      decompress-unzip: 4.0.1
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
 
   '@bytecodealliance/weval@0.4.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -4637,14 +4408,6 @@ snapshots:
   '@napi-rs/lzma-linux-x64-musl@1.4.5':
     optional: true
 
-  '@napi-rs/lzma-wasm32-wasi@1.4.5':
-    dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-    optional: true
-
   '@napi-rs/lzma-wasm32-wasi@1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
       '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
@@ -4669,29 +4432,6 @@ snapshots:
 
   '@napi-rs/lzma-win32-x64-msvc@1.4.5':
     optional: true
-
-  '@napi-rs/lzma@1.4.5':
-    optionalDependencies:
-      '@napi-rs/lzma-android-arm-eabi': 1.4.5
-      '@napi-rs/lzma-android-arm64': 1.4.5
-      '@napi-rs/lzma-darwin-arm64': 1.4.5
-      '@napi-rs/lzma-darwin-x64': 1.4.5
-      '@napi-rs/lzma-freebsd-x64': 1.4.5
-      '@napi-rs/lzma-linux-arm-gnueabihf': 1.4.5
-      '@napi-rs/lzma-linux-arm64-gnu': 1.4.5
-      '@napi-rs/lzma-linux-arm64-musl': 1.4.5
-      '@napi-rs/lzma-linux-ppc64-gnu': 1.4.5
-      '@napi-rs/lzma-linux-riscv64-gnu': 1.4.5
-      '@napi-rs/lzma-linux-s390x-gnu': 1.4.5
-      '@napi-rs/lzma-linux-x64-gnu': 1.4.5
-      '@napi-rs/lzma-linux-x64-musl': 1.4.5
-      '@napi-rs/lzma-wasm32-wasi': 1.4.5
-      '@napi-rs/lzma-win32-arm64-msvc': 1.4.5
-      '@napi-rs/lzma-win32-ia32-msvc': 1.4.5
-      '@napi-rs/lzma-win32-x64-msvc': 1.4.5
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
 
   '@napi-rs/lzma@1.4.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     optionalDependencies:
@@ -4743,11 +4483,6 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.11.1
       '@emnapi/runtime': 1.11.1
-      '@tybys/wasm-util': 0.10.2
-    optional: true
-
-  '@napi-rs/wasm-runtime@1.1.4':
-    dependencies:
       '@tybys/wasm-util': 0.10.2
     optional: true
 
@@ -5690,8 +5425,6 @@ snapshots:
   basic-ftp@5.3.1: {}
 
   before-after-hook@2.2.3: {}
-
-  binaryen@123.0.0: {}
 
   binaryen@130.0.0: {}
 
@@ -6956,8 +6689,6 @@ snapshots:
   signal-exit@4.1.0: {}
 
   smart-buffer@4.2.0: {}
-
-  smol-toml@1.6.1: {}
 
   socks-proxy-agent@8.0.5:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,7 +32,6 @@ catalog:
   '@bytecodealliance/componentize-js': ^0.21.0
   mime: ^4.0.7
   puppeteer: ^25.1.0
-  smol-toml: ^1.4.2
   typescript: ^6.0.3
   vitest: ^4.0.8
   which: ^2.0.2


### PR DESCRIPTION
This commit updates various upstream Rust tooling to the latest available:

- wasm-tools -> 0.253.0
- wasmtime -> 46.0.1
- wat -> 1.253.0
- wit-bindgen -> 0.59.0
- wast -> 253.0.0