### PR TITLE
feat(p2-shim): add empty HTTP trailers

### DIFF
--- a/packages/preview2-shim/src/browser/http.ts
+++ b/packages/preview2-shim/src/browser/http.ts
@@ -600,7 +600,7 @@ class FutureTrailers implements TypesNamespace.FutureTrailers {
             tag: "ok",
             val: {
                 tag: "ok",
-                val: undefined,
+                val: fieldsLock(fieldsFromEntriesChecked([])),
             },
         };
     }

--- a/packages/preview2-shim/src/nodejs/http.ts
+++ b/packages/preview2-shim/src/nodejs/http.ts
@@ -20,10 +20,11 @@ import {
     ioCall,
     outputStreamCreate,
     pollableCreate,
+    createPoll,
     registerDispose,
     registerIncomingHttpHandler,
 } from "../io/worker-io.js";
-import { HTTP } from "../io/calls.js";
+import { CLOCKS_DURATION_SUBSCRIBE, HTTP } from "../io/calls.js";
 
 import * as http from "node:http";
 import { InputStream, OutputStream, Pollable } from "../../types/interfaces/wasi-io-streams.js";
@@ -107,7 +108,7 @@ delete IncomingRequest._create;
 class FutureTrailers implements TypesNamespace.FutureTrailers {
     #requested = false;
     subscribe() {
-        return pollableCreate(0, this);
+        return createPoll(CLOCKS_DURATION_SUBSCRIBE, null, 0n);
     }
     get():
         | Result<Result<TypesNamespace.Trailers | undefined, TypesNamespace.ErrorCode>, void>
@@ -120,7 +121,7 @@ class FutureTrailers implements TypesNamespace.FutureTrailers {
             tag: "ok",
             val: {
                 tag: "ok",
-                val: undefined,
+                val: fieldsLock(fieldsFromEntriesChecked([])),
             },
         };
     }

--- a/packages/preview2-shim/test/browser.ts
+++ b/packages/preview2-shim/test/browser.ts
@@ -100,6 +100,32 @@ export const test = {
         }
 
         const bodyText = new TextDecoder().decode(bodyBytes);
+
+        const futureTrailers = IncomingBody.finish(incomingBody);
+        const trailersPollable = futureTrailers.subscribe();
+        if (!trailersPollable.ready()) { throw "ERROR: trailers future was not ready"; }
+
+        const trailersResult = futureTrailers.get();
+        if (!trailersResult || trailersResult.tag !== "ok" || trailersResult.val.tag !== "ok") {
+            throw "ERROR: trailers future failed: " + JSON.stringify(trailersResult);
+        }
+        const trailers = trailersResult.val.val;
+        if (!trailers || trailers.entries().length !== 0) {
+            throw "ERROR: expected present, empty trailers";
+        }
+        let immutable = false;
+        try {
+            trailers.append("x-test", new TextEncoder().encode("value"));
+        } catch (e) {
+            immutable = e.tag === "immutable" || (e.payload && e.payload.tag === "immutable");
+        }
+        if (!immutable) { throw "ERROR: trailers must be immutable"; }
+
+        const secondGet = futureTrailers.get();
+        if (!secondGet || secondGet.tag !== "err") {
+            throw "ERROR: trailers future must only be consumed once";
+        }
+
         return bodyText;
     }
 }

--- a/packages/preview2-shim/test/test.ts
+++ b/packages/preview2-shim/test/test.ts
@@ -298,6 +298,25 @@ suite("Node.js Preview2", () => {
                 responseBody = new TextDecoder().decode(buf);
             }
 
+            const futureTrailers = http.types.IncomingBody.finish(incomingBody);
+            const trailersPollable = futureTrailers.subscribe();
+            trailersPollable.block();
+            assert.ok(trailersPollable.ready());
+            const trailersResult = futureTrailers.get();
+            if (!trailersResult || trailersResult.tag !== "ok" || trailersResult.val.tag !== "ok") {
+                throw new Error("expected successful trailers result");
+            }
+            const trailers = trailersResult.val.val;
+            if (!trailers) {
+                throw new Error("expected present trailers");
+            }
+            assert.deepStrictEqual(trailers.entries(), []);
+            throws(
+                () => trailers.append("x-test", encoder.encode("value")),
+                (err: any) => err?.tag === "immutable",
+            );
+            assert.strictEqual(futureTrailers.get()?.tag, "err");
+
             assert.strictEqual(status, 200);
             assert.ok(headers["content-type"].startsWith("text/html"));
             assert.ok(responseBody.includes("WebAssembly"));


### PR DESCRIPTION
Resolves #549 
Resoles #577 

Right now the trailers implementation mirrors the older upstream wasmtime impl that does not forward any trailers, but for now this will at least let components run that are built to use trailers.