### PR TITLE
fix(bindgen): fix TypeError from sync-lowered async funcs

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -2208,7 +2208,7 @@ impl AsyncTaskIntrinsic {
                         // TODO(breaking): remove checking for manual async specification here, once we can go p3-only
                         //
                         if (!isManualAsync && !isAsync && funcTypeIsAsync) {{
-                            const {{ promise, resolve }} = new Promise();
+                            const {{ promise, resolve }} = {promise_with_resolvers_fn}();
                             queueMicrotask(async () => {{
                                 if (!subtask.isResolvedState()) {{
                                     await task.suspendUntil({{ readyFn: () => task.isResolvedState() }});
@@ -2471,7 +2471,7 @@ impl AsyncTaskIntrinsic {
                         // TODO(breaking): remove checking for manual async specification here, once we can go p3-only
                         //
                         if (!isManualAsync && !isAsync && funcTypeIsAsync) {{
-                            const {{ promise, resolve }} = new Promise();
+                            const {{ promise, resolve }} = {promise_with_resolvers_fn}();
                             queueMicrotask(async () => {{
                                 if (!subtask.isResolvedState()) {{
                                     await task.suspendUntil({{ readyFn: () => task.isResolvedState() }});


### PR DESCRIPTION
These just needed `new Promise()` - always an error - to be replaced with `PromiseWithResolversPonyfill` (I don't understand the kids these days).