### PR TITLE
perf(p2-shim): reuse browser filesystem buffers

### DIFF
--- a/packages/preview2-shim/src/browser/filesystem.ts
+++ b/packages/preview2-shim/src/browser/filesystem.ts
@@ -113,6 +113,28 @@ function getSource(fileEntry: FileDataEntry): Uint8Array {
     return fileEntry.source!;
 }
 
+// Keep spare capacity separate so FileDataEntry.source always reflects the logical file size.
+const fileWriteBuffers = new WeakMap<FileDataEntry, Uint8Array>();
+
+function getFileWriteBuffer(
+    entry: FileDataEntry,
+    source: Uint8Array,
+    requiredLength: number,
+): Uint8Array {
+    let buffer = fileWriteBuffers.get(entry);
+    if (!buffer || buffer.buffer !== source.buffer || buffer.byteOffset !== source.byteOffset) {
+        buffer = source;
+    }
+    if (requiredLength <= buffer.byteLength) {
+        return buffer;
+    }
+
+    const newBuffer = new Uint8Array(Math.max(requiredLength, source.byteLength * 2));
+    newBuffer.set(source);
+    fileWriteBuffers.set(entry, newBuffer);
+    return newBuffer;
+}
+
 class DirectoryEntryStream implements TypesNamespace.DirectoryEntryStream {
     idx = 0;
     entries: [string, FileDataEntry][] = [];
@@ -176,15 +198,24 @@ class Descriptor implements TypesNamespace.Descriptor {
 
     writeViaStream(_offset: bigint) {
         const entry = this.#entry;
-        let offset = Number(_offset);
+        let offset = coerceToSafeIntegerNumber(_offset);
         return outputStreamCreate({
             write(buf: Uint8Array): void {
-                const src = entry.source as Uint8Array;
-                const newSource = new Uint8Array(buf.byteLength + src.byteLength);
-                newSource.set(src, 0);
-                newSource.set(buf, offset);
-                offset += buf.byteLength;
-                entry.source = newSource;
+                if (buf.byteLength === 0) {
+                    return;
+                }
+                const source = getSource(entry);
+                const end = offset + buf.byteLength;
+                if (!Number.isSafeInteger(end)) {
+                    throw new TypeError(`excessively large number: ${end}`);
+                }
+                const buffer = getFileWriteBuffer(entry, source, end);
+                if (offset > source.byteLength) {
+                    buffer.fill(0, source.byteLength, offset);
+                }
+                buffer.set(buf, offset);
+                entry.source = buffer.subarray(0, Math.max(source.byteLength, end));
+                offset = end;
             },
         }) as IOutputStream;
     }

--- a/packages/preview2-shim/test/test.ts
+++ b/packages/preview2-shim/test/test.ts
@@ -1104,6 +1104,40 @@ suite("Sandboxing", () => {
         }),
     );
 });
+suite("Browser filesystem", () => {
+    test("writeViaStream reuses file capacity", async () => {
+        const { _setFileData, preopens } = await import("../src/browser/filesystem.js");
+        const file = { source: new Uint8Array([1, 2, 3]) };
+        _setFileData({ dir: { file } });
+
+        const [[rootDescriptor]] = preopens.getDirectories();
+        const descriptor = rootDescriptor.openAt({}, "file", {}, { write: true });
+        const stream = descriptor.writeViaStream(3n);
+
+        stream.write(new Uint8Array([4, 5]));
+        const buffer = file.source.buffer;
+        stream.write(new Uint8Array([6]));
+
+        assert.strictEqual(file.source.buffer, buffer);
+        assert.deepStrictEqual(file.source, new Uint8Array([1, 2, 3, 4, 5, 6]));
+    });
+
+    test("writeViaStream preserves overwrite and sparse-write semantics", async () => {
+        const { _setFileData, preopens } = await import("../src/browser/filesystem.js");
+        const file = { source: new Uint8Array([1, 2, 3, 4]) };
+        _setFileData({ dir: { file } });
+
+        const [[rootDescriptor]] = preopens.getDirectories();
+        const descriptor = rootDescriptor.openAt({}, "file", {}, { write: true });
+
+        descriptor.writeViaStream(1n).write(new Uint8Array([8, 9]));
+        assert.deepStrictEqual(file.source, new Uint8Array([1, 8, 9, 4]));
+
+        descriptor.writeViaStream(6n).write(new Uint8Array([7]));
+        assert.deepStrictEqual(file.source, new Uint8Array([1, 8, 9, 4, 0, 0, 7]));
+    });
+});
+
 suite("Browser shim guards", () => {
     test("pollList throws on empty list", async () => {
         const { poll } = await import("../src/browser/io.js");


### PR DESCRIPTION
Fixes #1069

Reuse geometrically grown backing buffers for browser filesystem write streams instead of reallocating and copying the entire file for each write. The public source view continues to expose the logical file size, including correct overwrite and sparse-write behavior.

On Node.js 22.14.0, 256/512/1024 writes of 8 KiB improved from 140.9/677.2/2081.2 ms to 1.234/1.8/3.327 ms.

## Testing

- preview2-shim build and typecheck
- workspace lint
- focused formatter check
- focused write-stream regression tests
- full preview2-shim suite: 62 passed; 2 Windows/environment-dependent Node-only tests failed (drive-path FS read and Google response assertion)
