### PR TITLE
fix(jco): re-export browser bindgen from @bytecodealliance/jco-transpile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -516,59 +516,8 @@ jobs:
           name: jco-transpile-vendor
           path: packages/jco-transpile/vendor
 
-      # Build TypeScript for both packages so `types/` and `dist/` are populated
-      # in the tarballs. Order matters: jco's TS references jco-transpile/wasm-tools.
-      - name: Build TypeScript (jco-transpile, then jco)
-        run: |
-          pnpm --filter '@bytecodealliance/jco-transpile' run build:ts
-          pnpm --filter '@bytecodealliance/jco' run build:ts
-
-      - name: Pack tarballs
-        run: |
-          mkdir -p /tmp/jco-pack
-          (cd packages/jco-transpile && npm pack --pack-destination /tmp/jco-pack --ignore-scripts)
-          (cd packages/jco && npm pack --pack-destination /tmp/jco-pack --ignore-scripts)
-          ls -la /tmp/jco-pack
-
-      - name: Assert jco tarball does NOT ship obj/
-        run: |
-          if tar tzf /tmp/jco-pack/bytecodealliance-jco-*.tgz | grep -q '^package/obj/'; then
-            echo "regression: jco tarball ships obj/; browser entry should re-export from jco-transpile instead" >&2
-            tar tzf /tmp/jco-pack/bytecodealliance-jco-*.tgz | grep '^package/obj/' >&2
-            exit 1
-          fi
-
-      - name: Bundle the browser entry with esbuild against the packed tarballs
-        run: |
-          mkdir -p /tmp/jco-bundler-smoke
-          cd /tmp/jco-bundler-smoke
-          cat > package.json <<'EOF'
-          {
-            "name": "jco-bundler-smoke",
-            "private": true,
-            "type": "module"
-          }
-          EOF
-          # Install both packed tarballs; npm will accept 0.4.3 as satisfying jco's ^0.4.2 constraint.
-          npm install --no-save --no-audit --no-fund \
-            /tmp/jco-pack/bytecodealliance-jco-transpile-*.tgz \
-            /tmp/jco-pack/bytecodealliance-jco-*.tgz
-          cat > main.js <<'EOF'
-          import { generate, generateTypes, transpile } from '@bytecodealliance/jco/component';
-          if (typeof generate !== 'function') throw new Error('generate not exported');
-          if (typeof generateTypes !== 'function') throw new Error('generateTypes not exported');
-          if (typeof transpile !== 'function') throw new Error('transpile not exported');
-          EOF
-          # node:* is marked external because the vendored bindgen has runtime feature
-          # detection with a dynamic `await import("node:fs/promises")`; browsers never hit
-          # that path, and the smoke test only needs to prove import resolution succeeds.
-          npx --yes esbuild main.js \
-            --bundle \
-            --format=esm \
-            --platform=browser \
-            --outfile=out.js \
-            '--external:node:*'
-          test -s out.js
+      - name: Bundle browser entry against packed tarballs
+        run: node scripts/build-browser-bundle.mjs
 
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -473,6 +473,103 @@ jobs:
             --no-sandbox
         run: pnpm --filter 'packages/${{ matrix.workspace }}' run test
 
