### PR TITLE
fix(bindgen): Fix dropping multiple borrow types in one func

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -2044,31 +2044,19 @@ impl Bindgen for FunctionBindgen<'_> {
                     let symbol_resource_handle = self.intrinsic(Intrinsic::SymbolResourceHandle);
                     let cur_resource_borrows =
                         self.intrinsic(Intrinsic::Resource(ResourceIntrinsic::CurResourceBorrows));
-                    let is_host = matches!(
-                        self.resource_map.iter().nth(0).unwrap().1.data,
-                        ResourceData::Host { .. }
-                    );
-
-                    if is_host {
-                        uwriteln!(
-                            self.src,
-                            "for (const rsc of {cur_resource_borrows}) {{
-                                rsc[{symbol_resource_handle}] = undefined;
-                            }}
-                            {cur_resource_borrows} = [];"
-                        );
-                    } else {
-                        uwriteln!(
-                            self.src,
-                            "for (const {{ rsc, drop }} of {cur_resource_borrows}) {{
+                    uwriteln!(
+                        self.src,
+                        "for (const entry of {cur_resource_borrows}) {{
+                            const rsc = entry.rsc ?? entry;
+                            if (entry.drop) {{
                                 if (rsc[{symbol_resource_handle}]) {{
-                                    drop(rsc[{symbol_resource_handle}]);
-                                    rsc[{symbol_resource_handle}] = undefined;
+                                    entry.drop(rsc[{symbol_resource_handle}]);
                                 }}
                             }}
-                            {cur_resource_borrows} = [];"
-                        );
-                    }
+                            rsc[{symbol_resource_handle}] = undefined;
+                        }}
+                        {cur_resource_borrows} = [];"
+                    );
                     self.clear_resource_borrows = false;
                 }
             }

--- a/crates/test-components/src/bin/stream_resource_method.rs
+++ b/crates/test-components/src/bin/stream_resource_method.rs
@@ -1,0 +1,26 @@
+//! Regression component for the borrow-cleanup shape mismatch in
+//! stream-carrying methods on host-implemented resources.
+
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "stream-resource-method",
+    });
+    export!(Component);
+}
+
+use wit_bindgen::StreamReader;
+
+use bindings::exports::jco::test_components::stream_resource_method_fns::{Chunk, Guest};
+use bindings::jco::test_components::stream_resources::StreamSummer;
+
+struct Component;
+
+impl Guest for Component {
+    async fn sum_via_resource(rx: StreamReader<Chunk>) -> u32 {
+        let summer = StreamSummer::new();
+        summer.sum_stream(rx).await
+    }
+}
+
+fn main() {}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -647,3 +647,24 @@ world implements-labels {
   export relay: echoer;
   export echo-both: func(msg: string) -> tuple<string, string>;
 }
+
+interface stream-resources {
+  record chunk {
+    data: stream<u8>,
+  }
+
+  resource stream-summer {
+    constructor();
+    sum-stream: async func(rx: stream<chunk>) -> u32;
+  }
+}
+
+interface stream-resource-method-fns {
+  use stream-resources.{chunk};
+  sum-via-resource: async func(rx: stream<chunk>) -> u32;
+}
+
+world stream-resource-method {
+  import stream-resources;
+  export stream-resource-method-fns;
+}

--- a/packages/jco-transpile/test/p3/async.ts
+++ b/packages/jco-transpile/test/p3/async.ts
@@ -5,7 +5,7 @@ import { suite, test, assert, expect } from 'vitest';
 import { WASIShim } from '@bytecodealliance/preview2-shim/instantiation';
 
 import { setupAsyncTest } from '../helpers.js';
-import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR } from '../common.js';
+import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR, createReadableStreamFromValues } from '../common.js';
 
 suite('Async (WASI P3)', () => {
     // see: https://github.com/bytecodealliance/jco/issues/1076
@@ -163,6 +163,52 @@ suite('Async (WASI P3)', () => {
         const resource = await exported.getResourceResult(42);
         assert.instanceOf(resource, ExampleResource);
         assert.strictEqual(resource.getId(), 42);
+
+        await cleanup();
+    });
+
+    test.concurrent('stream-taking method on imported host resource', async () => {
+        class StreamSummer {
+            async sumStream(rx) {
+                let sum = 0;
+                for await (const chunk of rx) {
+                    for (const c of Array.isArray(chunk) ? chunk : [chunk]) {
+                        for await (const value of c.data) {
+                            if (typeof value === 'number') {
+                                sum += value;
+                            } else {
+                                for (const b of value) {
+                                    sum += b;
+                                }
+                            }
+                        }
+                    }
+                }
+                return sum;
+            }
+        }
+
+        const { instance, cleanup } = await setupAsyncTest({
+            asyncMode: 'jspi',
+            component: {
+                path: join(LOCAL_TEST_COMPONENTS_DIR, 'stream-resource-method.wasm'),
+                imports: {
+                    ...new WASIShim().getImportObject(),
+                    'jco:test-components/stream-resources': { StreamSummer },
+                },
+            },
+        });
+
+        const exported = instance['jco:test-components/stream-resource-method-fns'];
+        assert.instanceOf(exported.sumViaResource, AsyncFunction);
+
+        const sum = await exported.sumViaResource(
+            createReadableStreamFromValues([
+                { data: createReadableStreamFromValues(new Uint8Array([1, 2])) },
+                { data: createReadableStreamFromValues(new Uint8Array([3, 4])) },
+            ]),
+        );
+        assert.strictEqual(sum, 10);
 
         await cleanup();
     });


### PR DESCRIPTION
Two different versions of the borrow cleanup code were emitted depending on whether one (random) type was host-owned, which breaks when a func takes both host- and guest-owned resources at once.

This change makes the emitted code handle either kind of resource conditionally at runtime.