### PR TITLE
fix(p3-shim): report invalid read offsets through future

### DIFF
--- a/packages/preview3-shim/src/nodejs/workers/filesystem-worker.ts
+++ b/packages/preview3-shim/src/nodejs/workers/filesystem-worker.ts
@@ -28,8 +28,15 @@ async function handleRead({ fd, offset, stream }) {
   }
 
   const writer = stream.getWriter();
+  let pos = BigInt(offset);
   try {
-    let pos = BigInt(offset);
+    filePosition(pos);
+  } catch (err) {
+    await writer.close();
+    throw err;
+  }
+
+  try {
     const start = pos;
 
     while (true) {

--- a/packages/preview3-shim/test/filesystem.test.js
+++ b/packages/preview3-shim/test/filesystem.test.js
@@ -117,6 +117,25 @@ describe("Descriptor with os.tmpdir()", () => {
     child[Symbol.dispose]?.();
   });
 
+  test("readViaStream reports invalid offsets through its future", async () => {
+    const sub = `${relBase}/file-read-invalid-offset.txt`;
+    const child = await rootDescriptor.openAt(
+      {},
+      sub,
+      { create: true },
+      { read: true, write: true },
+    );
+
+    const [sr, fr] = child.readViaStream(BigInt(Number.MAX_SAFE_INTEGER) + 1n);
+
+    await expect(sr.readAll()).resolves.toEqual(Buffer.alloc(0));
+    await expect(fr.read()).rejects.toMatchObject({
+      payload: { tag: "invalid" },
+    });
+
+    child[Symbol.dispose]?.();
+  });
+
   test("writeViaStream rejects read-only descriptors before consuming data", async () => {
     const sub = `${relBase}/file-read-only-write.txt`;
     const writable = await rootDescriptor.openAt(
@@ -162,6 +181,8 @@ describe("Descriptor with os.tmpdir()", () => {
 
       await child.appendViaStream(rx);
     }
+
+    expect((await child.stat()).size).toBe(2n);
 
     const [sr, fr] = child.readViaStream(0n);
     const buf = await sr.readAll();


### PR DESCRIPTION
This is attempt to fix https://github.com/bytecodealliance/jco/issues/1787

I think to resolve https://github.com/bytecodealliance/jco/issues/1787 we will need a fix on the wasi-testsuite side as well. The test is checking file size after each `stream.write`  completed and I think the check should be deferred to until after the stream future resolves.

Specifically, I think this check is racy: https://github.com/WebAssembly/wasi-testsuite/blob/main/tests/rust/wasm32-wasip3/src/bin/filesystem-io.rs#L115

Edit: see https://github.com/WebAssembly/wasi-testsuite/pull/278