+  # Release gate: prove @bytecodealliance/jco's browser entry can be resolved
+  # and bundled by a browser-targeted bundler against the actual packed tarballs.
+  # Catches regressions like a `files` omission or an import path that only breaks
+  # when the package is consumed via npm (not the local workspace).
+  browser-bundle-smoke:
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "latest"
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+        with:
+          version: 11
+
+      - name: Cache node modules
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: node-modules-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('pnpm-lock.yaml') }}
+          path: |
+            node_modules
+
+      - name: Install node modules
+        run: pnpm install
+
+      - name: Restore jco build output (obj/)
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: build
+          path: packages/jco/obj
+
+      - name: Restore jco-transpile vendor
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: jco-transpile-vendor
+          path: packages/jco-transpile/vendor
+
+      # Build TypeScript for both packages so `types/` and `dist/` are populated
+      # in the tarballs. Order matters: jco's TS references jco-transpile/wasm-tools.
+      - name: Build TypeScript (jco-transpile, then jco)
+        run: |
+          pnpm --filter '@bytecodealliance/jco-transpile' run build:ts
+          pnpm --filter '@bytecodealliance/jco' run build:ts
+
+      - name: Pack tarballs
+        run: |
+          mkdir -p /tmp/jco-pack
+          (cd packages/jco-transpile && npm pack --pack-destination /tmp/jco-pack --ignore-scripts)
+          (cd packages/jco && npm pack --pack-destination /tmp/jco-pack --ignore-scripts)
+          ls -la /tmp/jco-pack
+
+      - name: Assert jco tarball does NOT ship obj/
+        run: |
+          if tar tzf /tmp/jco-pack/bytecodealliance-jco-*.tgz | grep -q '^package/obj/'; then
+            echo "regression: jco tarball ships obj/; browser entry should re-export from jco-transpile instead" >&2
+            tar tzf /tmp/jco-pack/bytecodealliance-jco-*.tgz | grep '^package/obj/' >&2
+            exit 1
+          fi
+
+      - name: Bundle the browser entry with esbuild against the packed tarballs
+        run: |
+          mkdir -p /tmp/jco-bundler-smoke
+          cd /tmp/jco-bundler-smoke
+          cat > package.json <<'EOF'
+          {
+            "name": "jco-bundler-smoke",
+            "private": true,
+            "type": "module"
+          }
+          EOF
+          # Install both packed tarballs; npm will accept 0.4.3 as satisfying jco's ^0.4.2 constraint.
+          npm install --no-save --no-audit --no-fund \
+            /tmp/jco-pack/bytecodealliance-jco-transpile-*.tgz \
+            /tmp/jco-pack/bytecodealliance-jco-*.tgz
+          cat > main.js <<'EOF'
+          import { generate, generateTypes, transpile } from '@bytecodealliance/jco/component';
+          if (typeof generate !== 'function') throw new Error('generate not exported');
+          if (typeof generateTypes !== 'function') throw new Error('generateTypes not exported');
+          if (typeof transpile !== 'function') throw new Error('transpile not exported');
+          EOF
+          # node:* is marked external because the vendored bindgen has runtime feature
+          # detection with a dynamic `await import("node:fs/promises")`; browsers never hit
+          # that path, and the smoke test only needs to prove import resolution succeeds.
+          npx --yes esbuild main.js \
+            --bundle \
+            --format=esm \
+            --platform=browser \
+            --outfile=out.js \
+            '--external:node:*'
+          test -s out.js
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/packages/jco-transpile/package.json
+++ b/packages/jco-transpile/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bytecodealliance/jco-transpile",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "description": "WebAssembly Component transpilation functionality for Jco",
     "keywords": [
         "Component",
@@ -46,6 +46,10 @@
         "./wasm-tools": {
             "types": "./dist/wasm-tools.d.ts",
             "default": "./dist/wasm-tools.js"
+        },
+        "./component": {
+            "types": "./vendor/js-component-bindgen-component.d.ts",
+            "default": "./vendor/js-component-bindgen-component.js"
         }
     },
     "scripts": {

--- a/packages/jco-transpile/package.json
+++ b/packages/jco-transpile/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@bytecodealliance/jco-transpile",
-    "version": "0.4.3",
+    "version": "0.4.2",
     "description": "WebAssembly Component transpilation functionality for Jco",
     "keywords": [
         "Component",

--- a/packages/jco/package.json
+++ b/packages/jco/package.json
@@ -51,7 +51,7 @@
             "default": "./src/api.js"
         },
         "./component": {
-            "types": "./obj/js-component-bindgen-component.d.ts",
+            "types": "./types/browser.d.ts",
             "default": "./src/browser.js"
         }
     },

