### PR TITLE
fix(bindgen): lowered 8-bit writes actually write 8 bits

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/lower.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lower.rs
@@ -269,7 +269,7 @@ impl LowerIntrinsic {
                         }}
 
                         {require_valid_numeric_primitive_fn}.bind('bool', ctx.vals[0]);
-                        new DataView(ctx.memory.buffer).setUint32(ctx.storagePtr, ctx.vals[0], true);
+                        new DataView(ctx.memory.buffer).setUint8(ctx.storagePtr, ctx.vals[0] ? 1 : 0);
 
                         ctx.storagePtr += 1;
                     }}
@@ -290,7 +290,7 @@ impl LowerIntrinsic {
                         if (!ctx.memory) {{ throw new Error("missing memory for lower"); }}
 
                         {require_valid_numeric_primitive_fn}.bind('s8', ctx.vals[0]);
-                        new DataView(ctx.memory.buffer).setInt32(ctx.storagePtr, ctx.vals[0], true);
+                        new DataView(ctx.memory.buffer).setInt8(ctx.storagePtr, ctx.vals[0]);
 
                         ctx.storagePtr += 1;
                     }}
@@ -314,7 +314,7 @@ impl LowerIntrinsic {
                         {require_valid_numeric_primitive_fn}.bind('u8', ctx.vals[0]);
 
                         if (!ctx.memory) {{ throw new Error("missing memory for lower"); }}
-                        new DataView(ctx.memory.buffer).setUint32(ctx.storagePtr, ctx.vals[0], true);
+                        new DataView(ctx.memory.buffer).setUint8(ctx.storagePtr, ctx.vals[0]);
 
                         ctx.storagePtr += 1;
                     }}

--- a/crates/test-components/src/bin/async_scalar_lowers.rs
+++ b/crates/test-components/src/bin/async_scalar_lowers.rs
@@ -1,0 +1,96 @@
+//! Regression fixture for the async-import result lowering of 1-byte types
+//! (`bool`, `u8`, `s8`) and elementwise-lowered `list<u8>` results.
+//!
+//! The host runtime must write results into guest memory with their exact
+//! canonical-ABI sizes: a `bool` async-import result lands in a 1-byte
+//! return area allocated by wit-bindgen, and each `u8` list element lands in
+//! exactly 1 byte of an exactly-sized buffer. A lowering that writes wider
+//! values (e.g. a 4-byte `DataView.setUint32` per byte) silently overflows
+//! those allocations and corrupts the guest heap, detonating later in a
+//! layout-dependent way (dlmalloc `unlink_chunk` traps).
+//!
+//! To make that overflow deterministic to detect (instead of layout-luck),
+//! this fixture installs a global allocator that appends a rear canary to
+//! every allocation and counts violations on dealloc; `run` asserts zero
+//! violations after exercising the imports.
+//!
+//! See `crates/js-component-bindgen/src/intrinsics/lower.rs`
+//! (`_lowerFlatBool` / `_lowerFlatU8` / `_lowerFlatS8`).
+
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "async-scalar-lowers",
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::local_run_async;
+use bindings::jco::test_components::async_scalar_lowers_host as host;
+
+mod canary_alloc {
+    use core::alloc::{GlobalAlloc, Layout};
+    use core::sync::atomic::{AtomicUsize, Ordering};
+    use std::alloc::System;
+
+    /// Number of allocations whose rear canary was clobbered by the time
+    /// they were freed (i.e. something wrote past the end of the
+    /// allocation).
+    pub static VIOLATIONS: AtomicUsize = AtomicUsize::new(0);
+
+    const REAR_BYTE: u8 = 0xC5;
+    const REAR_PAD: usize = 16;
+
+    pub struct CanaryAlloc;
+
+    unsafe impl GlobalAlloc for CanaryAlloc {
+        unsafe fn alloc(&self, l: Layout) -> *mut u8 {
+            let padded = Layout::from_size_align_unchecked(l.size() + REAR_PAD, l.align());
+            let p = System.alloc(padded);
+            if !p.is_null() {
+                core::ptr::write_bytes(p.add(l.size()), REAR_BYTE, REAR_PAD);
+            }
+            p
+        }
+
+        unsafe fn dealloc(&self, p: *mut u8, l: Layout) {
+            for i in 0..REAR_PAD {
+                if p.add(l.size() + i).read() != REAR_BYTE {
+                    VIOLATIONS.fetch_add(1, Ordering::SeqCst);
+                    break;
+                }
+            }
+            let padded = Layout::from_size_align_unchecked(l.size() + REAR_PAD, l.align());
+            System.dealloc(p, padded);
+        }
+    }
+}
+
+#[global_allocator]
+static CANARY_ALLOC: canary_alloc::CanaryAlloc = canary_alloc::CanaryAlloc;
+
+struct Component;
+
+impl local_run_async::Guest for Component {
+    async fn run() {
+        use core::sync::atomic::Ordering;
+
+        // Repeat to give the overflow multiple chances to land on a freshly
+        // canaried return-area allocation.
+        for _ in 0..8 {
+            assert_eq!(host::get_bool().await, true);
+            assert_eq!(host::get_u8().await, 0xAB);
+            assert_eq!(host::get_s8().await, -5);
+            assert_eq!(host::get_list_u8().await, Ok((0..32).collect::<Vec<u8>>()));
+        }
+
+        let violations = canary_alloc::VIOLATIONS.load(Ordering::SeqCst);
+        assert_eq!(
+            violations, 0,
+            "host lowering wrote past the end of {violations} guest allocation(s) \
+             (1-byte results/list elements must be written with 1-byte stores)",
+        );
+    }
+}
+
+fn main() {}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -35,6 +35,13 @@ interface async-lower-result-pointer-host {
     get-flags: async func() -> result<test-flags, string>;
 }
 
