### PR TITLE
fix(bindgen): generate named stream and future types

### DIFF
--- a/crates/js-component-bindgen/src/ts_bindgen.rs
+++ b/crates/js-component-bindgen/src/ts_bindgen.rs
@@ -262,8 +262,8 @@ pub fn ts_bindgen(
                             generator.type_fixed_size_list(*id, name, t, len, &ty.docs)
                         }
                         TypeDefKind::Type(t) => generator.type_alias(*id, name, t, None, &ty.docs),
-                        TypeDefKind::Future(_) => todo!("(async impl) generate for future"),
-                        TypeDefKind::Stream(_) => todo!("(async impl) generate for stream"),
+                        TypeDefKind::Future(t) => generator.type_future(name, t, &ty.docs),
+                        TypeDefKind::Stream(t) => generator.type_stream(name, t, &ty.docs),
                         TypeDefKind::Unknown => unreachable!("(async impl) generate for unknown"),
                         TypeDefKind::Resource => {
                             generator.type_resource(*id, ty, GeneratedTypeMeta { is_export: false })
@@ -944,8 +944,8 @@ impl<'a> TsInterface<'a> {
                     self.type_fixed_size_list(*id, name, t, len, &ty.docs)
                 }
                 TypeDefKind::Type(t) => self.type_alias(*id, name, t, Some(iface_id), &ty.docs),
-                TypeDefKind::Future(_) => todo!("(async impl) generate for future"),
-                TypeDefKind::Stream(_) => todo!("(async impl) generate for stream"),
+                TypeDefKind::Future(t) => self.type_future(name, t, &ty.docs),
+                TypeDefKind::Stream(t) => self.type_stream(name, t, &ty.docs),
                 TypeDefKind::Unknown => unreachable!("unexpectedly unknown type def"),
                 TypeDefKind::Resource => self.type_resource(
                     *id,
@@ -1010,12 +1010,12 @@ impl<'a> TsInterface<'a> {
                     TypeDefKind::List(v) => self.print_list_ty(v),
                     TypeDefKind::FixedLengthList(v, len) => self.print_fixed_size_list(v, len),
                     TypeDefKind::Future(maybe_ty) => {
-                        self.src.push_str("Promise<");
+                        self.src.push_str("PromiseLike<");
                         self.print_optional_ty(maybe_ty.as_ref());
                         self.src.push_str(">");
                     }
                     TypeDefKind::Stream(maybe_ty) => {
-                        self.src.push_str("ReadableStream<");
+                        self.src.push_str("AsyncIterable<");
                         self.print_optional_ty(maybe_ty.as_ref());
                         self.src.push_str(">");
                     }
@@ -1439,6 +1439,26 @@ impl<'a> TsInterface<'a> {
                 self.src.push_str(";\n");
             }
         }
+    }
+
+    fn type_future(&mut self, name: &str, element_ty: &Option<Type>, docs: &Docs) {
+        self.docs(docs);
+        self.src.push_str(&format!(
+            "export type {} = PromiseLike<",
+            name.to_upper_camel_case()
+        ));
+        self.print_optional_ty(element_ty.as_ref());
+        self.src.push_str(">;\n");
+    }
+
+    fn type_stream(&mut self, name: &str, element_ty: &Option<Type>, docs: &Docs) {
+        self.docs(docs);
+        self.src.push_str(&format!(
+            "export type {} = AsyncIterable<",
+            name.to_upper_camel_case()
+        ));
+        self.print_optional_ty(element_ty.as_ref());
+        self.src.push_str(">;\n");
     }
 
     fn type_list(&mut self, _id: TypeId, name: &str, element_ty: &Type, docs: &Docs) {

--- a/packages/jco-transpile/test/fixtures/wit/named-async-types.wit
+++ b/packages/jco-transpile/test/fixtures/wit/named-async-types.wit
@@ -1,0 +1,30 @@
+package test:named-async-types;
+
+interface types {
+  record message {
+    text: string,
+  }
+
+  /// Messages delivered incrementally.
+  type message-stream = stream<message>;
+
+  /// Completion of asynchronous message processing.
+  type message-future = future<message>;
+
+  type signal-stream = stream;
+  type signal-future = future;
+}
+
+interface pipeline {
+  use types.{message-future, message-stream};
+
+  transform: func(input: message-stream) -> tuple<message-stream, message-future>;
+}
+
+world named-async-types {
+  type byte-stream = stream<u8>;
+  type ready = future;
+
+  import pipeline;
+  export types;
+}

--- a/packages/jco-transpile/test/typegen.ts
+++ b/packages/jco-transpile/test/typegen.ts
@@ -115,4 +115,29 @@ suite('Type Generation', () => {
         assert.include(worldDts, 'export type * as Primary');
         assert.include(worldDts, 'export type * as Secondary');
     });
+
+    test('named stream and future types', async () => {
+        const files = await generateHostTypes(`${WIT_FIXTURE_DIR}/named-async-types.wit`, {
+            worldName: 'test:named-async-types/named-async-types',
+        });
+
+        const worldDts = Buffer.from(files['named-async-types.d.ts']).toString();
+        const typesDts = Buffer.from(files['interfaces/test-named-async-types-types.d.ts']).toString();
+        const pipelineDts = Buffer.from(files['interfaces/test-named-async-types-pipeline.d.ts']).toString();
+
+        assert.include(worldDts, 'export type ByteStream = AsyncIterable<number>;');
+        assert.include(worldDts, 'export type Ready = PromiseLike<void>;');
+        assert.include(typesDts, 'export type MessageStream = AsyncIterable<Message>;');
+        assert.include(typesDts, 'export type MessageFuture = PromiseLike<Message>;');
+        assert.include(typesDts, 'export type SignalStream = AsyncIterable<void>;');
+        assert.include(typesDts, 'export type SignalFuture = PromiseLike<void>;');
+        assert.include(
+            pipelineDts,
+            "export type MessageStream = import('./test-named-async-types-types.js').MessageStream;",
+        );
+        assert.include(
+            pipelineDts,
+            "export type MessageFuture = import('./test-named-async-types-types.js').MessageFuture;",
+        );
+    });
 });


### PR DESCRIPTION
Emit TS aliases for named wit streams and futures in world and interface declarations.