### PR TITLE
fix(bindgen): reject task on driver loop exception

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -2072,6 +2072,8 @@ impl AsyncTaskIntrinsic {
                                 }},
                                 err,
                             }});
+                            task.setErrored(err);
+                            task.reject(err);
                         }}
                     }}
                 "#,


### PR DESCRIPTION
Internal exceptions (e.g. bindgen bugs) get caught and swallowed by the task driver loop. This makes them invisible to the caller an completely silent unless JCO_DEBUG is set.

This change rejects the task with the caught error.