### PR TITLE
feat(p3-shim): Add p3 browser shim skeleton

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -21,5 +21,17 @@
       "error",
       "all"
     ]
-  }
+  },
+  "overrides": [
+    {
+      // Allow unused vars since most of the browser shims just throw for now.
+      // TODO: remove once browser shims are mostly covered.
+      "files": [
+        "packages/preview3-shim/src/browser/**"
+      ],
+      "rules": {
+        "no-unused-vars": "off"
+      }
+    }
+  ]
 }

--- a/packages/preview3-shim/package.json
+++ b/packages/preview3-shim/package.json
@@ -28,12 +28,20 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/nodejs/index.d.ts",
-      "node": "./dist/nodejs/index.js"
+      "types": "./dist/browser/index.d.ts",
+      "node": {
+        "types": "./dist/nodejs/index.d.ts",
+        "default": "./dist/nodejs/index.js"
+      },
+      "default": "./dist/browser/index.js"
     },
     "./*": {
-      "types": "./dist/nodejs/*.d.ts",
-      "node": "./dist/nodejs/*.js"
+      "types": "./dist/browser/*.d.ts",
+      "node": {
+        "types": "./dist/nodejs/*.d.ts",
+        "default": "./dist/nodejs/*.js"
+      },
+      "default": "./dist/browser/*.js"
     },
     "./interfaces/*": {
       "types": "./types/interfaces/*.d.ts"

--- a/packages/preview3-shim/src/browser/cli.ts
+++ b/packages/preview3-shim/src/browser/cli.ts
@@ -1,0 +1,11 @@
+export { default as environment } from "./cli/environment.js";
+export { default as exit } from "./cli/exit.js";
+export { default as run } from "./cli/run.js";
+export { default as stderr } from "./cli/stderr.js";
+export { default as stdin } from "./cli/stdin.js";
+export { default as stdout } from "./cli/stdout.js";
+export { default as terminalInput } from "./cli/terminal-input.js";
+export { default as terminalOutput } from "./cli/terminal-output.js";
+export { default as terminalStderr } from "./cli/terminal-stderr.js";
+export { default as terminalStdin } from "./cli/terminal-stdin.js";
+export { default as terminalStdout } from "./cli/terminal-stdout.js";

--- a/packages/preview3-shim/src/browser/cli/environment.ts
+++ b/packages/preview3-shim/src/browser/cli/environment.ts
@@ -1,0 +1,20 @@
+import { Todo } from "../../common/errors.js";
+
+function getEnvironment(): Array<[string, string]> {
+  throw new Todo();
+}
+
+function getArguments(): Array<string> {
+  throw new Todo();
+}
+
+function getInitialCwd(): string | undefined {
+  throw new Todo();
+}
+
+export default {
+  getEnvironment,
+  getArguments,
+  getInitialCwd,
+} satisfies typeof import("../../../types/interfaces/wasi-cli-environment.d.ts");
+export type * from "../../../types/interfaces/wasi-cli-environment.d.ts";

--- a/packages/preview3-shim/src/browser/cli/exit.ts
+++ b/packages/preview3-shim/src/browser/cli/exit.ts
@@ -1,0 +1,16 @@
+import { Todo } from "../../common/errors.js";
+import type { Result } from "../../../types/interfaces/wasi-cli-exit.d.ts";
+
+function exit(status: Result<void, void>): void {
+  throw new Todo();
+}
+
+function exitWithCode(statusCode: number): void {
+  throw new Todo();
+}
+
+export default {
+  exit,
+  exitWithCode,
+} satisfies typeof import("../../../types/interfaces/wasi-cli-exit.d.ts");
+export type * from "../../../types/interfaces/wasi-cli-exit.d.ts";

--- a/packages/preview3-shim/src/browser/cli/run.ts
+++ b/packages/preview3-shim/src/browser/cli/run.ts
@@ -1,0 +1,10 @@
+import { Todo } from "../../common/errors.js";
+
+function run(): Promise<void> {
+  throw new Todo();
+}
+
+export default {
+  run,
+} satisfies typeof import("../../../types/interfaces/wasi-cli-run.d.ts");
+export type * from "../../../types/interfaces/wasi-cli-run.d.ts";

--- a/packages/preview3-shim/src/browser/cli/stderr.ts
+++ b/packages/preview3-shim/src/browser/cli/stderr.ts
@@ -1,0 +1,11 @@
+import { Todo } from "../../common/errors.js";
+import type { Result, ErrorCode } from "../../../types/interfaces/wasi-cli-stderr.d.ts";
+
+function writeViaStream(data: ReadableStream<number>): Promise<Result<void, ErrorCode>> {
+  throw new Todo();
+}
+
+export default {
+  writeViaStream,
+} satisfies typeof import("../../../types/interfaces/wasi-cli-stderr.d.ts");
+export type * from "../../../types/interfaces/wasi-cli-stderr.d.ts";

--- a/packages/preview3-shim/src/browser/cli/stdin.ts
+++ b/packages/preview3-shim/src/browser/cli/stdin.ts
@@ -1,0 +1,11 @@
+import { Todo } from "../../common/errors.js";
+import type { Result, ErrorCode } from "../../../types/interfaces/wasi-cli-stdin.d.ts";
+
+function readViaStream(): [ReadableStream<number>, Promise<Result<void, ErrorCode>>] {
+  throw new Todo();
+}
+
+export default {
+  readViaStream,
+} satisfies typeof import("../../../types/interfaces/wasi-cli-stdin.d.ts");
+export type * from "../../../types/interfaces/wasi-cli-stdin.d.ts";

--- a/packages/preview3-shim/src/browser/cli/stdout.ts
+++ b/packages/preview3-shim/src/browser/cli/stdout.ts
@@ -1,0 +1,11 @@
+import { Todo } from "../../common/errors.js";
+import type { Result, ErrorCode } from "../../../types/interfaces/wasi-cli-stdout.d.ts";
+
+function writeViaStream(data: ReadableStream<number>): Promise<Result<void, ErrorCode>> {
+  throw new Todo();
+}
+
+export default {
+  writeViaStream,
+} satisfies typeof import("../../../types/interfaces/wasi-cli-stdout.d.ts");
+export type * from "../../../types/interfaces/wasi-cli-stdout.d.ts";

--- a/packages/preview3-shim/src/browser/cli/terminal-input.ts
+++ b/packages/preview3-shim/src/browser/cli/terminal-input.ts
@@ -1,0 +1,8 @@
+import type { TerminalInput as TerminalInputT } from "../../../types/interfaces/wasi-cli-terminal-input.d.ts";
+
+class TerminalInput implements TerminalInputT {}
+
+export default {
+  TerminalInput,
+} satisfies typeof import("../../../types/interfaces/wasi-cli-terminal-input.d.ts");
+export type * from "../../../types/interfaces/wasi-cli-terminal-input.d.ts";

--- a/packages/preview3-shim/src/browser/cli/terminal-output.ts
+++ b/packages/preview3-shim/src/browser/cli/terminal-output.ts
@@ -1,0 +1,8 @@
+import type { TerminalOutput as TerminalOutputT } from "../../../types/interfaces/wasi-cli-terminal-output.d.ts";
+
+class TerminalOutput implements TerminalOutputT {}
+
+export default {
+  TerminalOutput,
+} satisfies typeof import("../../../types/interfaces/wasi-cli-terminal-output.d.ts");
+export type * from "../../../types/interfaces/wasi-cli-terminal-output.d.ts";

--- a/packages/preview3-shim/src/browser/cli/terminal-stderr.ts
+++ b/packages/preview3-shim/src/browser/cli/terminal-stderr.ts
@@ -1,0 +1,11 @@
+import { Todo } from "../../common/errors.js";
+import type { TerminalOutput } from "../../../types/interfaces/wasi-cli-terminal-stderr.d.ts";
+
+function getTerminalStderr(): TerminalOutput | undefined {
+  throw new Todo();
+}
+
+export default {
+  getTerminalStderr,
+} satisfies typeof import("../../../types/interfaces/wasi-cli-terminal-stderr.d.ts");
+export type * from "../../../types/interfaces/wasi-cli-terminal-stderr.d.ts";

--- a/packages/preview3-shim/src/browser/cli/terminal-stdin.ts
+++ b/packages/preview3-shim/src/browser/cli/terminal-stdin.ts
@@ -1,0 +1,11 @@
+import { Todo } from "../../common/errors.js";
+import type { TerminalInput } from "../../../types/interfaces/wasi-cli-terminal-stdin.d.ts";
+
+function getTerminalStdin(): TerminalInput | undefined {
+  throw new Todo();
+}
+
+export default {
+  getTerminalStdin,
+} satisfies typeof import("../../../types/interfaces/wasi-cli-terminal-stdin.d.ts");
+export type * from "../../../types/interfaces/wasi-cli-terminal-stdin.d.ts";

--- a/packages/preview3-shim/src/browser/cli/terminal-stdout.ts
+++ b/packages/preview3-shim/src/browser/cli/terminal-stdout.ts
@@ -1,0 +1,11 @@
+import { Todo } from "../../common/errors.js";
+import type { TerminalOutput } from "../../../types/interfaces/wasi-cli-terminal-stdout.d.ts";
+
+function getTerminalStdout(): TerminalOutput | undefined {
+  throw new Todo();
+}
+
+export default {
+  getTerminalStdout,
+} satisfies typeof import("../../../types/interfaces/wasi-cli-terminal-stdout.d.ts");
+export type * from "../../../types/interfaces/wasi-cli-terminal-stdout.d.ts";

--- a/packages/preview3-shim/src/browser/clocks.ts
+++ b/packages/preview3-shim/src/browser/clocks.ts
@@ -1,0 +1,3 @@
+export { default as monotonicClock } from "./clocks/monotonic-clock.js";
+export { default as systemClock } from "./clocks/system-clock.js";
+export { default as types } from "./clocks/types.js";

--- a/packages/preview3-shim/src/browser/clocks/monotonic-clock.ts
+++ b/packages/preview3-shim/src/browser/clocks/monotonic-clock.ts
@@ -1,0 +1,26 @@
+import { Todo } from "../../common/errors.js";
+import type { Mark, Duration } from "../../../types/interfaces/wasi-clocks-monotonic-clock.d.ts";
+
+function now(): Mark {
+  throw new Todo();
+}
+
+function getResolution(): Duration {
+  throw new Todo();
+}
+
+function waitUntil(when: Mark): Promise<void> {
+  throw new Todo();
+}
+
+function waitFor(howLong: Duration): Promise<void> {
+  throw new Todo();
+}
+
+export default {
+  now,
+  getResolution,
+  waitUntil,
+  waitFor,
+} satisfies typeof import("../../../types/interfaces/wasi-clocks-monotonic-clock.d.ts");
+export type * from "../../../types/interfaces/wasi-clocks-monotonic-clock.d.ts";

--- a/packages/preview3-shim/src/browser/clocks/system-clock.ts
+++ b/packages/preview3-shim/src/browser/clocks/system-clock.ts
@@ -1,0 +1,16 @@
+import { Todo } from "../../common/errors.js";
+import type { Instant, Duration } from "../../../types/interfaces/wasi-clocks-system-clock.d.ts";
+
+function now(): Instant {
+  throw new Todo();
+}
+
+function getResolution(): Duration {
+  throw new Todo();
+}
+
+export default {
+  now,
+  getResolution,
+} satisfies typeof import("../../../types/interfaces/wasi-clocks-system-clock.d.ts");
+export type * from "../../../types/interfaces/wasi-clocks-system-clock.d.ts";

--- a/packages/preview3-shim/src/browser/clocks/types.ts
+++ b/packages/preview3-shim/src/browser/clocks/types.ts
@@ -1,0 +1,2 @@
+export default {} satisfies typeof import("../../../types/interfaces/wasi-clocks-types.d.ts");
+export type * from "../../../types/interfaces/wasi-clocks-types.d.ts";

--- a/packages/preview3-shim/src/browser/filesystem.ts
+++ b/packages/preview3-shim/src/browser/filesystem.ts
@@ -1,0 +1,2 @@
+export { default as preopens } from "./filesystem/preopens.js";
+export { default as types } from "./filesystem/types.js";

--- a/packages/preview3-shim/src/browser/filesystem/preopens.ts
+++ b/packages/preview3-shim/src/browser/filesystem/preopens.ts
@@ -1,0 +1,11 @@
+import { Todo } from "../../common/errors.js";
+import type { Descriptor } from "../../../types/interfaces/wasi-filesystem-preopens.d.ts";
+
+function getDirectories(): Array<[Descriptor, string]> {
+  throw new Todo();
+}
+
+export default {
+  getDirectories,
+} satisfies typeof import("../../../types/interfaces/wasi-filesystem-preopens.d.ts");
+export type * from "../../../types/interfaces/wasi-filesystem-preopens.d.ts";

--- a/packages/preview3-shim/src/browser/filesystem/types.ts
+++ b/packages/preview3-shim/src/browser/filesystem/types.ts
@@ -1,0 +1,141 @@
+import { Todo } from "../../common/errors.js";
+import type {
+  Descriptor as DescriptorT,
+  Advice,
+  DescriptorFlags,
+  DescriptorStat,
+  DescriptorType,
+  DirectoryEntry,
+  ErrorCode,
+  Filesize,
+  MetadataHashValue,
+  NewTimestamp,
+  OpenFlags,
+  PathFlags,
+  Result,
+} from "../../../types/interfaces/wasi-filesystem-types.d.ts";
+
+class Descriptor implements DescriptorT {
+  readViaStream(offset: Filesize): [ReadableStream<number>, Promise<Result<void, ErrorCode>>] {
+    throw new Todo();
+  }
+
+  writeViaStream(data: ReadableStream<number>, offset: Filesize): Promise<Result<void, ErrorCode>> {
+    throw new Todo();
+  }
+
+  appendViaStream(data: ReadableStream<number>): Promise<Result<void, ErrorCode>> {
+    throw new Todo();
+  }
+
+  advise(offset: Filesize, length: Filesize, advice: Advice): Promise<void> {
+    throw new Todo();
+  }
+
+  syncData(): Promise<void> {
+    throw new Todo();
+  }
+
+  getFlags(): Promise<DescriptorFlags> {
+    throw new Todo();
+  }
+
+  getType(): Promise<DescriptorType> {
+    throw new Todo();
+  }
+
+  setSize(size: Filesize): Promise<void> {
+    throw new Todo();
+  }
+
+  setTimes(
+    dataAccessTimestamp: NewTimestamp,
+    dataModificationTimestamp: NewTimestamp,
+  ): Promise<void> {
+    throw new Todo();
+  }
+
+  readDirectory(): [ReadableStream<DirectoryEntry>, Promise<Result<void, ErrorCode>>] {
+    throw new Todo();
+  }
+
+  sync(): Promise<void> {
+    throw new Todo();
+  }
+
+  createDirectoryAt(path: string): Promise<void> {
+    throw new Todo();
+  }
+
+  stat(): Promise<DescriptorStat> {
+    throw new Todo();
+  }
+
+  statAt(pathFlags: PathFlags, path: string): Promise<DescriptorStat> {
+    throw new Todo();
+  }
+
+  setTimesAt(
+    pathFlags: PathFlags,
+    path: string,
+    dataAccessTimestamp: NewTimestamp,
+    dataModificationTimestamp: NewTimestamp,
+  ): Promise<void> {
+    throw new Todo();
+  }
+
+  linkAt(
+    oldPathFlags: PathFlags,
+    oldPath: string,
+    newDescriptor: Descriptor,
+    newPath: string,
+  ): Promise<void> {
+    throw new Todo();
+  }
+
+  openAt(
+    pathFlags: PathFlags,
+    path: string,
+    openFlags: OpenFlags,
+    flags: DescriptorFlags,
+  ): Promise<Descriptor> {
+    throw new Todo();
+  }
+
+  readlinkAt(path: string): Promise<string> {
+    throw new Todo();
+  }
+
+  removeDirectoryAt(path: string): Promise<void> {
+    throw new Todo();
+  }
+
+  renameAt(oldPath: string, newDescriptor: Descriptor, newPath: string): Promise<void> {
+    throw new Todo();
+  }
+
+  symlinkAt(oldPath: string, newPath: string): Promise<void> {
+    throw new Todo();
+  }
+
+  unlinkFileAt(path: string): Promise<void> {
+    throw new Todo();
+  }
+
+  isSameObject(other: Descriptor): Promise<boolean> {
+    throw new Todo();
+  }
+
+  metadataHash(): Promise<MetadataHashValue> {
+    throw new Todo();
+  }
+
+  metadataHashAt(pathFlags: PathFlags, path: string): Promise<MetadataHashValue> {
+    throw new Todo();
+  }
+}
+
+export default {
+  Descriptor,
+} satisfies typeof import("../../../types/interfaces/wasi-filesystem-types.d.ts");
+export type * from "../../../types/interfaces/wasi-filesystem-types.d.ts";

--- a/packages/preview3-shim/src/browser/http.ts
+++ b/packages/preview3-shim/src/browser/http.ts
@@ -1,0 +1,3 @@
+export { default as client } from "./http/client.js";
+export { default as handler } from "./http/handler.js";
+export { default as types } from "./http/types.js";

--- a/packages/preview3-shim/src/browser/http/client.ts
+++ b/packages/preview3-shim/src/browser/http/client.ts
@@ -1,0 +1,11 @@
+import { Todo } from "../../common/errors.js";
+import type { Request, Response } from "../../../types/interfaces/wasi-http-client.d.ts";
+
+function send(request: Request): Promise<Response> {
+  throw new Todo();
+}
+
+export default {
+  send,
+} satisfies typeof import("../../../types/interfaces/wasi-http-client.d.ts");
+export type * from "../../../types/interfaces/wasi-http-client.d.ts";

--- a/packages/preview3-shim/src/browser/http/handler.ts
+++ b/packages/preview3-shim/src/browser/http/handler.ts
@@ -1,0 +1,11 @@
+import { Todo } from "../../common/errors.js";
+import type { Request, Response } from "../../../types/interfaces/wasi-http-handler.d.ts";
+
+function handle(request: Request): Promise<Response> {
+  throw new Todo();
+}
+
+export default {
+  handle,
+} satisfies typeof import("../../../types/interfaces/wasi-http-handler.d.ts");
+export type * from "../../../types/interfaces/wasi-http-handler.d.ts";

--- a/packages/preview3-shim/src/browser/http/types.ts
+++ b/packages/preview3-shim/src/browser/http/types.ts
@@ -1,0 +1,148 @@
+import { Todo } from "../../common/errors.js";
+import type {
+  Fields as FieldsT,
+  Request as RequestT,
+  RequestOptions as RequestOptionsT,
+  Response as ResponseT,
+  FieldName,
+  FieldValue,
+  Headers,
+  Method,
+  Scheme,
+  Duration,
+  StatusCode,
+  Trailers,
+  ErrorCode,
+  Result,
+} from "../../../types/interfaces/wasi-http-types.d.ts";
+
+class Fields implements FieldsT {
+  static fromList(entries: Array<[FieldName, FieldValue]>): FieldsT {
+    throw new Todo();
+  }
+  get(name: FieldName): Array<FieldValue> {
+    throw new Todo();
+  }
+  has(name: FieldName): boolean {
+    throw new Todo();
+  }
+  set(name: FieldName, value: Array<FieldValue>): void {
+    throw new Todo();
+  }
+  delete(name: FieldName): void {
+    throw new Todo();
+  }
+  getAndDelete(name: FieldName): Array<FieldValue> {
+    throw new Todo();
+  }
+  append(name: FieldName, value: FieldValue): void {
+    throw new Todo();
+  }
+  copyAll(): Array<[FieldName, FieldValue]> {
+    throw new Todo();
+  }
+  clone(): FieldsT {
+    throw new Todo();
+  }
+}
+class Request implements RequestT {
+  static new(
+    headers: Headers,
+    contents: ReadableStream<number> | undefined,
+    trailers: Promise<Result<Trailers | undefined, ErrorCode>>,
+    options: RequestOptions | undefined,
+  ): [Request, Promise<Result<void, ErrorCode>>] {
+    throw new Todo();
+  }
+  getMethod(): Method {
+    throw new Todo();
+  }
+  setMethod(method: Method): void {
+    throw new Todo();
+  }
+  getPathWithQuery(): string | undefined {
+    throw new Todo();
+  }
+  setPathWithQuery(pathWithQuery: string | undefined): void {
+    throw new Todo();
+  }
+  getScheme(): Scheme | undefined {
+    throw new Todo();
+  }
+  setScheme(scheme: Scheme | undefined): void {
+    throw new Todo();
+  }
+  getAuthority(): string | undefined {
+    throw new Todo();
+  }
+  setAuthority(authority: string | undefined): void {
+    throw new Todo();
+  }
+  getOptions(): RequestOptionsT | undefined {
+    throw new Todo();
+  }
+  getHeaders(): Headers {
+    throw new Todo();
+  }
+  static consumeBody(
+    this_: Request,
+    res: Promise<Result<void, ErrorCode>>,
+  ): [ReadableStream<number>, Promise<Result<Trailers | undefined, ErrorCode>>] {
+    throw new Todo();
+  }
+}
+class RequestOptions implements RequestOptionsT {
+  getConnectTimeout(): Duration | undefined {
+    throw new Todo();
+  }
+  setConnectTimeout(duration: Duration | undefined): void {
+    throw new Todo();
+  }
+  getFirstByteTimeout(): Duration | undefined {
+    throw new Todo();
+  }
+  setFirstByteTimeout(duration: Duration | undefined): void {
+    throw new Todo();
+  }
+  getBetweenBytesTimeout(): Duration | undefined {
+    throw new Todo();
+  }
+  setBetweenBytesTimeout(duration: Duration | undefined): void {
+    throw new Todo();
+  }
+  clone(): RequestOptionsT {
+    throw new Todo();
+  }
+}
+class Response implements ResponseT {
+  static new(
+    headers: Headers,
+    contents: ReadableStream<number> | undefined,
+    trailers: Promise<Result<Trailers | undefined, ErrorCode>>,
+  ): [Response, Promise<Result<void, ErrorCode>>] {
+    throw new Todo();
+  }
+  getStatusCode(): StatusCode {
+    throw new Todo();
+  }
+  setStatusCode(statusCode: StatusCode): void {
+    throw new Todo();
+  }
+  getHeaders(): Headers {
+    throw new Todo();
+  }
+  static consumeBody(
+    this_: Response,
+    res: Promise<Result<void, ErrorCode>>,
+  ): [ReadableStream<number>, Promise<Result<Trailers | undefined, ErrorCode>>] {
+    throw new Todo();
+  }
+}
+
+export default {
+  Fields,
+  Request,
+  RequestOptions,
+  Response,
+} satisfies typeof import("../../../types/interfaces/wasi-http-types.d.ts");
+export type * from "../../../types/interfaces/wasi-http-types.d.ts";

--- a/packages/preview3-shim/src/browser/index.ts
+++ b/packages/preview3-shim/src/browser/index.ts
@@ -1,0 +1,6 @@
+export * as cli from "./cli.js";
+export * as clocks from "./clocks.js";
+export * as filesystem from "./filesystem.js";
+export * as http from "./http.js";
+export * as random from "./random.js";
+export * as sockets from "./sockets.js";

--- a/packages/preview3-shim/src/browser/random.ts
+++ b/packages/preview3-shim/src/browser/random.ts
@@ -1,0 +1,3 @@
+export { default as random } from "./random/random.js";
+export { default as insecure } from "./random/insecure.js";
+export { default as insecureSeed } from "./random/insecure-seed.js";

--- a/packages/preview3-shim/src/browser/random/insecure-seed.ts
+++ b/packages/preview3-shim/src/browser/random/insecure-seed.ts
@@ -1,0 +1,10 @@
+import { Todo } from "../../common/errors.js";
+
+function getInsecureSeed(): [bigint, bigint] {
+  throw new Todo();
+}
+
+export default {
+  getInsecureSeed,
+} satisfies typeof import("../../../types/interfaces/wasi-random-insecure-seed.d.ts");
+export type * from "../../../types/interfaces/wasi-random-insecure-seed.d.ts";

--- a/packages/preview3-shim/src/browser/random/insecure.ts
+++ b/packages/preview3-shim/src/browser/random/insecure.ts
@@ -1,0 +1,15 @@
+import { Todo } from "../../common/errors.js";
+
+function getInsecureRandomBytes(maxLen: bigint): Uint8Array {
+  throw new Todo();
+}
+
+function getInsecureRandomU64(): bigint {
+  throw new Todo();
+}
+
+export default {
+  getInsecureRandomBytes,
+  getInsecureRandomU64,
+} satisfies typeof import("../../../types/interfaces/wasi-random-insecure.d.ts");
+export type * from "../../../types/interfaces/wasi-random-insecure.d.ts";

--- a/packages/preview3-shim/src/browser/random/random.ts
+++ b/packages/preview3-shim/src/browser/random/random.ts
@@ -1,0 +1,15 @@
+import { Todo } from "../../common/errors.js";
+
+function getRandomBytes(maxLen: bigint): Uint8Array {
+  throw new Todo();
+}
+
+function getRandomU64(): bigint {
+  throw new Todo();
+}
+
+export default {
+  getRandomBytes,
+  getRandomU64,
+} satisfies typeof import("../../../types/interfaces/wasi-random-random.d.ts");
+export type * from "../../../types/interfaces/wasi-random-random.d.ts";

--- a/packages/preview3-shim/src/browser/sockets.ts
+++ b/packages/preview3-shim/src/browser/sockets.ts
@@ -1,0 +1,2 @@
+export { default as ipNameLookup } from "./sockets/ip-name-lookup.js";
+export { default as types } from "./sockets/types.js";

--- a/packages/preview3-shim/src/browser/sockets/ip-name-lookup.ts
+++ b/packages/preview3-shim/src/browser/sockets/ip-name-lookup.ts
@@ -1,0 +1,11 @@
+import { Todo } from "../../common/errors.js";
+import type { IpAddress } from "../../../types/interfaces/wasi-sockets-ip-name-lookup.d.ts";
+
+function resolveAddresses(name: string): Promise<Array<IpAddress>> {
+  throw new Todo();
+}
+
+export default {
+  resolveAddresses,
+} satisfies typeof import("../../../types/interfaces/wasi-sockets-ip-name-lookup.d.ts");
+export type * from "../../../types/interfaces/wasi-sockets-ip-name-lookup.d.ts";

--- a/packages/preview3-shim/src/browser/sockets/types.ts
+++ b/packages/preview3-shim/src/browser/sockets/types.ts
@@ -1,0 +1,142 @@
+import { Todo } from "../../common/errors.js";
+import type {
+  Duration,
+  ErrorCode,
+  IpAddressFamily,
+  IpSocketAddress,
+  Result,
+  TcpSocket as TcpSocketT,
+  UdpSocket as UdpSocketT,
+} from "../../../types/interfaces/wasi-sockets-types.d.ts";
+
+export class TcpSocket implements TcpSocketT {
+  static create(addressFamily: IpAddressFamily): TcpSocket {
+    throw new Todo();
+  }
+  bind(localAddress: IpSocketAddress): void {
+    throw new Todo();
+  }
+  connect(remoteAddress: IpSocketAddress): Promise<void> {
+    throw new Todo();
+  }
+  listen(): ReadableStream<TcpSocketT> {
+    throw new Todo();
+  }
+  send(data: ReadableStream<number>): Promise<Result<void, ErrorCode>> {
+    throw new Todo();
+  }
+  receive(): [ReadableStream<number>, Promise<Result<void, ErrorCode>>] {
+    throw new Todo();
+  }
+  getLocalAddress(): IpSocketAddress {
+    throw new Todo();
+  }
+  getRemoteAddress(): IpSocketAddress {
+    throw new Todo();
+  }
+  getIsListening(): boolean {
+    throw new Todo();
+  }
+  getAddressFamily(): IpAddressFamily {
+    throw new Todo();
+  }
+  setListenBacklogSize(value: bigint): void {
+    throw new Todo();
+  }
+  getKeepAliveEnabled(): boolean {
+    throw new Todo();
+  }
+  setKeepAliveEnabled(value: boolean): void {
+    throw new Todo();
+  }
+  getKeepAliveIdleTime(): Duration {
+    throw new Todo();
+  }
+  setKeepAliveIdleTime(value: Duration): void {
+    throw new Todo();
+  }
+  getKeepAliveInterval(): Duration {
+    throw new Todo();
+  }
+  setKeepAliveInterval(value: Duration): void {
+    throw new Todo();
+  }
+  getKeepAliveCount(): number {
+    throw new Todo();
+  }
+  setKeepAliveCount(value: number): void {
+    throw new Todo();
+  }
+  getHopLimit(): number {
+    throw new Todo();
+  }
+  setHopLimit(value: number): void {
+    throw new Todo();
+  }
+  getReceiveBufferSize(): bigint {
+    throw new Todo();
+  }
+  setReceiveBufferSize(value: bigint): void {
+    throw new Todo();
+  }
+  getSendBufferSize(): bigint {
+    throw new Todo();
+  }
+  setSendBufferSize(value: bigint): void {
+    throw new Todo();
+  }
+}
+
+export class UdpSocket implements UdpSocketT {
+  static create(addressFamily: IpAddressFamily): UdpSocket {
+    throw new Todo();
+  }
+  bind(localAddress: IpSocketAddress): void {
+    throw new Todo();
+  }
+  connect(remoteAddress: IpSocketAddress): void {
+    throw new Todo();
+  }
+  disconnect(): void {
+    throw new Todo();
+  }
+  send(data: Uint8Array, remoteAddress: IpSocketAddress | undefined): Promise<void> {
+    throw new Todo();
+  }
+  receive(): Promise<[Uint8Array, IpSocketAddress]> {
+    throw new Todo();
+  }
+  getLocalAddress(): IpSocketAddress {
+    throw new Todo();
+  }
+  getRemoteAddress(): IpSocketAddress {
+    throw new Todo();
+  }
+  getAddressFamily(): IpAddressFamily {
+    throw new Todo();
+  }
+  getUnicastHopLimit(): number {
+    throw new Todo();
+  }
+  setUnicastHopLimit(value: number): void {
+    throw new Todo();
+  }
+  getReceiveBufferSize(): bigint {
+    throw new Todo();
+  }
+  setReceiveBufferSize(value: bigint): void {
+    throw new Todo();
+  }
+  getSendBufferSize(): bigint {
+    throw new Todo();
+  }
+  setSendBufferSize(value: bigint): void {
+    throw new Todo();
+  }
+}
+
+export default {
+  TcpSocket,
+  UdpSocket,
+} satisfies typeof import("../../../types/interfaces/wasi-sockets-types.d.ts");
+export type * from "../../../types/interfaces/wasi-sockets-types.d.ts";

--- a/packages/preview3-shim/src/common/errors.ts
+++ b/packages/preview3-shim/src/common/errors.ts
@@ -1,0 +1,5 @@
+export class Todo extends Error {
+  constructor() {
+    super("TODO: not yet implemented");
+  }
+}


### PR DESCRIPTION
This PR adds a p3 browser shim skeleton, so the shim can be filled out incrementally over time.

The skeleton has no actual implementations, but it's still useful: components generated by p3-targeting toolchains import these interfaces whether or not they end up calling them, and stubs let those components load rather than fail to resolve.

It also leans on TypeScript to enforce that every interface is fully covered.
