### PR TITLE
fix(bindgen): fix string flat lowering of multibyte utf-8 and multiunit utf-16 chars

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/lower.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lower.rs
@@ -596,12 +596,11 @@ impl LowerIntrinsic {
                         {debug_log_fn}('[{lower_flat_string_utf8_fn}()] args', ctx);
                         if (!ctx.realloc) {{ throw new Error('missing realloc during flat string lower'); }}
 
-                        const s = ctx.vals[0];
-                        const {{ ptr, codepoints }} = {utf8_encode_fn}(ctx.vals[0], ctx.realloc, ctx.memory);
+                        const {{ ptr, len }} = {utf8_encode_fn}(ctx.vals[0], ctx.realloc, ctx.memory);
 
                         const view = new DataView(ctx.memory.buffer);
                         view.setUint32(ctx.storagePtr, ptr, true);
-                        view.setUint32(ctx.storagePtr + 4, codepoints, true);
+                        view.setUint32(ctx.storagePtr + 4, len, true);
 
                         ctx.storagePtr += 8;
                     }}

--- a/crates/js-component-bindgen/src/intrinsics/lower.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lower.rs
@@ -565,23 +565,13 @@ impl LowerIntrinsic {
                         {debug_log_fn}('[{lower_flat_string_utf16_fn}()] args', {{ ctx }});
                         if (!ctx.realloc) {{ throw new Error('missing realloc during flat string lower'); }}
 
-                        const s = ctx.vals[0];
-                        const {{ ptr, len, codepoints }} = {utf16_encode_fn}(ctx.vals[0], ctx.realloc, ctx.memory);
+                        const {{ ptr, len }} = {utf16_encode_fn}(ctx.vals[0], ctx.realloc, ctx.memory);
 
                         const view = new DataView(ctx.memory.buffer);
                         view.setUint32(ctx.storagePtr, ptr, true);
-                        view.setUint32(ctx.storagePtr + 4, codepoints, true);
+                        view.setUint32(ctx.storagePtr + 4, len, true);
 
-                        const bytes = new Uint16Array(ctx.memory.buffer, start, codeUnits);
-                        if (ctx.memory.buffer.byteLength < start + bytes.byteLength) {{
-                            throw new Error('memory out of bounds');
-                        }}
-                        if (ctx.storageLen !== undefined && ctx.storageLen !== bytes.byteLength) {{
-                            throw new Error(`storage length [${{ctx.storageLen}}] != [${{bytes.byteLength}}])`);
-                        }}
-                        new Uint16Array(ctx.memory.buffer, ctx.storagePtr).set(bytes);
-
-                        ctx.storagePtr += len;
+                        ctx.storagePtr += 8;
                     }}
                 "));
             }

--- a/packages/jco-transpile/test/p3/stream-lowers.ts
+++ b/packages/jco-transpile/test/p3/stream-lowers.ts
@@ -279,7 +279,7 @@ suite('stream<T> lowers', () => {
             const instance = await getInstance();
             assert.instanceOf(instance['jco:test-components/stream-lower-async'].readStreamValuesString, AsyncFunction);
 
-            const vals = ['hello', 'world', '!', '☃☃'];
+            const vals = ['hello', 'world', '!', 'utf-8 multibyte: ☃☃', 'utf-16 multiunit: 😀😀'];
             const returnedVals = await instance['jco:test-components/stream-lower-async'].readStreamValuesString(
                 createReadableStreamFromValues(vals),
             );

--- a/packages/jco-transpile/test/p3/stream-lowers.ts
+++ b/packages/jco-transpile/test/p3/stream-lowers.ts
@@ -279,7 +279,7 @@ suite('stream<T> lowers', () => {
             const instance = await getInstance();
             assert.instanceOf(instance['jco:test-components/stream-lower-async'].readStreamValuesString, AsyncFunction);
 
-            const vals = ['hello', 'world', '!'];
+            const vals = ['hello', 'world', '!', '☃☃'];
             const returnedVals = await instance['jco:test-components/stream-lower-async'].readStreamValuesString(
                 createReadableStreamFromValues(vals),
             );


### PR DESCRIPTION
UTF-8 length was lowered as codepoints instead of bytes, breaking on multibyte chars.

UTF-16 length was lowered as codepoints instead of code _units_, breaking on multi-unit chars. Additionally, the UTF-16 lowering was redundantly re-encoding the string - possibly a refactoring mistake?