+interface async-scalar-lowers-host {
+    get-bool: async func() -> bool;
+    get-u8: async func() -> u8;
+    get-s8: async func() -> s8;
+    get-list-u8: async func() -> result<list<u8>, string>;
+}
+
 interface sync-lower-result-pointer-host {
     add-pair: func(a: u32, b: u32, c: u32, d: u32, e: u32) -> tuple<u32, u32>;
 }
@@ -263,6 +270,11 @@ world async-flat-param-adder {
 world async-lower-result-pointer {
   import async-lower-result-pointer-host;
   import sync-lower-result-pointer-host;
+  export local-run-async;
+}
+
+world async-scalar-lowers {
+  import async-scalar-lowers-host;
   export local-run-async;
 }
 

--- a/packages/jco-transpile/test/p3/import-scalar-lowers.ts
+++ b/packages/jco-transpile/test/p3/import-scalar-lowers.ts
@@ -1,0 +1,57 @@
+import { join } from 'node:path';
+
+import { suite, test, assert } from 'vitest';
+
+import { WASIShim } from '@bytecodealliance/preview2-shim/instantiation';
+
+import { setupAsyncTest } from '../helpers.js';
+import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR } from '../common.js';
+
+// Regression coverage for the flat lowering of 1-byte async host import
+// results (`bool`, `u8`, `s8`) and elementwise-lowered `list<u8>` results:
+// the runtime must write these into guest memory with 1-byte stores. The
+// previous `DataView.setUint32` writes overflowed 3 bytes past the guest's
+// exactly-sized return-area/list allocations, silently corrupting the guest
+// heap (layout-dependent dlmalloc `unlink_chunk` traps much later).
+//
+// The `async-scalar-lowers` fixture guest detects any such overflow
+// deterministically via a rear-canary global allocator and asserts zero
+// violations (see crates/test-components/src/bin/async_scalar_lowers.rs and
+// crates/js-component-bindgen/src/intrinsics/lower.rs).
+suite('async host import 1-byte scalar result lowering', () => {
+    test.concurrent('bool/u8/s8/list<u8> results are written with exact widths', async () => {
+        const { instance, cleanup } = await setupAsyncTest({
+            asyncMode: 'jspi',
+            component: {
+                path: join(LOCAL_TEST_COMPONENTS_DIR, 'async-scalar-lowers.wasm'),
+                imports: {
+                    ...new WASIShim().getImportObject(),
+                    'jco:test-components/async-scalar-lowers-host': {
+                        getBool: async () => true,
+                        getU8: async () => 0xab,
+                        getS8: async () => -5,
+                        getListU8: async () => new Uint8Array(Array.from({ length: 32 }, (_, i) => i)),
+                    },
+                },
+            },
+            jco: {
+                transpile: {
+                    extraArgs: {
+                        minify: false,
+                    },
+                },
+            },
+        });
+
+        try {
+            const run = instance['jco:test-components/local-run-async'].run;
+            assert.instanceOf(run, AsyncFunction);
+            await Promise.race([
+                run(),
+                new Promise((_, reject) => setTimeout(() => reject(new Error('export call timed out')), 10_000)),
+            ]);
+        } finally {
+            await cleanup();
+        }
+    });
+});


### PR DESCRIPTION
Lowered bool, u8, and s8 were using set(U)Int32, which accidentally works most of the time since Wasm is little-endian and values are typically written in memory order. Where it can fail is at the end of a destination buffer where it can cause up to three bytes after the buffer to be overwritten with zeros.