### PR TITLE
fix(bindgen): fix utf-8 to utf-16 transcode length calculation

### DIFF
--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -2462,12 +2462,12 @@ impl<'a> Instantiator<'a, '_> {
                               function trampoline{i} (from_ptr, len, to_ptr) {{
                                   const decoder = new TextDecoder();
                                   const content = decoder.decode(new Uint8Array(memory{from}.buffer, from_ptr, len));
-                                  const strlen = content.length
-                                  const view = new Uint16Array(memory{to}.buffer, to_ptr, strlen * 2)
-                                  for (var i = 0; i < strlen; i++) {{
+                                  const codeUnits = content.length;
+                                  const view = new Uint16Array(memory{to}.buffer, to_ptr, codeUnits);
+                                  for (var i = 0; i < codeUnits; i++) {{
                                       view[i] = content.charCodeAt(i);
                                   }}
-                                  return strlen;
+                                  return codeUnits;
                               }}
                             "#,
                         );


### PR DESCRIPTION
This was mistakenly doubling the length of the array view (presumably thinking the Uint16Array length was in bytes). I renamed the var from `strlen` to `codeUnits` so that the next person to see it will at least stop and think "what the heck is a code unit?".

This only rarely triggered a real bug; if the destination was near the end of the Memory and/or the string was long enough then it could overflow, triggering `RangeError`.