### PR TITLE
fix(bindgen): flags lowered little-endianly

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/lower.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lower.rs
@@ -926,9 +926,9 @@ impl LowerIntrinsic {
                             if (intSizeBytes === 1) {{
                                 dv.setUint8(ctx.storagePtr, flagValue);
                             }} else if (intSizeBytes === 2) {{
-                                dv.setUint16(ctx.storagePtr, flagValue);
+                                dv.setUint16(ctx.storagePtr, flagValue, true);
                             }} else if (intSizeBytes === 4) {{
-                                dv.setUint32(ctx.storagePtr, flagValue);
+                                dv.setUint32(ctx.storagePtr, flagValue, true);
                             }} else {{
                                 throw new Error(`unrecognized flag size [${{intSizeBytes}} bytes]`);
                             }}

--- a/crates/test-components/src/bin/stream_lower.rs
+++ b/crates/test-components/src/bin/stream_lower.rs
@@ -14,7 +14,7 @@ use bindings::jco::test_components::resources;
 
 use bindings::exports::jco::test_components::stream_lower_async::{
     ExampleEnum, ExampleFlags, ExampleRecord, ExampleVariant, LayoutVariant, PaddedRecord,
-    VariantStringRecord,
+    VariantStringRecord, WideFlags,
 };
 
 struct Component;
@@ -127,6 +127,10 @@ impl stream_lower_async::Guest for Component {
     }
 
     async fn read_stream_values_flags(rx: StreamReader<ExampleFlags>) -> Vec<ExampleFlags> {
+        read_async_values(rx).await
+    }
+
+    async fn read_stream_values_wide_flags(rx: StreamReader<WideFlags>) -> Vec<WideFlags> {
         read_async_values(rx).await
     }
 

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -125,6 +125,12 @@ interface example-types {
         second,
         third,
     }
+
+    /// Flags with more than 8 members to use a wider repr (u16)
+    flags wide-flags {
+        f00, f01, f02, f03, f04, f05, f06, f07,
+        f08, f09, f10, f11,
+    }
 }
 
 interface get-stream-async {
@@ -455,6 +461,7 @@ interface stream-lower-async {
         example-enum,
         example-record,
         example-flags,
+        wide-flags,
         layout-variant,
         variant-string-record,
         padded-record,
@@ -493,6 +500,7 @@ interface stream-lower-async {
     read-stream-values-tight-tuple: async func(s: stream<tuple<u8, u8, u32>>) -> list<tuple<u8, u8, u32>>;
 
     read-stream-values-flags: async func(s: stream<example-flags>) -> list<example-flags>;
+    read-stream-values-wide-flags: async func(s: stream<wide-flags>) -> list<wide-flags>;
 
     read-stream-values-enum: async func(s: stream<example-enum>) -> list<example-enum>;
 

--- a/packages/jco-transpile/test/p3/stream-lowers.ts
+++ b/packages/jco-transpile/test/p3/stream-lowers.ts
@@ -411,6 +411,43 @@ suite('stream<T> lowers', () => {
             assert.deepEqual(returnedVals, vals);
         });
 
+        // Regression test for multi-byte flags lowering endianness: flags with
+        // more than 8 members are stored as u16/u32 and must be written
+        // little-endian to match the lift
+        test.concurrent('flags (more than 8 members)', async () => {
+            const instance = await getInstance();
+            assert.instanceOf(
+                instance['jco:test-components/stream-lower-async'].readStreamValuesWideFlags,
+                AsyncFunction,
+            );
+
+            const allUnset = {
+                f00: false,
+                f01: false,
+                f02: false,
+                f03: false,
+                f04: false,
+                f05: false,
+                f06: false,
+                f07: false,
+                f08: false,
+                f09: false,
+                f10: false,
+                f11: false,
+            };
+            const vals = [
+                // bits within both bytes: byte-swapped stores flip f00<->f08, f09<->f01
+                { ...allUnset, f00: true, f09: true },
+                { ...allUnset, f08: true },
+                { ...allUnset, f01: true },
+                { ...allUnset, f11: true },
+            ];
+            const returnedVals = await instance['jco:test-components/stream-lower-async'].readStreamValuesWideFlags(
+                createReadableStreamFromValues(vals),
+            );
+            assert.deepEqual(returnedVals, vals);
+        });
+
         test.concurrent('enum', async () => {
             const instance = await getInstance();
             assert.instanceOf(instance['jco:test-components/stream-lower-async'].readStreamValuesEnum, AsyncFunction);


### PR DESCRIPTION
This only comes up for flags with > 8 fields, which (presumably) doesn't exist in WASI today.