--- a/packages/jco/src/browser.js
+++ b/packages/jco/src/browser.js
@@ -2,7 +2,7 @@ import {
     $init,
     generate as _generate,
     generateTypes as _generateTypes,
-} from "../obj/js-component-bindgen-component.js";
+} from "@bytecodealliance/jco-transpile/component";
 
 export async function generate() {
     await $init;

--- a/scripts/build-browser-bundle.mjs
+++ b/scripts/build-browser-bundle.mjs
@@ -1,0 +1,88 @@
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const workDir = mkdtempSync(join(tmpdir(), 'jco-browser-bundle-'));
+const packDir = join(workDir, 'pack');
+const projectDir = join(workDir, 'project');
+
+function run(command, args, options = {}) {
+    console.log(`> ${command} ${args.join(' ')}`);
+    execFileSync(command, args, {
+        cwd: root,
+        stdio: 'inherit',
+        ...options,
+    });
+}
+
+function findTarball(pattern) {
+    const matches = readdirSync(packDir).filter((name) => pattern.test(name));
+    if (matches.length !== 1) {
+        throw new Error(`expected one tarball matching ${pattern}, found: ${matches.join(', ')}`);
+    }
+    return join(packDir, matches[0]);
+}
+
+try {
+    for (const project of ['@bytecodealliance/jco-transpile', '@bytecodealliance/jco']) {
+        run('pnpm', ['--filter', project, 'pack', '--pack-destination', packDir]);
+    }
+
+    const jcoTranspileTarball = findTarball(/^bytecodealliance-jco-transpile-.+\.tgz$/);
+    const jcoTarball = findTarball(/^bytecodealliance-jco-\d.+\.tgz$/);
+    const tarContents = execFileSync('tar', ['tzf', jcoTarball], {
+        encoding: 'utf8',
+    });
+    const objFiles = tarContents.split('\n').filter((entry) => entry.startsWith('package/obj/'));
+    if (objFiles.length > 0) {
+        throw new Error(
+            `jco tarball ships obj/; browser entry should re-export from jco-transpile instead:\n${objFiles.join('\n')}`,
+        );
+    }
+
+    mkdirSync(projectDir);
+    writeFileSync(
+        join(projectDir, 'package.json'),
+        JSON.stringify({
+            name: 'jco-browser-bundle-smoke',
+            private: true,
+            type: 'module',
+        }),
+    );
+    writeFileSync(
+        join(projectDir, 'main.js'),
+        `
+import { generate, generateTypes, transpile } from "@bytecodealliance/jco/component";
+if (typeof generate !== "function") throw new Error("generate not exported");
+if (typeof generateTypes !== "function") throw new Error("generateTypes not exported");
+if (typeof transpile !== "function") throw new Error("transpile not exported");
+`,
+    );
+
+    run('npm', ['install', '--no-save', '--no-audit', '--no-fund', jcoTranspileTarball, jcoTarball], {
+        cwd: projectDir,
+    });
+    run(
+        'npx',
+        [
+            '--yes',
+            'esbuild',
+            'main.js',
+            '--bundle',
+            '--format=esm',
+            '--platform=browser',
+            '--outfile=out.js',
+            '--external:node:*',
+        ],
+        { cwd: projectDir },
+    );
+
+    if (statSync(join(projectDir, 'out.js')).size === 0) {
+        throw new Error('browser bundle is empty');
+    }
+} finally {
+    rmSync(workDir, { recursive: true, force: true });
+}


### PR DESCRIPTION
## Problem

`@bytecodealliance/jco@1.25.2` (published 2026-07-09) ships a broken browser build. `packages/jco/src/browser.js` imports the bindgen artifact from `../obj/js-component-bindgen-component.js`, but `packages/jco/package.json`'s `files` array is only `["lib","src","types"]`, so `npm publish` drops the entire `obj/` directory and any bundler resolving the `browser` conditional export fails:

```
[plugin:vite:import-analysis] Failed to resolve import
"../obj/js-component-bindgen-component.js"
from "node_modules/@bytecodealliance/jco/src/browser.js".
```

Issue #646 tracked the same class of regression in 1.11.0. It has re-regressed since the vendoring reorg (#1732 / #1744) — `obj/` is no longer produced next to `browser.js` at publish time.

## Fix (revised per maintainer guidance)

Per @vados-cosmonic in https://github.com/bytecodealliance/jco/pull/1751#issuecomment-5033154859, this PR now wires the browser entry through `@bytecodealliance/jco-transpile` rather than re-adding the `obj/*` globs to `packages/jco`'s `files` list. The sibling `jco-transpile` package already vendors the bindgen under `vendor/js-component-bindgen-component.js` and ships it via its `files` array, so exposing it as a subpath export makes it consumable from `jco` (and any other downstream) without duplicating the artifact.

- `packages/jco-transpile/package.json`: add a `./component` subpath to `exports` pointing at `./vendor/js-component-bindgen-component.{js,d.ts}`. Version bumped to `0.4.3` (patch — non-breaking additive export).
- `packages/jco/src/browser.js`: replace `import ... from "../obj/js-component-bindgen-component.js"` with `import ... from "@bytecodealliance/jco-transpile/component"`. Public exports (`generate`, `generateTypes`, `transpile`, and their `$init`-await wrapping) are preserved for backwards compatibility.
- `packages/jco/package.json`: repoint the `./component` types export from the (unshipped) `./obj/js-component-bindgen-component.d.ts` to `./types/browser.d.ts`, which is already produced by `build:ts` and covered by the `types` entry in `files`. `obj/` is no longer referenced from anywhere the tarball needs to see.

Note: `packages/jco/package.json`'s `@bytecodealliance/jco-transpile` dependency is left at `^0.4.2` — that satisfies workspace-linked `0.4.3` in local dev, and once `jco-transpile@0.4.3` is on the registry, npm/pnpm consumers of a future `jco` release automatically resolve to a version that has the new subpath. Maintainers may prefer to bump the range explicitly at release time.

## Regression test

Added a `browser-bundle-smoke` job to `.github/workflows/main.yml` (release gate — runs on every PR):

1. Restores the existing `build` / `jco-transpile-vendor` artifacts.
2. Builds TypeScript for both packages so `types/` and `dist/` are in place.
3. `npm pack --ignore-scripts` for both packages into a scratch dir.
4. Asserts the jco tarball does **not** ship an `obj/` tree (guards against re-adding `obj/*` to `files` "just in case").
5. Installs both tarballs into an ephemeral project and runs `esbuild --bundle --platform=browser` on `import '@bytecodealliance/jco/component'`.
6. Fails the CI check if bundling fails or if `out.js` is empty.

`node:*` is marked external in the smoke test because the vendored bindgen has runtime feature detection with a dynamic `await import('node:fs/promises')` for host env use; a browser code path never reaches that import and the smoke test only needs to prove import resolution and bundling succeed. This is the same class of check upstream would need for a real browser E2E test but doesn't require puppeteer / a browser runtime, so it runs on every PR.

## Verification

Locally, before the fix, `esbuild --bundle --platform=browser` on `import '@bytecodealliance/jco/component'` fails at the `../obj/...` import. After the fix, packing both packages, installing into `/tmp/jco-bundler-smoke`, and running:

```
npx esbuild main.js --bundle --format=esm --platform=browser --outfile=out.js --external:'node:*'
```

produces a 410 KB `out.js` and exits 0. The packed `bytecodealliance-jco-1.25.2.tgz` contains **zero** entries under `obj/` (confirmed with `tar tzf ... | grep -c obj` → `0`).

## References

- Issue #646 — original 2025 `obj/`-missing regression fixed in 1.11.1
- PR #1732 — vendoring reorg for `jco-transpile`
- PR #1744 — release-bindgen debug-clobber fix
- Regressing commit `3c64835a` — chore(jco): remove un-needed dist files, re-enable tests

## Branch-name note

Branch is still `fix/ship-obj-in-tarball` — the name predates the maintainer's redirect to `jco-transpile` and is kept as-is to preserve this PR's URL. The commit and description reflect the actual approach.
