### PR TITLE
fix(bindgen): lanns fixes reloaded

### DIFF
--- a/crates/js-component-bindgen/src/function_bindgen.rs
+++ b/crates/js-component-bindgen/src/function_bindgen.rs
@@ -3062,7 +3062,6 @@ impl Bindgen for FunctionBindgen<'_> {
                 let debug_log_fn = self.intrinsic(Intrinsic::DebugLog);
                 let async_iterator_symbol = self.intrinsic(Intrinsic::SymbolAsyncIterator);
                 let iterator_symbol = self.intrinsic(Intrinsic::SymbolIterator);
-                let symbol_dispose = self.intrinsic(Intrinsic::SymbolDispose);
                 let external_readable_stream_class =
                     self.intrinsic(Intrinsic::PlatformReadableStreamClass);
                 let get_or_create_async_state_fn = self.intrinsic(Intrinsic::Component(
@@ -3070,6 +3069,9 @@ impl Bindgen for FunctionBindgen<'_> {
                 ));
                 let gen_stream_host_inject_fn = self.intrinsic(Intrinsic::AsyncStream(
                     AsyncStreamIntrinsic::GenStreamHostInjectFn,
+                ));
+                let gen_read_fn_from_lowerable_stream_fn = self.intrinsic(Intrinsic::AsyncStream(
+                    AsyncStreamIntrinsic::GenReadFnFromLowerableStream,
                 ));
 
                 // TODO(???): A component could end up receiving a stream that it outputted,
@@ -3212,22 +3214,7 @@ impl Bindgen for FunctionBindgen<'_> {
                             }},
                         }});
 
-                        let readFn{tmp};
-                        if ({async_iterator_symbol} in {stream_arg}) {{
-                            let asyncIterator = {stream_arg}[{async_iterator_symbol}]();
-                            readFn{tmp} = () => asyncIterator.next();
-                            readFn{tmp}.drop = (reason) => asyncIterator.return?.(reason) ?? {stream_arg}[{symbol_dispose}]?.();
-                        }} else if ({iterator_symbol} in {stream_arg}) {{
-                            let iterator = {stream_arg}[{iterator_symbol}]();
-                            readFn{tmp} = async () => iterator.next();
-                            readFn{tmp}.drop = (reason) => iterator.return?.(reason) ?? {stream_arg}[{symbol_dispose}]?.();
-                        }} else if ({stream_arg} instanceof {external_readable_stream_class}) {{
-                            // At this point we're dealing with a readable stream that *somehow *does not*
-                            // implement the async iterator protocol.
-                            const lockedReader = {stream_arg}.getReader();
-                            readFn{tmp} = () => lockedReader.read();
-                            readFn{tmp}.drop = (reason) => lockedReader.cancel(reason).finally(() => lockedReader.releaseLock());
-                        }}
+                        const readFn{tmp} = {gen_read_fn_from_lowerable_stream_fn}({stream_arg});
 
                         const hostInjectFn = {gen_stream_host_inject_fn}({{
                             readFn: readFn{tmp},

--- a/crates/js-component-bindgen/src/intrinsics/component.rs
+++ b/crates/js-component-bindgen/src/intrinsics/component.rs
@@ -142,6 +142,15 @@ impl ComponentIntrinsic {
                     class {component_async_state_class} {{
                         static EVENT_HANDLER_EVENTS = [ 'backpressure-change' ];
 
+                        static TickResult = {{
+                            // no suspended tasks remain
+                            DONE: 'done',
+                            // a suspended task was resumed (more may be ready)
+                            RESUMED: 'resumed',
+                            // suspended tasks remain but none were ready
+                            IDLE: 'idle',
+                        }};
+
                         #componentIdx;
                         #callingAsyncImport = false;
                         #syncImportWait = {promise_with_resolvers_fn}();
@@ -404,54 +413,6 @@ impl ComponentIntrinsic {
                             this.#onExclusiveReleaseHandlers.push(fn);
                         }}
 
-                        // nextTaskPromise & nextTaskQueue are used to await current task completion and queues
-                        // any tasks attempting to enter() and complete.
-                        //
-                        // see: nextTaskExecutionSlot()
-                        //
-                        // TODO(threads): this should be unnecessary once threads are properly implemented,
-                        // as the task.enter() logic should suffice (it should be guaranteed that we cannot re-enter
-                        // unless the task in question is the current task in the thread execution, and only one can
-                        // run at a time)
-                        #nextTaskPromise = Promise.resolve(true);
-                        #nextTaskQueue = [];
-
-                        async nextTaskExecutionSlot(args) {{
-                            const {{ task }} = args;
-
-                            const placeholder = {{
-                                completed: false,
-                                task,
-                                promise: task.exitPromise().then(() => {{
-                                    placeholder.completed = true;
-                                }}),
-                            }};
-                            this.#nextTaskQueue.push(placeholder);
-
-                            let next;
-                            while (true) {{
-                                await this.#nextTaskPromise;
-
-                                next = this.#nextTaskQueue.find(placeholder => !placeholder.completed);
-
-                                // This task is next in the queue, we can continue
-                                if (next === undefined || next === placeholder) {{
-                                    this.#nextTaskPromise = next.promise;
-                                    if (this.#nextTaskQueue.length > 1000) {{
-                                        this.#nextTaskQueue = this.#nextTaskQueue.filter(p => !p.completed);
-                                        if (this.#nextTaskQueue.length > 1000) {{
-                                            {debug_log_fn}('[{component_async_state_class}#()nextTaskExecutionSlot] next task queue length > 1000 even after cleanup, tasks may be leaking');
-                                        }}
-                                    }}
-                                    break;
-                                }}
-
-                                // If we get here, this task was *not* next in the queue, continue waiting
-                                // (at this point the task that *is* next will likely have already set itself
-                                // as this.#nextTaskPromise)
-                            }}
-                        }}
-
                         #getSuspendedTaskMeta(taskID) {{
                             return this.#suspendedTasksByTaskID.get(taskID);
                         }}
@@ -529,10 +490,15 @@ impl ComponentIntrinsic {
                             if (this.#tickLoop !== null) {{ return; }}
                             this.#tickLoop = 1;
                             setTimeout(async () => {{
-                                let done = this.tick();
-                                while (!done) {{
-                                    await new Promise((resolve) => setTimeout(resolve, 30));
-                                    done = this.tick();
+                                let result = this.tick();
+                                while (result !== {component_async_state_class}.TickResult.DONE) {{
+                                    // After resuming a task, re-tick as soon as the resumed
+                                    // slice's microtask continuations have drained (timeout 0)
+                                    // so queued sibling resumptions aren't charged the idle
+                                    // polling interval; otherwise poll at the idle cadence.
+                                    const delay = result === {component_async_state_class}.TickResult.RESUMED ? 0 : 10;
+                                    await new Promise((resolve) => setTimeout(resolve, delay));
+                                    result = this.tick();
                                 }}
                                 this.#tickLoop = null;
                             }}, 10);
@@ -553,7 +519,7 @@ impl ComponentIntrinsic {
                                 if (meta.task.isRejected()) {{
                                     {debug_log_fn}('[{component_async_state_class}#tick()] detected task rejection, leaving early', {{ meta }});
                                     this.resumeTaskByID(taskID);
-                                    return;
+                                    return {component_async_state_class}.TickResult.RESUMED;
                                 }}
 
                                 const isReady = meta.readyFn();
@@ -564,9 +530,27 @@ impl ComponentIntrinsic {
                                     componentIdx: this.#componentIdx,
                                 }});
                                 this.resumeTaskByID(taskID);
+
+                                // NOTE: during single-flight resumption, we should resume at most one task per
+                                // tick so that the resumed slice (a microtask continuation)
+                                // runs -- and its current-task register window opens and
+                                // closes -- before any sibling task of this component is
+                                // resumed. 
+                                // 
+                                // Resuming multiple suspended tasks in one synchronous
+                                // cascade interleaves their register save/restore windows
+                                // ([restoreA, restoreB, resumeA, resumeB]), re-entering wasm
+                                // with the register naming the wrong task, and the 
+                                // 'known residual' of the JSPI current-task register
+                                // fix); with concurrent task lifetimes per component this
+                                // corrupts guest context-local storage.
+                                return {component_async_state_class}.TickResult.RESUMED;
                             }}
 
-                            return this.#suspendedTaskIDs.filter(t => t !== null).length === 0;
+                            const idle = this.#suspendedTaskIDs.filter(t => t !== null).length > 0;
+                            return idle
+                                ? {component_async_state_class}.TickResult.IDLE
+                                : {component_async_state_class}.TickResult.DONE;
                         }}
 
                         addStreamEndToTable(args) {{

--- a/crates/js-component-bindgen/src/intrinsics/component.rs
+++ b/crates/js-component-bindgen/src/intrinsics/component.rs
@@ -145,7 +145,8 @@ impl ComponentIntrinsic {
                         #componentIdx;
                         #callingAsyncImport = false;
                         #syncImportWait = {promise_with_resolvers_fn}();
-                        #locked = false;
+                        #lockHolderTaskID = null;
+                        #lockWaiters = [];
                         #parkedTasks = new Map();
                         #suspendedTasksByTaskID = new Map();
                         #suspendedTaskIDs = [];
@@ -298,25 +299,92 @@ impl ComponentIntrinsic {
                             }}
                         }}
 
-                        isExclusivelyLocked() {{ return this.#locked === true; }}
-                        setLocked(locked) {{
-                            this.#locked = locked;
-                        }}
+                        // The per-slice mutual-exclusion lock for guest execution in this
+                        // component instance. Guest slices (callback invocations and
+                        // sync-lifted bodies) must be atomic per component even across the
+                        // JSPI suspensions jco introduces for host imports: wit-bindgen's
+                        // executors publish per-task state in single linear-memory cells
+                        // (the wasip3-task pointer, context-local storage discipline) that
+                        // an interleaved slice of the same component corrupts
+                        //
+                        // The lock is *owned*: acquisition records the holder task and
+                        // release is a no-op for anyone else, so a task exiting can no
+                        // longer drop a hold it does not own (blind acquire/release-any
+                        // was the previous discipline). Contended acquisition queues
+                        // FIFO; release hands the lock to the next waiter directly.
+                        isExclusivelyLocked() {{ return this.#lockHolderTaskID !== null; }}
+                        exclusivelyLockedBy(taskID) {{ return this.#lockHolderTaskID === taskID; }}
 
-                        exclusiveLock() {{
+                        exclusiveLock(taskID) {{
                             {debug_log_fn}('[{component_async_state_class}#exclusiveLock()]', {{
-                                locked: this.#locked,
+                                holder: this.#lockHolderTaskID,
+                                requester: taskID,
                                 componentIdx: this.#componentIdx,
                             }});
-                            this.setLocked(true);
+                            if (taskID === undefined || taskID === null) {{
+                                throw new Error('exclusive lock requires the acquiring task id');
+                            }}
+                            if (this.#lockHolderTaskID !== null) {{
+                                throw new Error(`component [${{this.#componentIdx}}] exclusive lock held by task [${{this.#lockHolderTaskID}}], requested by [${{taskID}}]`);
+                            }}
+                            this.#lockHolderTaskID = taskID;
                         }}
 
-                        exclusiveRelease() {{
+                        // Awaitable acquisition: takes the lock immediately when free,
+                        // otherwise queues FIFO behind the current holder and earlier
+                        // waiters. The resolved promise implies ownership.
+                        async acquireExclusiveLock(taskID) {{
+                            if (taskID === undefined || taskID === null) {{
+                                throw new Error('exclusive lock requires the acquiring task id');
+                            }}
+                            if (this.#lockHolderTaskID === null) {{
+                                this.#lockHolderTaskID = taskID;
+                                {debug_log_fn}('[{component_async_state_class}#acquireExclusiveLock()] acquired', {{
+                                    holder: taskID,
+                                    componentIdx: this.#componentIdx,
+                                }});
+                                return;
+                            }}
+                            if (this.#lockHolderTaskID === taskID) {{
+                                throw new Error(`task [${{taskID}}] already holds the lock for component [${{this.#componentIdx}}]`);
+                            }}
+                            {debug_log_fn}('[{component_async_state_class}#acquireExclusiveLock()] waiting', {{
+                                holder: this.#lockHolderTaskID,
+                                requester: taskID,
+                                componentIdx: this.#componentIdx,
+                                queued: this.#lockWaiters.length,
+                            }});
+                            await new Promise((resolve) => {{
+                                this.#lockWaiters.push({{ taskID, resolve }});
+                            }});
+                        }}
+
+                        exclusiveRelease(taskID) {{
                             {debug_log_fn}('[{component_async_state_class}#exclusiveRelease()] args', {{
-                                locked: this.#locked,
+                                holder: this.#lockHolderTaskID,
+                                releaser: taskID,
                                 componentIdx: this.#componentIdx,
                             }});
-                            this.setLocked(false);
+                            if (this.#lockHolderTaskID !== taskID) {{
+                                // Ownerless releases were the historical behavior; a foreign
+                                // release now leaves the hold intact
+                                {debug_log_fn}('[{component_async_state_class}#exclusiveRelease()] ignoring foreign release', {{
+                                    holder: this.#lockHolderTaskID,
+                                    releaser: taskID,
+                                    componentIdx: this.#componentIdx,
+                                }});
+                                return false;
+                            }}
+
+                            const next = this.#lockWaiters.shift();
+                            if (next) {{
+                                // Direct FIFO handoff: the waiter owns the lock as of now;
+                                // its continuation runs as a microtask.
+                                this.#lockHolderTaskID = next.taskID;
+                                next.resolve();
+                            }} else {{
+                                this.#lockHolderTaskID = null;
+                            }}
 
                             this.#onExclusiveReleaseHandlers = this.#onExclusiveReleaseHandlers.filter(v => !!v);
                             for (const [idx, f] of this.#onExclusiveReleaseHandlers.entries()) {{
@@ -328,6 +396,7 @@ impl ComponentIntrinsic {
                                     throw err;
                                 }}
                             }}
+                            return true;
                         }}
 
                         onNextExclusiveRelease(fn) {{

--- a/crates/js-component-bindgen/src/intrinsics/component.rs
+++ b/crates/js-component-bindgen/src/intrinsics/component.rs
@@ -413,6 +413,12 @@ impl ComponentIntrinsic {
                             this.#onExclusiveReleaseHandlers.push(fn);
                         }}
 
+                        async waitForExclusiveRelease() {{
+                            while (this.isExclusivelyLocked()) {{
+                                await new Promise(resolve => this.onNextExclusiveRelease(resolve));
+                            }}
+                        }}
+
                         #getSuspendedTaskMeta(taskID) {{
                             return this.#suspendedTasksByTaskID.get(taskID);
                         }}

--- a/crates/js-component-bindgen/src/intrinsics/component.rs
+++ b/crates/js-component-bindgen/src/intrinsics/component.rs
@@ -877,9 +877,37 @@ impl ComponentIntrinsic {
                             return futureEnd;
                         }}
 
+                        addFutureEndToTable(args) {{
+                            {debug_log_fn}('[{component_async_state_class}#addFutureEndToTable()] args', args);
+                            const {{ tableIdx, futureEnd }} = args;
+                            if (typeof futureEnd === 'number') {{ throw new Error("INSERTING BAD FUTUREEND"); }}
+
+                            let {{ table, componentIdx }} = {global_future_table_map}[tableIdx];
+                            if (componentIdx === undefined || !table) {{
+                                throw new Error(`invalid global future table state for table [${{tableIdx}}]`);
+                            }}
+
+                            const handle = table.insert(futureEnd);
+                            futureEnd.setHandle(handle);
+                            futureEnd.setFutureTableIdx(tableIdx);
+
+                            const cstate = {get_or_create_async_state_fn}(componentIdx);
+                            const waitableIdx = cstate.handles.insert(futureEnd);
+                            futureEnd.setWaitableIdx(waitableIdx);
+
+                            {debug_log_fn}('[{component_async_state_class}#addFutureEndToTable()] added future end', {{
+                                tableIdx,
+                                table,
+                                handle,
+                                futureEnd,
+                                destComponentIdx: componentIdx,
+                            }});
+
+                            return {{ handle, waitableIdx }};
+                        }}
+
                         removeFutureEndFromTable(args) {{
                             {debug_log_fn}('[{component_async_state_class}#removeFutureEndFromTable()] args', args);
-
                             const {{ tableIdx, futureWaitableIdx }} = args;
                             if (tableIdx === undefined) {{ throw new Error("missing table idx while removing future end"); }}
                             if (futureWaitableIdx === undefined) {{

--- a/crates/js-component-bindgen/src/intrinsics/lift.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lift.rs
@@ -466,7 +466,8 @@ impl LiftIntrinsic {
 
                         if (ctx.useDirectParams) {{
                             if (ctx.params.length === 0) {{ throw new Error('expected at least a single i34 argument'); }}
-                            val = ctx.params[0];
+                            // core i32 values arrive as signed numbers
+                            val = ctx.params[0] >>> 0;
                             ctx.params = ctx.params.slice(1);
                             return [val, ctx];
                         }}
@@ -532,7 +533,8 @@ impl LiftIntrinsic {
                         if (ctx.useDirectParams) {{
                             if (ctx.params.length === 0) {{ throw new Error('expected at least one single i64 argument'); }}
                             if (typeof ctx.params[0] !== 'bigint') {{ throw new Error('expected bigint'); }}
-                            val = ctx.params[0];
+                            // core i64 values arrive as signed BigInts
+                            val = BigInt.asUintN(64, ctx.params[0]);
                             ctx.params = ctx.params.slice(1);
                             return [val, ctx];
                         }}
@@ -566,12 +568,6 @@ impl LiftIntrinsic {
                             if (ctx.params.length === 0) {{ throw new Error('expected at least one single f32 argument'); }}
                             val = ctx.params[0];
                             ctx.params = ctx.params.slice(1);
-
-                            if (ctx.inVariant) {{
-                                const dv = new DataView(new ArrayBuffer(4));
-                                dv.setInt32(0, val);
-                                val = dv.getFloat32(0);
-                            }}
 
                             return [val, ctx];
                         }}
@@ -607,12 +603,6 @@ impl LiftIntrinsic {
                               }}
                               val = ctx.params[0];
                               ctx.params = ctx.params.slice(1);
-
-                              if (ctx.inVariant) {{
-                                  const dv = new DataView(new ArrayBuffer(8));
-                                  dv.setBigInt64(0, val);
-                                  val = dv.getFloat64(0);
-                              }}
 
                               return [val, ctx];
                           }}
@@ -815,9 +805,10 @@ impl LiftIntrinsic {
                 let lift_u8 = Self::LiftFlatU8.name();
                 let lift_u16 = Self::LiftFlatU16.name();
                 let lift_u32 = Self::LiftFlatU32.name();
-                let lift_f64 = Self::LiftFlatFloat64.name();
 
                 output.push_str(&format!(r#"
+                    const {lift_flat_variant_fn}Scratch = new DataView(new ArrayBuffer(8));
+
                     function {lift_flat_variant_fn}(meta) {{
                         const {{
                             caseMetas,
@@ -825,17 +816,13 @@ impl LiftIntrinsic {
                             variantAlign32,
                             variantPayloadOffset32,
                             variantFlatCount,
+                            variantPayloadFlatTypes,
                             isEnum,
                         }} = meta;
 
                         return function {lift_flat_variant_fn}Inner(ctx) {{
                             {debug_log_fn}('[{lift_flat_variant_fn}()] args', {{ ctx }});
                             const origUseParams = ctx.useDirectParams;
-
-                            // If we're in the process of lifting a variant, we note
-                            // we are during any lifting that happens (e.g. to accomodate f32/f64 mechanics)
-                            const wasInVariant = ctx.inVariant;
-                            ctx.inVariant = true;
 
                             let caseIdx;
                             let liftRes;
@@ -859,6 +846,7 @@ impl LiftIntrinsic {
                                 caseSize32,
                                 caseAlign32,
                                 caseFlatCount,
+                                caseFlatTypes,
                             ] = caseMetas[caseIdx];
 
                             if (variantPayloadOffset32 === undefined) {{
@@ -878,11 +866,36 @@ impl LiftIntrinsic {
                                     ctx.storagePtr = originalPtr + variantSize32;
                                 }}
                             }} else {{
-                                if (ctx.useDirectParams && ctx.params && liftFn !== {lift_f64} && typeof ctx.params[0] === 'bigint') {{
-                                    if (ctx.params[0] > BigInt(Number.MAX_SAFE_INTEGER)) {{
-                                        throw new Error(`invalid value, reinterpreted i32/f32 too large: [${{ctx.params[0]}}]`);
+                                // When lifting from direct params, the payload arrives as the
+                                // *join* of all case flat representations: each slot whose
+                                // joined core type differs from the selected case's core type
+                                // must be reinterpreted before the payload lift
+                                // (see CanonicalABI `lift_flat_variant`)
+                                if (ctx.useDirectParams) {{
+                                    if (!variantPayloadFlatTypes || !caseFlatTypes) {{
+                                        throw new Error('missing variant flat type metadata during direct-param lift');
                                     }}
-                                    ctx.params[0] = Number(ctx.params[0]);
+                                    const scratch = {lift_flat_variant_fn}Scratch;
+                                    for (let i = 0; i < caseFlatTypes.length; i++) {{
+                                        const have = variantPayloadFlatTypes[i];
+                                        const want = caseFlatTypes[i];
+                                        if (have === want) {{ continue; }}
+                                        const val = ctx.params[i];
+                                        if (have === 'i64' && want === 'i32') {{
+                                            ctx.params[i] = Number(BigInt.asIntN(32, val));
+                                        }} else if (have === 'i64' && want === 'f32') {{
+                                            scratch.setInt32(0, Number(BigInt.asIntN(32, val)), true);
+                                            ctx.params[i] = scratch.getFloat32(0, true);
+                                        }} else if (have === 'i64' && want === 'f64') {{
+                                            scratch.setBigInt64(0, val, true);
+                                            ctx.params[i] = scratch.getFloat64(0, true);
+                                        }} else if (have === 'i32' && want === 'f32') {{
+                                            scratch.setInt32(0, val, true);
+                                            ctx.params[i] = scratch.getFloat32(0, true);
+                                        }} else {{
+                                            throw new Error(`invalid variant payload coercion [${{have}}] -> [${{want}}]`);
+                                        }}
+                                    }}
                                 }}
 
                                 const [newVal, newCtx] = liftFn(ctx);
@@ -914,8 +927,6 @@ impl LiftIntrinsic {
                                 const rem = ctx.storagePtr % variantAlign32;
                                 if (rem !== 0) {{ ctx.storagePtr += variantAlign32 - rem; }}
                             }}
-
-                            ctx.inVariant = wasInVariant;
 
                             return [val, ctx];
                         }}

--- a/crates/js-component-bindgen/src/intrinsics/lift.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lift.rs
@@ -1402,7 +1402,7 @@ impl LiftIntrinsic {
                                 isReadable: streamEnd.isReadable(),
                                 isWritable: streamEnd.isWritable(),
                                 writeFn: (v) => {{ return streamEnd.write(v); }},
-                                readFn: () => {{ return streamEnd.read(); }},
+                                readFn: (opts) => {{ return streamEnd.read(opts); }},
                                 dropFn: () => {{ return streamEnd.drop(); }},
                             }});
 

--- a/crates/js-component-bindgen/src/intrinsics/lift.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lift.rs
@@ -1250,7 +1250,7 @@ impl LiftIntrinsic {
                 // (`classNameFn`), never as a direct reference: lift metadata
                 // is evaluated eagerly at module top level (e.g. inside
                 // taskReturn trampoline binds), which may run before the
-                // resource class declaration and TDZ-throw (lann/jco#51).
+                // resource class declaration and TDZ-throw.
                 output.push_str(&format!(
                     r#"
                     function {lift_flat_own_fn}(meta) {{

--- a/crates/js-component-bindgen/src/intrinsics/lift.rs
+++ b/crates/js-component-bindgen/src/intrinsics/lift.rs
@@ -1246,13 +1246,18 @@ impl LiftIntrinsic {
                 let lift_flat_own_fn = self.name();
                 let lift_flat_u32_fn = Self::LiftFlatU32.name();
 
+                // NOTE: meta carries the resource class behind a thunk
+                // (`classNameFn`), never as a direct reference: lift metadata
+                // is evaluated eagerly at module top level (e.g. inside
+                // taskReturn trampoline binds), which may run before the
+                // resource class declaration and TDZ-throw (lann/jco#51).
                 output.push_str(&format!(
                     r#"
                     function {lift_flat_own_fn}(meta) {{
-                        const {{ className, createResourceFn, componentIdx }} = meta;
+                        const {{ classNameFn, createResourceFn, componentIdx }} = meta;
 
                         return function {lift_flat_own_fn}Inner(ctx) {{
-                            {debug_log_fn}('[{lift_flat_own_fn}()] args', {{ ctx, className }});
+                            {debug_log_fn}('[{lift_flat_own_fn}()] args', {{ ctx, className: classNameFn() }});
 
                             if (ctx.componentIdx !== componentIdx) {{
                                 throw new Error('invalid component for resource lift');

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -159,6 +159,10 @@ pub enum Intrinsic {
 
     /// Clear the global task meta
     ClearGlobalCurrentTaskMetaFn,
+
+    /// Wrap the JS payload of a `WebAssembly.Suspending` import so the
+    /// importing component's current-task register survives suspension
+    SuspendingImportWrapperFn,
 }
 
 impl Intrinsic {
@@ -1065,6 +1069,33 @@ impl Intrinsic {
                 ));
             }
 
+            // Under JSPI a wasm stack suspends inside a task's callback
+            // slice; other tasks then set the per-component current-task
+            // register. Restoring the captured entry when the awaited
+            // import settles is the last JS to run before the suspended
+            // stack resumes, so the resumed continuation's context.get /
+            // context.set (and task-exit bookkeeping) address the task
+            // that is actually executing.
+            Self::SuspendingImportWrapperFn => {
+                let suspending_import_wrapper_fn = Self::SuspendingImportWrapperFn.name();
+                let global_current_task_meta_obj = Self::GlobalCurrentTaskMeta.name();
+
+                output.push_str(&format!(
+                    r#"
+                      function {suspending_import_wrapper_fn}(componentIdx, fn) {{
+                          return async function (...args) {{
+                              const saved = {global_current_task_meta_obj}[componentIdx] ?? null;
+                              try {{
+                                  return await fn.apply(null, args);
+                              }} finally {{
+                                  {global_current_task_meta_obj}[componentIdx] = saved;
+                              }}
+                          }};
+                      }}
+                    "#,
+                ));
+            }
+
             // TODO(feat): customizable stream classes
             Intrinsic::PlatformReadableStreamClass => {
                 let name = self.name();
@@ -1124,7 +1155,7 @@ pub struct RenderIntrinsicsArgs<'a> {
 }
 
 /// Intrinsics that should be rendered as early as possible
-const EARLY_INTRINSICS: [Intrinsic; 43] = [
+const EARLY_INTRINSICS: [Intrinsic; 44] = [
     Intrinsic::PromiseWithResolversPonyfill,
     Intrinsic::SymbolDispose,
     Intrinsic::SymbolAsyncIterator,
@@ -1138,6 +1169,7 @@ const EARLY_INTRINSICS: [Intrinsic; 43] = [
     Intrinsic::WithGlobalCurrentTaskMetaFn,
     Intrinsic::WithGlobalCurrentTaskMetaFnAsync,
     Intrinsic::ClearGlobalCurrentTaskMetaFn,
+    Intrinsic::SuspendingImportWrapperFn,
     Intrinsic::LookupMemoriesForComponent,
     Intrinsic::RegisterGlobalMemoryForComponent,
     Intrinsic::RepTableClass,
@@ -1829,6 +1861,7 @@ impl Intrinsic {
             Self::WithGlobalCurrentTaskMetaFn => "_withGlobalCurrentTaskMeta",
             Self::WithGlobalCurrentTaskMetaFnAsync => "_withGlobalCurrentTaskMetaAsync",
             Self::ClearGlobalCurrentTaskMetaFn => "_clearCurrentTask",
+            Self::SuspendingImportWrapperFn => "_suspendingImport",
 
             // Iteratively saved metadata
             Intrinsic::GlobalComponentMemoryMap => "GLOBAL_COMPONENT_MEMORY_MAP",

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -1437,6 +1437,29 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
         ));
     }
 
+    if args.intrinsics.contains(&Intrinsic::AsyncStream(
+        AsyncStreamIntrinsic::GenReadFnFromLowerableStream,
+    )) {
+        args.intrinsics.extend([
+            &Intrinsic::AsyncStream(AsyncStreamIntrinsic::IsStreamLowerableObject),
+            &Intrinsic::SymbolAsyncIterator,
+            &Intrinsic::SymbolIterator,
+            &Intrinsic::SymbolDispose,
+            &Intrinsic::PlatformReadableStreamClass,
+        ]);
+    }
+
+    if args.intrinsics.contains(&Intrinsic::AsyncStream(
+        AsyncStreamIntrinsic::IsStreamLowerableObject,
+    )) {
+        args.intrinsics.extend([
+            &Intrinsic::AsyncStream(AsyncStreamIntrinsic::ExternalStreamClass),
+            &Intrinsic::SymbolAsyncIterator,
+            &Intrinsic::SymbolIterator,
+            &Intrinsic::PlatformReadableStreamClass,
+        ]);
+    }
+
     if args
         .intrinsics
         .contains(&Intrinsic::Lower(LowerIntrinsic::LowerFlatFuture))

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -757,6 +757,11 @@ impl Intrinsic {
                 let rep_table_class = Intrinsic::RepTableClass.name();
                 output.push_str(&format!(r#"
                     class {rep_table_class} {{
+                        // Sentinel marking a freed slot; the freelist link for a freed slot
+                        // lives in the odd cell. This keeps get()/contains()/remove() on freed
+                        // reps well-defined (previously they returned/corrupted freelist links).
+                        static FREE = Symbol('{rep_table_class}.free');
+
                         #data = [0, null];
                         #size = 0;
                         #target;
@@ -778,8 +783,11 @@ impl Intrinsic {
                                 this.#size += 1;
                                 return rep;
                             }}
-                            this.#data[0] = this.#data[freeIdx << 1];
                             const placementIdx = freeIdx << 1;
+                            if (this.#data[placementIdx] !== {rep_table_class}.FREE) {{
+                                throw new Error('corrupt rep table freelist: head does not point at a freed slot');
+                            }}
+                            this.#data[0] = this.#data[placementIdx + 1];
                             this.#data[placementIdx] = val;
                             this.#data[placementIdx + 1] = null;
                             {debug_log_fn}('[{rep_table_class}#insert()] inserted', {{ val, target: this.target, rep: freeIdx }});
@@ -793,6 +801,7 @@ impl Intrinsic {
 
                             const baseIdx = rep << 1;
                             const val = this.#data[baseIdx];
+                            if (val === {rep_table_class}.FREE) {{ return undefined; }}
                             return val;
                         }}
 
@@ -801,7 +810,8 @@ impl Intrinsic {
                             if (rep === 0) {{ throw new Error('invalid resource rep during contains, (cannot be 0)'); }}
 
                             const baseIdx = rep << 1;
-                            return !!this.#data[baseIdx];
+                            const val = this.#data[baseIdx];
+                            return val !== {rep_table_class}.FREE && !!val;
                         }}
 
                         remove(rep) {{
@@ -810,9 +820,16 @@ impl Intrinsic {
                             if (this.#data.length === 2) {{ throw new Error('invalid'); }}
 
                             const baseIdx = rep << 1;
+                            if (baseIdx >= this.#data.length) {{
+                                throw new Error(`invalid rep [${{rep}}] during remove, out of range`);
+                            }}
                             const val = this.#data[baseIdx];
+                            if (val === {rep_table_class}.FREE) {{
+                                throw new Error(`double removal of rep [${{rep}}] (already freed)`);
+                            }}
 
-                            this.#data[baseIdx] = this.#data[0];
+                            this.#data[baseIdx] = {rep_table_class}.FREE;
+                            this.#data[baseIdx + 1] = this.#data[0];
                             this.#data[0] = rep;
                             this.#size -= 1;
 

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_future.rs
@@ -1009,6 +1009,7 @@ impl AsyncFutureIntrinsic {
 
                         getElemMeta() {{ return {{...this.#elemMeta}}; }}
                         futureTableIdx() {{ return this.#futureTableIdx; }}
+                        setFutureTableIdx(idx) {{ this.#futureTableIdx = idx; }}
 
                         globalFutureMapRep() {{ return this.#globalFutureMapRep; }}
                         setGlobalFutureMapRep(rep) {{ this.#globalFutureMapRep = rep; }}
@@ -1415,14 +1416,61 @@ impl AsyncFutureIntrinsic {
             Self::FutureTransfer => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let future_transfer_fn = self.name();
+                let get_or_create_async_state_fn =
+                    Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
+                let global_future_table_map = Self::GlobalFutureTableMap.name();
+
                 output.push_str(&format!(
                     r#"
-                      function {future_transfer_fn}(ctx) {{
-                        const params = [...arguments];
+                    function {future_transfer_fn}(
+                        srcFutureWaitableIdx,
+                        srcTableIdx,
+                        destTableIdx,
+                    ) {{
                         {debug_log_fn}('[{future_transfer_fn}()] args', {{
-                            ctx,
-                            params,
+                            srcFutureWaitableIdx,
+                            srcTableIdx,
+                            destTableIdx,
                         }});
+
+                        const futureMeta = {global_future_table_map}[srcTableIdx];
+                        if (!futureMeta) {{ throw new Error('missing future meta during transfer'); }}
+                        const componentIdx = futureMeta.componentIdx;
+
+                        // NOTE: no current-task lookup here: per the Canonical ABI the
+                        // transfer is a pure table operation between the source and
+                        // destination components' waitable tables, and the
+                        // return-position transfer of a fused *sync* call runs after
+                        // the callee task's teardown (same as stream.transfer).
+
+                        const cstate = {get_or_create_async_state_fn}(componentIdx);
+                        if (!cstate) {{ throw new Error(`missing async state for component [${{componentIdx}}]`); }}
+
+                        const futureEnd = cstate.removeFutureEndFromTable({{ tableIdx: srcTableIdx, futureWaitableIdx: srcFutureWaitableIdx }});
+                        if (!futureEnd.isReadable()) {{
+                            throw new Error("writable future ends cannot be moved");
+                        }}
+                        if (futureEnd.isDoneState()) {{
+                            throw new Error('future read ends cannot be moved once the value has been delivered');
+                        }}
+
+                        const {{ handle, waitableIdx }} = cstate.addFutureEndToTable({{ tableIdx: destTableIdx, futureEnd }});
+                        futureEnd.setTarget(`future read end (waitable [${{waitableIdx}}])`);
+
+                        {debug_log_fn}('[{future_transfer_fn}()] successfully transferred', {{
+                            dest: {{
+                                futureEndHandle: handle,
+                                futureEndWaitableIdx: waitableIdx,
+                                tableIdx: destTableIdx,
+                            }},
+                            src: {{
+                                futureEndWaitableIdx: srcFutureWaitableIdx,
+                                tableIdx: srcTableIdx,
+                            }},
+                            componentIdx,
+                        }});
+
+                        return waitableIdx;
                     }}
                     "#
                 ));

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -1977,8 +1977,6 @@ impl AsyncStreamIntrinsic {
             Self::StreamTransfer => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let stream_transfer_fn = self.name();
-                let get_global_current_task_meta_fn = Intrinsic::GetGlobalCurrentTaskMetaFn.name();
-                let current_task_get_fn = AsyncTaskIntrinsic::GetCurrentTask.name();
                 let get_or_create_async_state_fn =
                     Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
                 let global_stream_table_map = AsyncStreamIntrinsic::GlobalStreamTableMap.name();
@@ -2000,18 +1998,15 @@ impl AsyncStreamIntrinsic {
                         if (!streamMeta) {{ throw new Error('missing stream meta during transfer'); }}
                         const componentIdx = streamMeta.componentIdx;
 
-                        const globalTaskMeta = {get_global_current_task_meta_fn}(componentIdx);
-                        if (!globalTaskMeta) {{ throw new Error('missing global current task globalTaskMeta'); }}
-                        const taskID = globalTaskMeta.taskID;
-
-                        const taskMeta = {current_task_get_fn}(componentIdx, taskID);
-                        if (!taskMeta) {{ throw new Error('missing current task metadata while doing stream transfer'); }}
-
-                        const task = taskMeta.task;
-                        if (!task) {{ throw new Error('missing task while doing stream transfer'); }}
-                        if (componentIdx !== task.componentIdx()) {{
-                            throw new Error("task component ID should match current component ID");
-                        }}
+                        // NOTE: no current-task lookup here: per the Canonical ABI the
+                        // transfer is a pure table operation between the source and
+                        // destination components' waitable tables. 
+                        // 
+                        // In particular, the return-position transfer of a fused *sync* guest->guest 
+                        // call runs after the callee task's teardown has already cleared the
+                        // per-component current-task register, so deriving task context
+                        // from the source stream's owning component is unsatisfiable
+                        // there.
 
                         const cstate = {get_or_create_async_state_fn}(componentIdx);
                         if (!cstate) {{ throw new Error(`missing async state for component [${{componentIdx}}]`); }}

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -444,6 +444,8 @@ impl AsyncStreamIntrinsic {
                 let stream_end_class = Self::StreamEndClass.name();
                 let managed_buffer_class = Intrinsic::ManagedBufferClass.name();
                 let global_buffer_manager = Intrinsic::GlobalBufferManager.name();
+                let get_or_create_async_state_fn =
+                    Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
 
                 // Internal helper fn that sets up for a `copy()` call
                 let copy_setup_impl = format!(
@@ -1123,6 +1125,16 @@ impl AsyncStreamIntrinsic {
 
                                 const resultKind = packedResult & 0xF;
                                 const transferred = packedResult >> 4;
+
+                                // The copy event is published from inside the guest's current
+                                // callback slice. Do not expose lifted values to host code until
+                                // that slice has returned and released the instance lock: the
+                                // consumer may immediately make a synchronous call on a lifted
+                                // resource, which cannot itself wait for a contended lock.
+                                const componentIdx = this.getWaitable().componentIdx();
+                                if (componentIdx !== -1) {{
+                                    await {get_or_create_async_state_fn}(componentIdx).waitForExclusiveRelease();
+                                }}
 
                                 if (resultKind === {stream_end_class}.CopyResult.DROPPED) {{
                                     this.#endOfStream = true;

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -1494,6 +1494,7 @@ impl AsyncStreamIntrinsic {
 
                           get length() {{ return this.#length; }}
                           get done() {{ return this.#done; }}
+                          get sourceIsSync() {{ return !!this.#readFn.sourceIsSync; }}
 
                           push(source) {{
                               if (source.length === 0) {{ return 0; }}
@@ -2090,6 +2091,9 @@ impl AsyncStreamIntrinsic {
                               let iterator = stream[{iterator_symbol}]();
                               readFn = async () => iterator.next();
                               readFn.drop = (reason) => iterator.return?.(reason) ?? stream[{symbol_dispose}]?.();
+                              // Synchronous sources can be drained eagerly (up to a
+                              // requested count) without risking an indefinite wait
+                              readFn.sourceIsSync = true;
                           }} else if (stream instanceof {external_readable_stream_class}) {{
                               // At this point we're dealing with a readable stream that *somehow *does not*
                               // implement the async iterator protocol.
@@ -2196,7 +2200,11 @@ impl AsyncStreamIntrinsic {
                                   if (readEnd.hasPendingEvent()) {{ return bail(); }}
                                   if (!hasPendingReadBuffer()) {{ return bail(); }}
                                   drainPendingValues();
-                                  if (values.length > 0) {{ break; }}
+                                  // Deliver data as soon as any is available rather than
+                                  // waiting on the source for a full count -- except for
+                                  // synchronous sources, which can be drained eagerly
+                                  // without waiting
+                                  if (values.length > 0 && !pendingValues.sourceIsSync) {{ break; }}
                                   if (appended === 0 && !pendingValues.done) {{ count -= 1; }}
                                   if (pendingValues.done) {{ break; }}
                               }}

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -2397,28 +2397,57 @@ impl AsyncTaskIntrinsic {
 
                         return new Promise((resolve, reject) => {{
                             setTimeout(() => {{
-                                const subtaskState = subtask.getStateNumber();
-                                if (subtaskState < 0 || subtaskState >= 2**4) {{
-                                    // throw new Error('invalid subtask state, out of valid range');
-                                    reject(new Error('invalid subtask state, out of valid range'));
-                                }}
-                                let res;
-                                // An async-lowered import whose callee resolved synchronously returns
-                                // [Subtask.State.RETURNED] only an no subtask handle is exposed.
-                                if (subtask.isReturned()) {{
-                                    if (!subtask.resolveDelivered()) {{
-                                        subtask.deliverResolve();
+                                // NOTE: whether the import settled before this timer fires is a race
+                                // between the import's settlement (microtask + any host timers), this
+                                // setTimeout(0), and JSPI resume scheduling -- engines order these
+                                // differently (e.g. V8 13.6 vs 14.x). Either outcome is CABI-legal,
+                                // but the invariants of each branch must hold independently, and this
+                                // promise must *always* settle (an unhandled throw here would leave a
+                                // JSPI-suspended guest suspended forever).
+                                try {{
+                                    const subtaskState = subtask.getStateNumber();
+                                    if (subtaskState < 0 || subtaskState >= 2**4) {{
+                                        reject(new Error('invalid subtask state, out of valid range'));
+                                        return;
                                     }}
-                                    const removed = cstate.handles.remove(subtask.waitableRep());
-                                    if (removed !== subtask) {{
-                                        throw new Error('subtask handle cleanup removed unexpected entry');
-                                        reject(new Error('subtask handle cleanup removed unexpected entry'));
+                                    let res;
+                                    // An async-lowered import whose callee resolved synchronously returns
+                                    // [Subtask.State.RETURNED] only and no subtask handle is exposed.
+                                    if (subtask.isReturned()) {{
+                                        // The on-progress handler parked a pending SUBTASK event on the
+                                        // waitable when the import settled. The guest never learns this
+                                        // waitable's rep (we return a bare RETURNED state), so consume the
+                                        // event now -- otherwise a stale event is left parked forever (and
+                                        // the waitable can never be dropped).
+                                        if (subtask.hasPendingEvent()) {{
+                                            subtask.getPendingEvent();
+                                        }}
+                                        if (!subtask.resolveDelivered()) {{
+                                            subtask.deliverResolve();
+                                        }}
+                                        const removed = cstate.handles.remove(subtask.waitableRep());
+                                        if (removed !== subtask) {{
+                                            reject(new Error('subtask handle cleanup removed unexpected entry'));
+                                            return;
+                                        }}
+                                        subtask.drop();
+                                        res = subtaskState;
+                                    }} else {{
+                                        res = Number(subtask.waitableRep()) << 4 | subtaskState;
                                     }}
-                                    res = subtaskState;
-                                }} else {{
-                                    res = Number(subtask.waitableRep()) << 4 | subtaskState;
-                                }}
+                                    {debug_log_fn}('[{lower_import_fn}()] async-lowered import return', {{
+                                        fnName: importFn.fnName,
+                                        componentIdx,
+                                        subtaskID: subtask.id(),
+                                        waitableRep: subtask.waitableRep(),
+                                        subtaskState,
+                                        eagerReturn: subtask.isReturned(),
+                                        packedResult: res,
+                                    }});
                                     resolve(res);
+                                }} catch (err) {{
+                                    reject(err);
+                                }}
                             }}, 0);
                         }});
                     }}
@@ -2666,6 +2695,15 @@ impl AsyncTaskIntrinsic {
                         }});
 
                         if (requiresManualAsyncResult) {{ return manualAsyncResult.promise; }}
+
+                        {debug_log_fn}('[{lower_import_backwards_compat_fn}()] async-lowered import return', {{
+                            fnName: importFn.fnName,
+                            componentIdx,
+                            subtaskID: subtask.id(),
+                            waitableRep: subtask.waitableRep(),
+                            subtaskState,
+                            packedResult: Number(subtask.waitableRep()) << 4 | subtaskState,
+                        }});
 
                         return Number(subtask.waitableRep()) << 4 | subtaskState;
                     }}

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -737,6 +737,7 @@ impl AsyncTaskIntrinsic {
                             getCalleeParamsFn,
                             resultPtr,
                             errHandling,
+                            callingWasmExport,
                         }});
 
                         const newTaskID = newTask.id();
@@ -876,6 +877,8 @@ impl AsyncTaskIntrinsic {
                         #state;
                         #isAsync;
                         #isManualAsync;
+                        #callingWasmExport = true;
+                        #lockFreeEntry = false;
                         #preserveFutureResult;
                         #entryFnName = null;
 
@@ -936,6 +939,11 @@ impl AsyncTaskIntrinsic {
                            this.#isManualAsync = opts?.isManualAsync ?? false;
                            this.#preserveFutureResult = opts?.preserveFutureResult ?? false;
                            this.#entryFnName = opts.entryFnName;
+                           // Tasks that execute guest slices (export calls, fused
+                           // callees) default to true; import-handler tasks pass false
+                           // explicitly (they run host code nested inside the caller's
+                           // already-locked slice).
+                           this.#callingWasmExport = opts?.callingWasmExport !== false;
 
                            const {{
                                promise: completionPromise,
@@ -1092,12 +1100,21 @@ impl AsyncTaskIntrinsic {
                         enterSync() {{
                             if (this.needsExclusiveLock()) {{
                                 const cstate = {get_or_create_async_state_fn}(this.#componentIdx);
-                                // TODO(???): it is *very possible* for a the line below to fail if
-                                // an async function is already running (and holding the exclusive lock)
-                                //
-                                // It's not really possible to fix this unless we turn every sync export into
-                                // an async export that will use the regular async enabled `enter()`.
-                                cstate.exclusiveLock();
+                                if (!cstate.isExclusivelyLocked()) {{
+                                    cstate.exclusiveLock(this.#id);
+                                }} else {{
+                                    // A host-called sync export arriving while another
+                                    // task's slice holds the lock: synchronous entry
+                                    // cannot wait, and historically this entry silently
+                                    // stole the hold. Run without the lock instead --
+                                    // the holder's bookkeeping stays intact and its
+                                    // release still pairs
+                                    this.#lockFreeEntry = true;
+                                    {debug_log_fn}('[{task_class}#enterSync()] entering without exclusive lock', {{
+                                        taskID: this.#id,
+                                        componentIdx: this.#componentIdx,
+                                    }});
+                                }}
                             }}
                             return true;
                         }}
@@ -1140,20 +1157,19 @@ impl AsyncTaskIntrinsic {
                                 // It is currently possible for an actually sync export to be specified
                                 // as async via JSPI
                                 if (this.#isManualAsync) {{
-                                    if (this.needsExclusiveLock()) {{ cstate.exclusiveLock(); }}
+                                    if (this.needsExclusiveLock()) {{ await cstate.acquireExclusiveLock(this.#id); }}
                                 }}
 
                                 return this.#entered;
                             }}
 
                             // Perform intial backpressure check
-                            if (cstate.hasBackpressure() || this.needsExclusiveLock() && cstate.isExclusivelyLocked()) {{
+                            if (cstate.hasBackpressure()) {{
                                 cstate.addBackpressureWaiter();
 
                                 const result = await this.waitUntil({{
                                     readyFn: () => {{
-                                        return !(cstate.hasBackpressure()
-                                                 || this.needsExclusiveLock() && cstate.isExclusivelyLocked());
+                                        return !cstate.hasBackpressure();
                                     }},
                                     cancellable: true,
                                 }});
@@ -1166,31 +1182,11 @@ impl AsyncTaskIntrinsic {
                                 }}
                             }}
 
-                            // Lock the component state or keep trying until we can/do
-                            try {{
-                                if (this.needsExclusiveLock()) {{ cstate.exclusiveLock(); }}
-                            }} catch {{
-                                // Continuously attempt to lock until we can
-                                while (cstate.hasBackpressure() || this.needsExclusiveLock() && cstate.isExclusivelyLocked()) {{
-                                    try {{
-                                        if (this.needsExclusiveLock()) {{ cstate.exclusiveLock(); }}
-                                        break;
-                                    }} catch(err) {{
-                                        cstate.addBackpressureWaiter();
-                                        const result = await this.waitUntil({{
-                                            readyFn: () => {{
-                                                return !(cstate.hasBackpressure()
-                                                         || this.needsExclusiveLock() && cstate.isExclusivelyLocked());
-                                            }},
-                                            cancellable: true,
-                                        }});
-                                        cstate.removeBackpressureWaiter();
-                                        if (result === {task_class}.BlockResult.CANCELLED) {{
-                                            this.cancel();
-                                            return false;
-                                        }}
-                                    }}
-                                }}
+                            // Acquire the per-slice exclusive lock (FIFO-queued when
+                            // contended); the first slice runs under this hold and the
+                            // driver loop releases/re-acquires it per slice thereafter.
+                            if (this.needsExclusiveLock()) {{
+                                await cstate.acquireExclusiveLock(this.#id);
                             }}
 
                             this.#entered = true;
@@ -1502,13 +1498,16 @@ impl AsyncTaskIntrinsic {
                             if (!state) {{ throw new Error('missing async state for component [' + this.#componentIdx + ']'); }}
 
                             // Exempt the host from exclusive lock check
-                            if (this.#componentIdx !== -1 && !args?.skipExclusiveLockCheck) {{
-                                if (this.needsExclusiveLock() && !state.isExclusivelyLocked()) {{
-                                    throw new Error(`task [${{this.#id}}] exit: component [${{this.#componentIdx}}] should have been exclusively locked`);
+                            if (this.#componentIdx !== -1 && !args?.skipExclusiveLockCheck && !this.#lockFreeEntry) {{
+                                if (this.needsExclusiveLock() && !state.exclusivelyLockedBy(this.#id)) {{
+                                    throw new Error(`task [${{this.#id}}] exit: component [${{this.#componentIdx}}] should have been exclusively locked by it`);
                                 }}
                             }}
 
-                            state.exclusiveRelease();
+                            // Ownership-checked: releases only this task's own hold (a
+                            // task exiting while another task's slice holds the lock no
+                            // longer clears the foreign hold).
+                            state.exclusiveRelease(this.#id);
 
                             for (const f of this.#onExitHandlers) {{
                                 try {{
@@ -1524,6 +1523,14 @@ impl AsyncTaskIntrinsic {
                         }}
 
                         needsExclusiveLock() {{
+                            // Host (-1) tasks model host-side import handling: there is no
+                            // guest linear memory or executor state to protect, and host
+                            // calls from unrelated guest components would contend spuriously.
+                            if (this.#componentIdx === -1) {{ return false; }}
+                            // Import-handler tasks (CallInterface) run host code nested
+                            // inside the calling guest slice, which already holds the
+                            // lock; only tasks that execute guest slices need it.
+                            if (!this.#callingWasmExport) {{ return false; }}
                             return !this.#isAsync || this.hasCallback();
                         }}
 
@@ -2069,7 +2076,7 @@ impl AsyncTaskIntrinsic {
                         let wset;
                         try {{
                             while (true) {{
-                                if (callbackCode !== 0) {{ componentState.exclusiveRelease(); }}
+                                if (callbackCode !== 0) {{ componentState.exclusiveRelease(task.id()); }}
 
                                 switch (callbackCode) {{
                                     case 0: // EXIT
@@ -2091,7 +2098,7 @@ impl AsyncTaskIntrinsic {
                                         }});
                                         asyncRes = await task.yieldUntil({{
                                             cancellable: true,
-                                            readyFn: () => !componentState.isExclusivelyLocked(),
+                                            readyFn: () => true,
                                         }});
                                         {debug_log_fn}('[{driver_loop_fn}()] finished yield', {{
                                             fnName,
@@ -2118,7 +2125,7 @@ impl AsyncTaskIntrinsic {
                                         }}
 
                                         asyncRes = await wset.waitUntil({{
-                                            readyFn: () => !componentState.isExclusivelyLocked(),
+                                            readyFn: () => true,
                                             task,
                                             cancellable: true,
                                         }});
@@ -2138,11 +2145,16 @@ impl AsyncTaskIntrinsic {
                                         throw new Error(`Unrecognized async function result [${{ret}}]`);
                                 }}
 
-                                componentState.exclusiveLock();
+                                // Own the per-slice lock before delivering the event into
+                                // the next callback slice (FIFO-queued when another task's
+                                // slice is mid-flight, including across its JSPI
+                                // suspensions.
+                                await componentState.acquireExclusiveLock(task.id());
 
                                 // If the task failed via any means, leave early and reject.
                                 if (task.isRejected()) {{
                                     {debug_log_fn}('[{driver_loop_fn}()] detected task rejection, leaving early');
+                                    componentState.exclusiveRelease(task.id());
                                     return;
                                 }}
 
@@ -2777,21 +2789,41 @@ impl AsyncTaskIntrinsic {
                         newTask.setParentSubtask(subtask);
 
                         subtask.onStart();
-                        newTask.enterSync();
-                        {set_global_current_task_meta_fn}({{
-                            taskID: newTask.id(),
-                            componentIdx: newTask.componentIdx(),
-                        }});
-                        {symmetric_sync_guest_call_stack}.push({{
-                            componentIdx: newTask.componentIdx(),
-                        }});
 
-                        {debug_log_fn}('[{enter_symmetric_sync_guest_call_fn}()] finished preparing', {{
-                            callerComponentIdx,
-                            calleeComponentIdx,
-                            subtaskID: subtask.id(),
-                            newTaskID: newTask.id(),
-                        }});
+                        const finishEnter = () => {{
+                            {set_global_current_task_meta_fn}({{
+                                taskID: newTask.id(),
+                                componentIdx: newTask.componentIdx(),
+                            }});
+                            {symmetric_sync_guest_call_stack}.push({{
+                                componentIdx: newTask.componentIdx(),
+                            }});
+
+                            {debug_log_fn}('[{enter_symmetric_sync_guest_call_fn}()] finished preparing', {{
+                                callerComponentIdx,
+                                calleeComponentIdx,
+                                subtaskID: subtask.id(),
+                                newTaskID: newTask.id(),
+                            }});
+                        }};
+
+                        // Take the callee's per-slice exclusive lock. Uncontended entry
+                        // stays fully synchronous (returning a non-promise means the
+                        // Suspending-wrapped trampoline does not suspend, so pure-sync
+                        // compositions keep working without WebAssembly.promising).
+                        // Contended entry queues FIFO on the holder instead of silently
+                        // stealing the hold; the returned
+                        // promise suspends the caller's (JSPI) stack until ownership.
+                        if (!newTask.needsExclusiveLock()) {{
+                            finishEnter();
+                            return;
+                        }}
+                        if (!cstate.isExclusivelyLocked()) {{
+                            cstate.exclusiveLock(newTask.id());
+                            finishEnter();
+                            return;
+                        }}
+                        return cstate.acquireExclusiveLock(newTask.id()).then(finishEnter);
                     }}
                     "#,
                 ));

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_task.rs
@@ -498,6 +498,10 @@ impl AsyncTaskIntrinsic {
                                 returnFnParams: [...params, subtaskCallMetadata.resultPtr],
                             }});
                             const res = subtaskCallMetadata.returnFn.apply(null, [...params, subtaskCallMetadata.resultPtr]);
+                            // For sync-lowered calls the fused [return-call] helper returns
+                            // the lowering's flat result directly; stash it for
+                            // _syncStartCall to return to the blocked caller.
+                            subtaskCallMetadata.returnFnResult = res;
                             subtaskCallMetadata.returnFnCalled = true;
                             task.resolve([]);
                             return;
@@ -1146,7 +1150,14 @@ impl AsyncTaskIntrinsic {
                                 return this.#entered;
                             }}
 
-                            await cstate.nextTaskExecutionSlot({{ task: this }});
+                            // NOTE: concurrent task lifetimes within one component instance are
+                            // permitted by the Component Model: entry is governed by the
+                            // backpressure and exclusive-lock checks below (the lock is held per
+                            // execution slice, not for the task's lifetime).
+                            //
+                            // Serializing entire task lifetimes here (the former "execution slot" queue)
+                            // deadlocks pipelines where a parked long-lived task's progress depends on a
+                            // later entry into the same component.
 
                             // If a task is synchronous then we can avoid component-relevant
                             // tracking and immediately enter.

--- a/crates/js-component-bindgen/src/intrinsics/p3/host.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/host.rs
@@ -171,6 +171,14 @@ impl HostIntrinsic {
                             // prepare async with result (u32::MAX - 1)
                             isAsync = true;
                             hasResultPointer = true;
+                        }} else if (resultCountOrAsync > 1) {{
+                            // Sync lowering whose flattened results exceed
+                            // MAX_FLAT_RESULTS (1): the results are spilled via a
+                            // return pointer, passed as the caller's trailing core
+                            // argument (the fused [return-call] helper writes
+                            // through it). An unflattenable result count arrives
+                            // as the i32::MAX sentinel and takes this path too.
+                            hasResultPointer = true;
                         }}
 
                         const currentCallerTaskMeta = {current_task_get_fn}(callerComponentIdx);

--- a/crates/js-component-bindgen/src/intrinsics/p3/host.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/host.rs
@@ -351,6 +351,17 @@ impl HostIntrinsic {
                             throw new Error(`unsupported result count [${{ resultCount }}]`);
                         }}
 
+                        // NOTE: `params` are the *caller's* lowered core args captured during
+                        // PrepareCall, while `paramCount` describes the *callee's* lifted core
+                        // signature.
+                        //
+                        // The two intentionally differ whenever the caller spilled
+                        // its arguments to memory (async lowers pass a single pointer for
+                        // functions with more than MAX_FLAT_ASYNC_PARAMS flat params).
+                        //
+                        // The fused [async-start] adapter that is provided (`startFn`,
+                        // invoked via `subtask.onStart()` below) performs the conversion.
+                        //
                         const params = preparedTask.getCalleeParams();
 
                         const callerComponentState = {get_or_create_async_state_fn}(subtask.componentIdx());
@@ -482,7 +493,10 @@ impl HostIntrinsic {
                             }});
 
                             let startRes = subtask.onStart({{ startFnParams: params }});
-                            startRes = Array.isArray(startRes) ? startRes : [startRes];
+                            startRes = startRes === undefined ? [] : Array.isArray(startRes) ? startRes : [startRes];
+                            if (startRes.length !== paramCount) {{
+                                throw new Error(`unexpected callee param count [${{ startRes.length }}] after start fn, {async_start_call_fn} invocation expected [${{ paramCount }}]`);
+                            }}
 
                             // NOTE: enter() below queues (FIFO) for the per-slice
                             // exclusive lock when another slice of the callee component
@@ -602,13 +616,186 @@ impl HostIntrinsic {
             Self::SyncStartCall => {
                 let debug_log_fn = Intrinsic::DebugLog.name();
                 let sync_start_call_fn = Self::SyncStartCall.name();
+                let get_or_create_async_state_fn =
+                    Intrinsic::Component(ComponentIntrinsic::GetOrCreateAsyncState).name();
+                let async_driver_loop_fn =
+                    Intrinsic::AsyncTask(AsyncTaskIntrinsic::DriverLoop).name();
+                let current_component_idx_globals =
+                    AsyncTaskIntrinsic::GlobalAsyncCurrentComponentIdxs.name();
+                let get_current_task_fn =
+                    Intrinsic::AsyncTask(AsyncTaskIntrinsic::GetCurrentTask).name();
+                let with_global_current_task_meta_async_fn =
+                    Intrinsic::WithGlobalCurrentTaskMetaFnAsync.name();
+                let get_global_current_task_meta_fn = Intrinsic::GetGlobalCurrentTaskMetaFn.name();
+                let set_global_current_task_meta_fn = Intrinsic::SetGlobalCurrentTaskMetaFn.name();
+
+                // NTOE: in the case of a sync-lowered import of an async fucntion,
+                // we must handle the blocking start-call differently:
+                //
+                // - we run immediately after `_prepareCall` in the same fused-adapter frame;
+                // - starts the prepared callee task;
+                // - drives the callback protocol until the task resolves via `task.return`;
+                // - returns the sync lowering's flat result, produced by the fused
+                //   `[return-call]` helper and stashed by the `taskReturn` intrinsic.
+                //
+                // Because the trampoline is wrapped with `Suspending`, it runs on the
+                // caller's suspended JSPI stack and blocks the caller until completion.
+                //
+                // Failure behavior also depends on the call path: here, callee failures
+                // propagate as exceptions and trap the sync caller. `_asyncStartCall`
+                // instead records such failures without immediately throwing them into
+                // the caller.
+                //
+                // Unlike `_asyncStartCall`, callee failures propagate as an
+                // exception (trapping the caller) rather than being recorded
+                // silently: a trapped callee traps a sync caller.
                 output.push_str(&format!(
-                    "
-                    function {sync_start_call_fn}(callbackIdx) {{
-                        {debug_log_fn}('[{sync_start_call_fn}()] args', {{ callbackIdx }});
-                        throw new Error('synchronous start call not implemented!');
+                    r#"
+                    async function {sync_start_call_fn}(args, callee, paramCount) {{
+                        const componentIdx = {current_component_idx_globals}.at(-1);
+
+                        const globalTaskMeta = {get_global_current_task_meta_fn}(componentIdx);
+                        if (!globalTaskMeta) {{ throw new Error('missing global current task meta during sync start call'); }}
+                        const taskID = globalTaskMeta.taskID;
+
+                        {debug_log_fn}('[{sync_start_call_fn}()] args', {{ args, paramCount, componentIdx }});
+                        const {{ getCallbackFn, callbackIdx }} = args;
+
+                        const preparedTaskMeta = {get_current_task_fn}(componentIdx, taskID);
+                        if (!preparedTaskMeta) {{ throw new Error('unexpectedly missing current (prepared) task'); }}
+
+                        const preparedTask = preparedTaskMeta.task;
+                        if (!preparedTask) {{ throw new Error('unexpectedly missing current (prepared) task'); }}
+                        if (!preparedTask.subtaskMeta) {{ throw new Error('missing subtask meta from prepare'); }}
+
+                        const {{ subtask, calleeComponentIdx, callerComponentIdx }} = preparedTask.subtaskMeta;
+                        if (!subtask) {{ throw new Error('missing subtask from prepare during sync start call'); }}
+                        if (calleeComponentIdx !== preparedTask.componentIdx()) {{
+                            throw new Error(`meta callee idx [${{calleeComponentIdx}}] != current task idx [${{preparedTask.componentIdx()}}] during sync start call`);
+                        }}
+
+                        // The caller's wasm stack stays suspended across the whole blocking
+                        // call; sibling slices of the caller's component may run meanwhile
+                        // and move its current-task register. Capture the entry at call
+                        // time and restore it before the caller resumes (the same
+                        // discipline as the suspending-import wrapper).
+                        const savedCallerTaskMeta = {get_global_current_task_meta_fn}(callerComponentIdx);
+                        try {{
+
+                        const callbackFn = getCallbackFn();
+                        preparedTask.setCallbackFn(callbackFn, 'callback_' + callbackIdx);
+
+                        // NOTE: `params` are the caller's lowered core args captured during
+                        // PrepareCall; the fused [sync-start] helper (`startFn`, invoked via
+                        // `subtask.onStart()` below) converts them into the callee's lifted
+                        // core signature (`paramCount`).
+                        const params = preparedTask.getCalleeParams();
+
+                        const calleeComponentState = {get_or_create_async_state_fn}(preparedTask.componentIdx());
+
+                        // For fused guest->guest calls the [return-call] helper performs the
+                        // result copy/lower; it is invoked by the taskReturn intrinsic when
+                        // the callee resolves (this handler is the fallback ordering guard,
+                        // mirroring _asyncStartCall).
+                        subtask.registerOnResolveHandler((res) => {{
+                            {debug_log_fn}('[{sync_start_call_fn}()] handling subtask result', {{ res, subtaskID: subtask.id() }});
+                            if (!subtask.isReturned()) {{ return; }}
+                            const subtaskCallMeta = subtask.getCallMetadata();
+                            if (subtaskCallMeta?.returnFn && !subtaskCallMeta.returnFnCalled) {{
+                                subtaskCallMeta.returnFnResult = subtaskCallMeta.returnFn.apply(null, [subtaskCallMeta.resultPtr]);
+                                subtaskCallMeta.returnFnCalled = true;
+                            }}
+                        }});
+
+                        let startRes = subtask.onStart({{ startFnParams: params }});
+                        startRes = startRes === undefined ? [] : Array.isArray(startRes) ? startRes : [startRes];
+                        if (startRes.length !== paramCount) {{
+                            throw new Error(`unexpected callee param count [${{ startRes.length }}] after start fn, {sync_start_call_fn} invocation expected [${{ paramCount }}]`);
+                        }}
+
+                        const started = await preparedTask.enter();
+                        if (!started) {{
+                            if (preparedTask.isCancelled()) {{ return undefined; }}
+                            throw new Error('callee task failed to start during sync start call');
+                        }}
+
+                        // The prepared task was created with the *lowering's* async-ness
+                        // (sync), so enter() took the sync shortcut without acquiring the
+                        // per-slice exclusive lock the callback-driven slices below pair
+                        // with; acquire it here (FIFO-queued when another slice of the callee
+                        // is mid-flight.
+                        if (preparedTask.needsExclusiveLock()) {{
+                            await calleeComponentState.acquireExclusiveLock(preparedTask.id());
+                        }}
+
+                        let jspiCallee;
+                        if (callee._cachedPromising) {{
+                            jspiCallee = callee._cachedPromising;
+                        }} else {{
+                            callee._cachedPromising = WebAssembly.promising(callee);
+                            jspiCallee = callee._cachedPromising;
+                        }}
+
+                        let callbackResult;
+                        try {{
+                            callbackResult = await {with_global_current_task_meta_async_fn}({{
+                                taskID: preparedTask.id(),
+                                componentIdx: preparedTask.componentIdx(),
+                                fn: () => {{
+                                    return jspiCallee.apply(null, startRes);
+                                }}
+                            }});
+                        }} catch (err) {{
+                            // A trapped callee propagates to the (sync) caller; release
+                            // the per-slice hold the driver loop will never pair.
+                            if (preparedTask.needsExclusiveLock()) {{
+                                calleeComponentState.exclusiveRelease(preparedTask.id());
+                            }}
+                            throw err;
+                        }}
+
+                        if (!callbackFn) {{
+                            // Async-lifted without a callback (stackful lift): the callee ran
+                            // to completion above; task.return already ran within it.
+                            {debug_log_fn}('[{sync_start_call_fn}()] no callback, resolving w/ callee result', {{
+                                taskID: preparedTask.id(),
+                                componentIdx: preparedTask.componentIdx(),
+                            }});
+                            if (!preparedTask.isResolved()) {{ preparedTask.resolve([callbackResult]); }}
+                        }} else {{
+                            const fnName = callbackFn.fnName ?? ('<sync-start subtask ' + subtask.id() + '>');
+                            {debug_log_fn}('[{sync_start_call_fn}()] starting driver loop', {{
+                                fnName,
+                                componentIdx: preparedTask.componentIdx(),
+                                subtaskID: subtask.id(),
+                            }});
+                            await {async_driver_loop_fn}({{
+                                componentState: calleeComponentState,
+                                task: preparedTask,
+                                fnName,
+                                isAsync: true,
+                                callbackResult,
+                            }});
+                        }}
+
+                        const callMeta = subtask.getCallMetadata();
+                        const flatResult = callMeta?.returnFnResult;
+                        {debug_log_fn}('[{sync_start_call_fn}()] returning flat result', {{
+                            flatResult,
+                            subtaskID: subtask.id(),
+                            taskID: preparedTask.id(),
+                        }});
+                        return flatResult;
+                        }} finally {{
+                            if (savedCallerTaskMeta) {{
+                                {set_global_current_task_meta_fn}({{
+                                    taskID: savedCallerTaskMeta.taskID,
+                                    componentIdx: callerComponentIdx,
+                                }});
+                            }}
+                        }}
                     }}
-                "
+                "#
                 ));
             }
 

--- a/crates/js-component-bindgen/src/intrinsics/p3/host.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/host.rs
@@ -476,19 +476,9 @@ impl HostIntrinsic {
                             let startRes = subtask.onStart({{ startFnParams: params }});
                             startRes = Array.isArray(startRes) ? startRes : [startRes];
 
-                            if (calleeComponentState.isExclusivelyLocked()) {{
-                                {debug_log_fn}('[{async_start_call_fn}()] during continuation callee is exclusively locked, suspending...', {{
-                                    taskID: preparedTask.id(),
-                                    subtaskID: subtask.id(),
-                                    callerComponentIdx,
-                                    calleeComponentIdx,
-                                }});
-                                await calleeComponentState.suspendTask({{
-                                    task: preparedTask,
-                                    readyFn: () => !calleeComponentState.isExclusivelyLocked(),
-                                }});
-                            }}
-
+                            // NOTE: enter() below queues (FIFO) for the per-slice
+                            // exclusive lock when another slice of the callee component
+                            // is mid-flight; no pre-wait needed.
                             const started = await preparedTask.enter();
                             if (!started) {{
                                 {debug_log_fn}('[{async_start_call_fn}()] task failed early', {{
@@ -524,6 +514,12 @@ impl HostIntrinsic {
                                 // subtask.getParentTask().reject(err);
 
                                 subtask.getParentTask().setErrored(err);
+
+                                // Release the enter()-acquired per-slice hold: the driver
+                                // loop that would normally pair it never starts.
+                                if (preparedTask.needsExclusiveLock()) {{
+                                    calleeComponentState.exclusiveRelease(preparedTask.id());
+                                }}
 
                                 return;
                             }}

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -2788,12 +2788,33 @@ impl<'a> Instantiator<'a, '_> {
                 let enter_symmetric_sync_guest_call_fn = self.bindgen.intrinsic(
                     Intrinsic::AsyncTask(AsyncTaskIntrinsic::EnterSymmetricSyncGuestCall),
                 );
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                      const trampoline{i} = {enter_symmetric_sync_guest_call_fn};
-                    "#,
+                // Under JSPI, contended entry queues for the callee's per-slice
+                // exclusive lock by returning a promise, which requires the
+                // trampoline to be Suspending (fused sync calls then run inside
+                // promising activations). Outside JSPI a Suspending import
+                // would trap on every call from the plain (non-promising)
+                // stacks such transpiles use, so the trampoline stays plain
+                // and contended entry traps (uncontended entry is fully
+                // synchronous either way).
+                let uses_jspi = matches!(
+                    self.bindgen.opts.async_mode,
+                    Some(AsyncMode::JavaScriptPromiseIntegration { .. })
                 );
+                if uses_jspi {
+                    uwriteln!(
+                        self.src.js,
+                        r#"
+                          const trampoline{i} = new WebAssembly.Suspending({enter_symmetric_sync_guest_call_fn});
+                        "#,
+                    );
+                } else {
+                    uwriteln!(
+                        self.src.js,
+                        r#"
+                          const trampoline{i} = {enter_symmetric_sync_guest_call_fn};
+                        "#,
+                    );
+                }
             }
 
             Trampoline::ExitSyncCall => {

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -1382,1497 +1382,6 @@ impl<'a> Instantiator<'a, '_> {
                 let waitable_set_wait_fn = self
                     .bindgen
                     .intrinsic(Intrinsic::Waitable(WaitableIntrinsic::WaitableSetWait));
-
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                    const trampoline{i} = new WebAssembly.Suspending({waitable_set_wait_fn}.bind(null, {{
-                        componentIdx: {instance_idx},
-                        isAsync: {async_},
-                        memoryIdx: {memory_idx},
-                        getMemoryFn: () => memory{memory_idx},
-                    }}));
-                    "#,
-                );
-            }
-
-            Trampoline::WaitableSetPoll { options, .. } => {
-                let CanonicalOptions {
-                    instance,
-                    async_,
-                    data_model:
-                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, .. }),
-                    cancellable,
-                    ..
-                } = self
-                    .component
-                    .options
-                    .get(*options)
-                    .expect("failed to find options")
-                else {
-                    panic!("unexpected memory data model during waitable-set.poll");
-                };
-
-                let instance_idx = instance.as_u32();
-                let memory_idx = memory
-                    .expect("missing memory idx for waitable-set.poll")
-                    .as_u32();
-                let waitable_set_poll_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Waitable(WaitableIntrinsic::WaitableSetPoll));
-
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                    const trampoline{i} = {waitable_set_poll_fn}.bind(
-                        null,
-                        {{
-                            componentIdx: {instance_idx},
-                            isAsync: {async_},
-                            isCancellable: {cancellable},
-                            memoryIdx: {memory_idx},
-                            getMemoryFn: () => memory{memory_idx},
-                        }}
-                    );
-                    "#,
-                );
-            }
-
-            Trampoline::WaitableSetDrop { instance } => {
-                let waitable_set_drop_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Waitable(WaitableIntrinsic::WaitableSetDrop));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {waitable_set_drop_fn}.bind(null, {instance_idx});\n",
-                    instance_idx = instance.as_u32(),
-                );
-            }
-
-            Trampoline::WaitableJoin { instance } => {
-                let waitable_join_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Waitable(WaitableIntrinsic::WaitableJoin));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {waitable_join_fn}.bind(null, {instance_idx});\n",
-                    instance_idx = instance.as_u32(),
-                );
-            }
-
-            Trampoline::StreamNew { ty, instance } => {
-                let stream_new_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamNew));
-                let instance_idx = instance.as_u32();
-                let stream_table_idx = ty.as_u32();
-
-                // Get to the payload type for the given stream table idx
-                let table_ty = &self.types[*ty];
-                let stream_ty_idx = table_ty.ty;
-                let stream_ty = &self.types[stream_ty_idx];
-
-                // TODO(???): do we have no way to go from interface type to in-component type idx?
-                // TODO(???): does this work under type aliases?? we need the type def?
-                // TODO(???): can the stream type be treated as a unique indicator of the payload type? maybe not?
-                // need a way to go from iface type + stream type -> payload type idx?
-                let payload_ty_name_js = stream_ty
-                    .payload
-                    .map(|iface_ty| format!("'{iface_ty:?}'"))
-                    .unwrap_or_else(|| "null".into());
-
-                // Gather type metadata
-                let (
-                    align_32_js,
-                    size_32_js,
-                    flat_count_js,
-                    lift_fn_js,
-                    lower_fn_js,
-                    is_none_js,
-                    is_numeric_type_js,
-                    is_borrow_js,
-                    is_async_value_js,
-                    typed_array_js,
-                ) = match stream_ty.payload {
-                    // If there is no payload for the stream, we know the values
-                    None => (
-                        "0".into(),
-                        "0".into(),
-                        "0".into(),
-                        "null".into(),
-                        "null".into(),
-                        "true",
-                        "false".into(),
-                        "false".into(),
-                        "false".into(),
-                        "undefined",
-                    ),
-                    // If there is a payload, generate relevant lift/lower and other metadata
-                    Some(ty) => (
-                        self.types.canonical_abi(&ty).align32.to_string(),
-                        self.types.canonical_abi(&ty).size32.to_string(),
-                        self.types
-                            .canonical_abi(&ty)
-                            .flat_count
-                            .map(|v| v.to_string())
-                            .unwrap_or_else(|| "null".into()),
-                        gen_flat_lift_fn_js_expr(self, &ty, &None),
-                        gen_flat_lower_fn_js_expr(self, &ty, &None),
-                        "false",
-                        format!(
-                            "{}",
-                            matches!(
-                                ty,
-                                InterfaceType::U8
-                                    | InterfaceType::U16
-                                    | InterfaceType::U32
-                                    | InterfaceType::U64
-                                    | InterfaceType::S8
-                                    | InterfaceType::S16
-                                    | InterfaceType::S32
-                                    | InterfaceType::S64
-                                    | InterfaceType::Float32
-                                    | InterfaceType::Float64
-                            )
-                        ),
-                        format!("{}", matches!(ty, InterfaceType::Borrow(_))),
-                        format!(
-                            "{}",
-                            matches!(ty, InterfaceType::Stream(_) | InterfaceType::Future(_))
-                        ),
-                        js_typed_array_ctor(&ty).unwrap_or("undefined"),
-                    ),
-                };
-
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {stream_new_fn}.bind(null, {{
-                        streamTableIdx: {stream_table_idx},
-                        callerComponentIdx: {instance_idx},
-                        elemMeta: {{
-                            liftFn: {lift_fn_js},
-                            lowerFn: {lower_fn_js},
-                            payloadTypeName: {payload_ty_name_js},
-                            isNone: {is_none_js},
-                            isNumeric: {is_numeric_type_js},
-                            isBorrowed: {is_borrow_js},
-                            isAsyncValue: {is_async_value_js},
-                            typedArray: {typed_array_js},
-                            flatCount: {flat_count_js},
-                            align32: {align_32_js},
-                            size32: {size_32_js},
-                        }},
-                    }});\n",
-                );
-            }
-
-            Trampoline::StreamRead {
-                instance,
-                ty,
-                options,
-            } => {
-                let options = self
-                    .component
-                    .options
-                    .get(*options)
-                    .expect("failed to find options");
-                assert_eq!(
-                    instance.as_u32(),
-                    options.instance.as_u32(),
-                    "options index instance must match trampoline"
-                );
-
-                let CanonicalOptions {
-                    instance,
-                    string_encoding,
-                    async_,
-                    data_model:
-                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
-                    ..
-                } = options
-                else {
-                    unreachable!("missing/invalid data model for options during stream.read")
-                };
-                let memory_idx = memory.expect("missing memory idx for stream.read").as_u32();
-                let (realloc_idx, get_realloc_fn_js) = match realloc {
-                    Some(v) => {
-                        let v = v.as_u32().to_string();
-                        (v.to_string(), format!("() => realloc{v}"))
-                    }
-                    None => ("undefined".into(), "undefined".into()),
-                };
-
-                let component_instance_id = instance.as_u32();
-                let string_encoding = string_encoding_js_literal(string_encoding);
-                let stream_table_idx = ty.as_u32();
-                let stream_read_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamRead));
-
-                // PrepareCall for an async call is sometimes missing memories,
-                // so we augment and save here, knowing that any stream.write/read operation
-                // that uses a memory is indicative of that component's memory
-                //
-                let register_global_memory_for_component_fn =
-                    Intrinsic::RegisterGlobalMemoryForComponent.name();
-                uwriteln!(
-                    self.src.js_init,
-                    r#"{register_global_memory_for_component_fn}({{
-                         componentIdx: {component_instance_id},
-                         memoryIdx: {memory_idx},
-                         memory: memory{memory_idx},
-                     }});"#
-                );
-
-                uwriteln!(
-                    self.src.js,
-                    r#"const trampoline{i} = new WebAssembly.Suspending({stream_read_fn}.bind(
-                         null,
-                         {{
-                             componentIdx: {component_instance_id},
-                             memoryIdx: {memory_idx},
-                             getMemoryFn: () => memory{memory_idx},
-                             reallocIdx: {realloc_idx},
-                             getReallocFn: {get_realloc_fn_js},
-                             stringEncoding: {string_encoding},
-                             isAsync: {async_},
-                             streamTableIdx: {stream_table_idx},
-                         }}
-                     ));
-                    "#,
-                );
-            }
-
-            Trampoline::StreamWrite {
-                instance,
-                ty,
-                options,
-            } => {
-                let options = self
-                    .component
-                    .options
-                    .get(*options)
-                    .expect("failed to find options");
-                assert_eq!(
-                    instance.as_u32(),
-                    options.instance.as_u32(),
-                    "options index instance must match trampoline"
-                );
-
-                let CanonicalOptions {
-                    instance,
-                    string_encoding,
-                    async_,
-                    data_model:
-                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
-                    ..
-                } = options
-                else {
-                    unreachable!("unexpected memory data model during stream.write");
-                };
-                let component_instance_id = instance.as_u32();
-                let memory_idx = memory
-                    .expect("missing memory idx for stream.write")
-                    .as_u32();
-                let (realloc_idx, get_realloc_fn_js) = match realloc {
-                    Some(v) => {
-                        let v = v.as_u32().to_string();
-                        (v.to_string(), format!("() => realloc{v}"))
-                    }
-                    None => ("undefined".into(), "undefined".into()),
-                };
-
-                let string_encoding = string_encoding_js_literal(string_encoding);
-                let stream_table_idx = ty.as_u32();
-                let stream_write_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamWrite));
-
-                // PrepareCall for an async call is sometimes missing memories,
-                // so we augment and save here, knowing that any stream.write/read operation
-                // that uses a memory is indicative of that component's memory
-                let register_global_memory_for_component_fn =
-                    Intrinsic::RegisterGlobalMemoryForComponent.name();
-                uwriteln!(
-                    self.src.js_init,
-                    r#"{register_global_memory_for_component_fn}({{
-                         componentIdx: {component_instance_id},
-                         memoryIdx: {memory_idx},
-                         memory: memory{memory_idx},
-                     }});"#
-                );
-
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                     const trampoline{i} = new WebAssembly.Suspending({stream_write_fn}.bind(
-                         null,
-                         {{
-                             componentIdx: {component_instance_id},
-                             memoryIdx: {memory_idx},
-                             getMemoryFn: () => memory{memory_idx},
-                             reallocIdx: {realloc_idx},
-                             getReallocFn: {get_realloc_fn_js},
-                             stringEncoding: {string_encoding},
-                             isAsync: {async_},
-                             streamTableIdx: {stream_table_idx},
-                         }}
-                     ));
-                    "#,
-                );
-            }
-
-            Trampoline::StreamCancelRead {
-                instance,
-                ty,
-                async_,
-            }
-            | Trampoline::StreamCancelWrite {
-                instance,
-                ty,
-                async_,
-            } => {
-                let stream_cancel_fn = match trampoline {
-                    Trampoline::StreamCancelRead { .. } => self.bindgen.intrinsic(
-                        Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamCancelRead),
-                    ),
-                    Trampoline::StreamCancelWrite { .. } => self.bindgen.intrinsic(
-                        Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamCancelWrite),
-                    ),
-                    _ => unreachable!("unexpected trampoline"),
-                };
-
-                let stream_table_idx = ty.as_u32();
-                let component_idx = instance.as_u32();
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                      const trampoline{i} = new WebAssembly.Suspending({stream_cancel_fn}.bind(null, {{
-                          streamTableIdx: {stream_table_idx},
-                          isAsync: {async_},
-                          componentIdx: {component_idx},
-                      }}));
-                    "#,
-                );
-            }
-
-            Trampoline::StreamDropReadable { ty, instance }
-            | Trampoline::StreamDropWritable { ty, instance } => {
-                let intrinsic_fn = match trampoline {
-                    Trampoline::StreamDropReadable { .. } => self.bindgen.intrinsic(
-                        Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamDropReadable),
-                    ),
-                    Trampoline::StreamDropWritable { .. } => self.bindgen.intrinsic(
-                        Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamDropWritable),
-                    ),
-                    _ => unreachable!("unexpected trampoline"),
-                };
-                let stream_idx = ty.as_u32();
-                let instance_idx = instance.as_u32();
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {intrinsic_fn}.bind(null, {{
-                        streamTableIdx: {stream_idx},
-                        componentIdx: {instance_idx},
-                    }});\n",
-                );
-            }
-
-            Trampoline::StreamTransfer => {
-                let stream_transfer_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamTransfer));
-                uwriteln!(self.src.js, "const trampoline{i} = {stream_transfer_fn};\n",);
-            }
-
-            Trampoline::FutureNew { instance, ty } => {
-                let future_new_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureNew));
-                let future_table_idx = ty.as_u32();
-                let component_idx = instance.as_u32();
-
-                // Build element metadata
-                let future_table_ty = &self.types[*ty];
-                let future_ty = &self.types[future_table_ty.ty];
-                let (
-                    payload_size32,
-                    payload_align32,
-                    payload_flat_count_js,
-                    payload_lift_fn_js,
-                    payload_lower_fn_js,
-                    is_borrowed,
-                    is_none_type,
-                    is_numeric_type,
-                    is_async_value,
-                ) = match future_ty.payload {
-                    None => (
-                        0,
-                        0,
-                        "0".into(),
-                        "() => {{ throw new Error('empty future payload'); }}".into(),
-                        "() => {{ throw new Error('empty future payload'); }}".into(),
-                        false,
-                        true,
-                        false,
-                        false,
-                    ),
-                    Some(payload_ty) => {
-                        let cabi = self.types.canonical_abi(&payload_ty);
-                        (
-                            cabi.size32,
-                            cabi.align32,
-                            cabi.flat_count
-                                .map(|v| format!("{v}"))
-                                .unwrap_or_else(|| "null".into()),
-                            gen_flat_lift_fn_js_expr(self, &payload_ty, &None),
-                            gen_flat_lower_fn_js_expr(self, &payload_ty, &None),
-                            matches!(payload_ty, InterfaceType::Borrow(_)),
-                            false,
-                            matches!(
-                                payload_ty,
-                                InterfaceType::U8
-                                    | InterfaceType::U16
-                                    | InterfaceType::U32
-                                    | InterfaceType::U64
-                                    | InterfaceType::S8
-                                    | InterfaceType::S16
-                                    | InterfaceType::S32
-                                    | InterfaceType::S64
-                                    | InterfaceType::Float32
-                                    | InterfaceType::Float64
-                            ),
-                            matches!(
-                                payload_ty,
-                                InterfaceType::Stream(_) | InterfaceType::Future(_)
-                            ),
-                        )
-                    }
-                };
-                let payload_ty_name_js = future_ty
-                    .payload
-                    .map(|iface_ty| format!("'{iface_ty:?}'"))
-                    .unwrap_or_else(|| "null".into());
-
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                      const trampoline{i} = {future_new_fn}.bind(null, {{
-                          componentIdx: {component_idx},
-                          futureTableIdx: {future_table_idx},
-                          elemMeta: {{
-                              liftFn: {payload_lift_fn_js},
-                              lowerFn: {payload_lower_fn_js},
-                              payloadTypeName: {payload_ty_name_js},
-                              isNone: {is_none_type},
-                              isNumeric: {is_numeric_type},
-                              isBorrowed: {is_borrowed},
-                              isAsyncValue: {is_async_value},
-                              flatCount: {payload_flat_count_js},
-                              align32: {payload_align32},
-                              size32: {payload_size32},
-                          }},
-                      }});
-                    "#,
-                );
-            }
-
-            Trampoline::FutureWrite {
-                instance,
-                ty,
-                options,
-            }
-            | Trampoline::FutureRead {
-                instance,
-                ty,
-                options,
-            } => {
-                let intrinsic_fn = match trampoline {
-                    Trampoline::FutureRead { .. } => self
-                        .bindgen
-                        .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureRead)),
-                    Trampoline::FutureWrite { .. } => self
-                        .bindgen
-                        .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureWrite)),
-                    _ => unreachable!("invalid trampoline"),
-                };
-
-                let options = self
-                    .component
-                    .options
-                    .get(*options)
-                    .expect("failed to find options");
-                let CanonicalOptions {
-                    async_,
-                    string_encoding,
-                    callback,
-                    post_return,
-                    data_model:
-                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
-                    ..
-                } = options
-                else {
-                    unreachable!("unexpected memory data model during future intrinsic");
-                };
-
-                assert_eq!(
-                    *instance, options.instance,
-                    "component instances should match"
-                );
-                assert!(
-                    callback.is_none(),
-                    "callback should not be present for future intrinsic"
-                );
-                assert!(
-                    post_return.is_none(),
-                    "post_return should not be present for future intrinsic"
-                );
-
-                let future_table_idx = ty.as_u32();
-                let component_idx = instance.as_u32();
-                let memory_idx = memory
-                    .expect("missing memory idx for future intrinsic")
-                    .as_u32();
-                let (realloc_idx, get_realloc_fn_js) = match realloc {
-                    Some(idx) => (
-                        idx.as_u32().to_string(),
-                        format!("() => realloc{}", idx.as_u32()),
-                    ),
-                    None => ("undefined".into(), "undefined".to_string()),
-                };
-                let string_encoding = string_encoding_js_literal(string_encoding);
-
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                      const trampoline{i} = new WebAssembly.Suspending({intrinsic_fn}.bind(
-                          null,
-                          {{
-                              componentIdx: {component_idx},
-                              memoryIdx: {memory_idx},
-                              getMemoryFn: () => memory{memory_idx},
-                              reallocIdx: {realloc_idx},
-                              getReallocFn: {get_realloc_fn_js},
-                              stringEncoding: {string_encoding},
-                              futureTableIdx: {future_table_idx},
-                              isAsync: {async_},
-                          }},
-                      ));
-                    "#,
-                );
-            }
-
-            Trampoline::FutureCancelRead {
-                instance,
-                ty,
-                async_,
-            }
-            | Trampoline::FutureCancelWrite {
-                instance,
-                ty,
-                async_,
-            } => {
-                let future_cancel_op_fn = match trampoline {
-                    Trampoline::FutureCancelRead { .. } => self.bindgen.intrinsic(
-                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureCancelRead),
-                    ),
-                    Trampoline::FutureCancelWrite { .. } => self.bindgen.intrinsic(
-                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureCancelWrite),
-                    ),
-                    _ => unreachable!(),
-                };
-
-                let component_idx = instance.as_u32();
-                let future_table_idx = ty.as_u32();
-
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                      const trampoline{i} = new WebAssembly.Suspending({future_cancel_op_fn}.bind(
-                          null,
-                          {{
-                              futureTableIdx: {future_table_idx},
-                              componentIdx: {component_idx},
-                              isAsync: {async_},
-                          }},
-                      ));
-                    "#,
-                );
-            }
-
-            Trampoline::FutureDropReadable { instance, ty }
-            | Trampoline::FutureDropWritable { instance, ty } => {
-                let future_drop_op_fn = match trampoline {
-                    Trampoline::FutureDropReadable { .. } => self.bindgen.intrinsic(
-                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureDropReadable),
-                    ),
-                    Trampoline::FutureDropWritable { .. } => self.bindgen.intrinsic(
-                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureDropWritable),
-                    ),
-                    _ => unreachable!(),
-                };
-
-                let component_idx = instance.as_u32();
-                let future_table_idx = ty.as_u32();
-
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                      const trampoline{i} = new WebAssembly.Suspending({future_drop_op_fn}.bind(
-                          null,
-                          {{
-                              futureTableIdx: {future_table_idx},
-                              componentIdx: {component_idx},
-                          }},
-                      ));
-                "#
-                );
-            }
-
-            Trampoline::FutureTransfer => {
-                let future_drop_writable_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureTransfer));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {future_drop_writable_fn};"
-                );
-            }
-
-            Trampoline::ErrorContextNew { ty, options, .. } => {
-                let CanonicalOptions {
-                    instance,
-                    string_encoding,
-                    data_model:
-                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, .. }),
-                    ..
-                } = self
-                    .component
-                    .options
-                    .get(*options)
-                    .expect("failed to find options")
-                else {
-                    panic!("unexpected memory data model during error-context.new");
-                };
-
-                self.ensure_error_context_local_table(*instance, *ty);
-
-                let local_err_tbl_idx = ty.as_u32();
-                let component_idx = instance.as_u32();
-
-                let memory_idx = memory
-                    .expect("missing realloc fn idx for error-context.debug-message")
-                    .as_u32();
-
-                // Generate a string decoding function to match this trampoline that does appropriate encoding
-                let decoder = match string_encoding {
-                    wasmtime_environ::component::StringEncoding::Utf8 => self
-                        .bindgen
-                        .intrinsic(Intrinsic::String(StringIntrinsic::GlobalTextDecoderUtf8)),
-                    wasmtime_environ::component::StringEncoding::Utf16 => self
-                        .bindgen
-                        .intrinsic(Intrinsic::String(StringIntrinsic::Utf16Decoder)),
-                    enc => panic!(
-                        "unsupported string encoding [{enc:?}] for error-context.debug-message"
-                    ),
-                };
-                uwriteln!(
-                    self.src.js,
-                    "function trampoline{i}InputStr(ptr, len) {{
-                         return {decoder}.decode(new DataView(memory{memory_idx}.buffer, ptr, len));
-                    }}"
-                );
-
-                let err_ctx_new_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::ErrCtx(ErrCtxIntrinsic::ErrorContextNew));
-                // Store the options associated with this new error context for later use in the global array
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {err_ctx_new_fn}.bind(
-                         null,
-                         {{
-                             componentIdx: {component_idx},
-                             localTableIdx: {local_err_tbl_idx},
-                             readStrFn: trampoline{i}InputStr,
-                         }}
-                     );
-                    "
-                );
-            }
-
-            Trampoline::ErrorContextDebugMessage {
-                instance, options, ..
-            } => {
-                let CanonicalOptions {
-                    async_,
-                    callback,
-                    post_return,
-                    string_encoding,
-                    data_model:
-                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
-                    ..
-                } = self
-                    .component
-                    .options
-                    .get(*options)
-                    .expect("failed to find options")
-                else {
-                    panic!("unexpected memory data model during error-context.debug-message");
-                };
-
-                let debug_message_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::ErrCtx(ErrCtxIntrinsic::ErrorContextDebugMessage));
-
-                let realloc_fn_idx = realloc
-                    .expect("missing realloc fn idx for error-context.debug-message")
-                    .as_u32();
-                let memory_idx = memory
-                    .expect("missing realloc fn idx for error-context.debug-message")
-                    .as_u32();
-
-                // Generate a string encoding function to match this trampoline that does appropriate encoding
-                match string_encoding {
-                    wasmtime_environ::component::StringEncoding::Utf8 => {
-                        let encode_fn = self
-                            .bindgen
-                            .intrinsic(Intrinsic::String(StringIntrinsic::Utf8Encode));
-                        uwriteln!(
-                            self.src.js,
-                            "function trampoline{i}OutputStr(s, outputPtr) {{
-                                 const memory = memory{memory_idx};
-                                 const reallocFn = realloc{realloc_fn_idx};
-                                 let {{ ptr, len }} = {encode_fn}(s, reallocFn, memory);
-                                 new DataView(memory.buffer).setUint32(outputPtr, ptr, true)
-                                 new DataView(memory.buffer).setUint32(outputPtr + 4, len, true)
-                             }}"
-                        );
-                    }
-                    wasmtime_environ::component::StringEncoding::Utf16 => {
-                        let encode_fn = self
-                            .bindgen
-                            .intrinsic(Intrinsic::String(StringIntrinsic::Utf16Encode));
-                        uwriteln!(
-                            self.src.js,
-                            "function trampoline{i}OutputStr(s, outputPtr) {{
-                                 const memory = memory{memory_idx};
-                                 const reallocFn = realloc{realloc_fn_idx};
-                                 let ptr = {encode_fn}(s, reallocFn, memory);
-                                 let len = s.length;
-                                 new DataView(memory.buffer).setUint32(outputPtr, ptr, true)
-                                 new DataView(memory.buffer).setUint32(outputPtr + 4, len, true)
-                             }}"
-                        );
-                    }
-                    enc => panic!(
-                        "unsupported string encoding [{enc:?}] for error-context.debug-message"
-                    ),
-                };
-
-                let options_obj = format!(
-                    "{{callback:{callback}, postReturn: {post_return}, async: {async_}}}",
-                    callback = callback
-                        .map(|v| v.as_u32().to_string())
-                        .unwrap_or_else(|| "null".into()),
-                    post_return = post_return
-                        .map(|v| v.as_u32().to_string())
-                        .unwrap_or_else(|| "null".into()),
-                );
-
-                let component_idx = instance.as_u32();
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {debug_message_fn}.bind(
-                         null,
-                         {{
-                             componentIdx: {component_idx},
-                             options: {options_obj},
-                             writeStrFn: trampoline{i}OutputStr,
-                         }}
-                     );"
-                );
-            }
-
-            Trampoline::ErrorContextDrop { instance, ty } => {
-                let drop_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::ErrCtx(ErrCtxIntrinsic::ErrorContextDrop));
-                let local_err_tbl_idx = ty.as_u32();
-                let component_idx = instance.as_u32();
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                      const trampoline{i} = {drop_fn}.bind(
-                          null,
-                          {{ componentIdx: {component_idx}, localTableIdx: {local_err_tbl_idx} }},
-                      );
-                    "#
-                );
-            }
-
-            Trampoline::ErrorContextTransfer => {
-                let transfer_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::ErrCtx(ErrCtxIntrinsic::ErrorContextTransfer));
-                uwriteln!(self.src.js, "const trampoline{i} = {transfer_fn};");
-            }
-
-            // This sets up a subtask (sets parent, etc) for guest -> guest calls
-            Trampoline::PrepareCall { memory } => {
-                let prepare_call_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Host(HostIntrinsic::PrepareCall));
-                let (memory_idx_js, memory_fn_js) = memory
-                    .map(|v| {
-                        (
-                            v.as_u32().to_string(),
-                            format!("() => memory{}", v.as_u32()),
-                        )
-                    })
-                    .unwrap_or_else(|| ("null".into(), "() => null".into()));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {prepare_call_fn}.bind(null, {memory_idx_js}, {memory_fn_js});",
-                )
-            }
-
-            Trampoline::SyncStartCall { callback } => {
-                let sync_start_call_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Host(HostIntrinsic::SyncStartCall));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {sync_start_call_fn}.bind(null, {});",
-                    callback
-                        .map(|v| v.as_u32().to_string())
-                        .unwrap_or_else(|| "null".into()),
-                );
-            }
-
-            // This actually starts a Task (whose parent is a subtask generated during PrepareCall)
-            // for a from-component async import call
-            Trampoline::AsyncStartCall {
-                callback,
-                post_return,
-            } => {
-                let async_start_call_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Host(HostIntrinsic::AsyncStartCall));
-                let (callback_idx, callback_fn) = callback
-                    .map(|v| (v.as_u32().to_string(), format!("callback_{}", v.as_u32())))
-                    .unwrap_or_else(|| ("null".into(), "null".into()));
-                let (post_return_idx, post_return_fn) = post_return
-                    .map(|v| (v.as_u32().to_string(), format!("postReturn{}", v.as_u32())))
-                    .unwrap_or_else(|| ("null".into(), "null".into()));
-
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {async_start_call_fn}.bind(
-                         null,
-                         {{
-                             postReturnIdx: {post_return_idx},
-                             getPostReturnFn: () => {post_return_fn},
-                             callbackIdx: {callback_idx},
-                             getCallbackFn: () => {callback_fn},
-                         }},
-                     );",
-                );
-            }
-
-            Trampoline::LowerImport {
-                index: _,
-                lower_ty,
-                options,
-            } => {
-                let canon_opts = self
-                    .component
-                    .options
-                    .get(*options)
-                    .expect("failed to find options");
-
-                // TODO(fix): remove Global lowers, should enable using just exports[x] to export[y] call
-                // TODO(fix): promising for the run (*as well as exports*)
-                // TODO(fix): delete all asyncImports/exports
-                // TODO(opt): opt-in sync import
-
-                let component_idx = canon_opts.instance.as_u32();
-                let is_async = canon_opts.async_;
-
-                let cancellable = canon_opts.cancellable;
-
-                let func_ty = self.types.index(*lower_ty);
-
-                // Build list of lift functions for the params of the lowered import
-                let param_types = &self.types.index(func_ty.params).types;
-                let param_lift_fns_js =
-                    gen_flat_lift_fn_list_js_expr(self, param_types.iter().as_slice(), &None);
-
-                // Build list of lower functions for the results of the lowered import
-                let result_types = &self.types.index(func_ty.results).types;
-                let result_lower_fns_js =
-                    gen_flat_lower_fn_list_js_expr(self, result_types.iter().as_slice(), &None);
-                let result_flat_count = result_types.iter().try_fold(0usize, |count, ty| {
-                    self.types
-                        .canonical_abi(ty)
-                        .flat_count
-                        .map(|flat_count| count + usize::from(flat_count))
-                });
-
-                let get_callback_fn_js = canon_opts
-                    .callback
-                    .map(|idx| format!("() => callback_{}", idx.as_u32()))
-                    .unwrap_or_else(|| "() => null".into());
-                let get_post_return_fn_js = canon_opts
-                    .post_return
-                    .map(|idx| format!("() => postReturn{}", idx.as_u32()))
-                    .unwrap_or_else(|| "() => null".into());
-
-                // Build the memory and realloc js expressions, retrieving the memory index and getter functions
-                let (memory_exprs, realloc_expr_js) =
-                    if let CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions {
-                        memory,
-                        realloc,
-                    }) = canon_opts.data_model
-                    {
-                        (
-                            memory.map(|idx| {
-                                (
-                                    idx.as_u32().to_string(),
-                                    format!("() => memory{}", idx.as_u32()),
-                                )
-                            }),
-                            realloc.map(|idx| format!("() => realloc{}", idx.as_u32())),
-                        )
-                    } else {
-                        (None, None)
-                    };
-                let (memory_idx_js, memory_expr_js) =
-                    memory_exprs.unwrap_or_else(|| ("null".into(), "() => null".into()));
-                let realloc_expr_js = realloc_expr_js.unwrap_or_else(|| "undefined".into());
-                let string_encoding_js = string_encoding_js_literal(&canon_opts.string_encoding);
-
-                // Build the lower import call that will wrap the actual trampoline
-                let func_ty_async = func_ty.async_;
-                let max_direct_results = if is_async || func_ty_async {
-                    0
-                } else {
-                    MAX_FLAT_RESULTS
-                };
-                let has_result_pointer = result_flat_count
-                    .map(|count| count > max_direct_results)
-                    .unwrap_or(true);
-                let call = format!(
-                    r#"{lower_import_intrinsic}.bind(
-                        null,
-                        {{
-                            trampolineIdx: {i},
-                            componentIdx: {component_idx},
-                            isAsync: {is_async},
-                            isManualAsync: _trampoline{i}.manuallyAsync,
-                            paramLiftFns: {param_lift_fns_js},
-                            resultLowerFns: {result_lower_fns_js},
-                            hasResultPointer: {has_result_pointer},
-                            funcTypeIsAsync: {func_ty_async},
-                            getCallbackFn: {get_callback_fn_js},
-                            getPostReturnFn: {get_post_return_fn_js},
-                            isCancellable: {cancellable},
-                            memoryIdx: {memory_idx_js},
-                            stringEncoding: {string_encoding_js},
-                            getMemoryFn: {memory_expr_js},
-                            getReallocFn: {realloc_expr_js},
-                            importFn: _trampoline{i},
-                        }},
-                    )"#,
-                    lower_import_intrinsic = if is_async || func_ty_async {
-                        self.bindgen
-                            .intrinsic(Intrinsic::AsyncTask(AsyncTaskIntrinsic::LowerImport))
-                    } else {
-                        self.bindgen.intrinsic(Intrinsic::AsyncTask(
-                            AsyncTaskIntrinsic::LowerImportBackwardsCompat,
-                        ))
-                    }
-                );
-
-                // NOTE: For Trampoline::LowerImport, the trampoline index is actually already defined,
-                // but we *redefine* it to call the lower import function first.
-                if is_async || func_ty_async {
-                    uwriteln!(
-                        self.src.js,
-                        "let trampoline{i} = new WebAssembly.Suspending({call});"
-                    );
-                } else {
-                    // TODO(breaking): once manually specifying async imports is removed,
-                    // we can avoid the second check below.
-                    uwriteln!(
-                        self.src.js,
-                        "let trampoline{i} = _trampoline{i}.manuallyAsync ? new WebAssembly.Suspending({call}) : {call};"
-                    );
-                }
-            }
-
-            Trampoline::Transcoder {
-                op,
-                from,
-                from64,
-                to,
-                to64,
-            } => {
-                if *from64 || *to64 {
-                    unimplemented!("memory 64 transcoder");
-                }
-                let from = from.as_u32();
-                let to = to.as_u32();
-                match op {
-                    Transcode::Copy(FixedEncoding::Utf8) => {
-                        uwriteln!(
-                            self.src.js,
-                            r#"
-                              function trampoline{i} (from_ptr, len, to_ptr) {{
-                                  new Uint8Array(memory{to}.buffer, to_ptr, len).set(new Uint8Array(memory{from}.buffer, from_ptr, len));
-                              }}
-                            "#
-                        );
-                    }
-                    Transcode::Copy(FixedEncoding::Utf16) => unimplemented!("utf16 copier"),
-                    Transcode::Copy(FixedEncoding::Latin1) => unimplemented!("latin1 copier"),
-                    Transcode::Latin1ToUtf16 => unimplemented!("latin to utf16 transcoder"),
-                    Transcode::Latin1ToUtf8 => unimplemented!("latin to utf8 transcoder"),
-                    Transcode::Utf16ToCompactProbablyUtf16 => {
-                        unimplemented!("utf16 to compact wtf16 transcoder")
-                    }
-                    Transcode::Utf16ToCompactUtf16 => {
-                        unimplemented!("utf16 to compact utf16 transcoder")
-                    }
-                    Transcode::Utf16ToLatin1 => unimplemented!("utf16 to latin1 transcoder"),
-                    Transcode::Utf16ToUtf8 => {
-                        uwriteln!(
-                            self.src.js,
-                            r#"
-                              function trampoline{i} (src, src_len, dst, dst_len) {{
-                                  const encoder = new TextEncoder();
-                                  const {{ read, written }} = encoder.encodeInto(String.fromCharCode.apply(null, new Uint16Array(memory{from}.buffer, src, src_len)), new Uint8Array(memory{to}.buffer, dst, dst_len));
-                                  return [read, written];
-                              }}
-                            "#,
-                        );
-                    }
-                    Transcode::Utf8ToCompactUtf16 => {
-                        unimplemented!("utf8 to compact utf16 transcoder")
-                    }
-                    Transcode::Utf8ToLatin1 => unimplemented!("utf8 to latin1 transcoder"),
-                    Transcode::Utf8ToUtf16 => {
-                        uwriteln!(
-                            self.src.js,
-                            r#"
-                              function trampoline{i} (from_ptr, len, to_ptr) {{
-                                  const decoder = new TextDecoder();
-                                  const content = decoder.decode(new Uint8Array(memory{from}.buffer, from_ptr, len));
-                                  const codeUnits = content.length;
-                                  const view = new Uint16Array(memory{to}.buffer, to_ptr, codeUnits);
-                                  for (var i = 0; i < codeUnits; i++) {{
-                                      view[i] = content.charCodeAt(i);
-                                  }}
-                                  return codeUnits;
-                              }}
-                            "#,
-                        );
-                    }
-                };
-            }
-
-            Trampoline::ResourceNew {
-                ty: resource_ty_idx,
-                ..
-            } => {
-                self.ensure_resource_table(*resource_ty_idx);
-                let rid = resource_ty_idx.as_u32();
-                let rsc_table_create_own = self.bindgen.intrinsic(Intrinsic::Resource(
-                    ResourceIntrinsic::ResourceTableCreateOwn,
-                ));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {rsc_table_create_own}.bind(null, handleTable{rid});"
-                );
-            }
-
-            Trampoline::ResourceRep {
-                ty: resource_ty_idx,
-                ..
-            } => {
-                self.ensure_resource_table(*resource_ty_idx);
-                let rid = resource_ty_idx.as_u32();
-                let rsc_flag = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Resource(ResourceIntrinsic::ResourceTableFlag));
-                uwriteln!(
-                    self.src.js,
-                    "function trampoline{i} (handle) {{
-                        return handleTable{rid}[(handle << 1) + 1] & ~{rsc_flag};
-                    }}"
-                );
-            }
-
-            Trampoline::ResourceDrop {
-                ty: resource_table_ty_idx,
-                ..
-            } => {
-                self.ensure_resource_table(*resource_table_ty_idx);
-                let tid = resource_table_ty_idx.as_u32();
-                let resource_table_ty = &self.types[*resource_table_ty_idx];
-                let resource_ty = resource_table_ty.unwrap_concrete_ty();
-                let rid = resource_ty.as_u32();
-
-                // Build the code fragment that encapsulates calling the destructor
-                let dtor = if let Some(resource_idx) =
-                    self.component.defined_resource_index(resource_ty)
-                {
-                    let resource_def = self
-                        .component
-                        .initializers
-                        .iter()
-                        .find_map(|i| match i {
-                            GlobalInitializer::Resource(r) if r.index == resource_idx => Some(r),
-                            _ => None,
-                        })
-                        .unwrap();
-
-                    // If a destructor index is defined for the resource, call it
-                    if let Some(dtor) = &resource_def.dtor {
-                        format!(
-                            "
-                            {}(handleEntry.rep);",
-                            self.core_def(dtor)
-                        )
-                    } else {
-                        "".into()
-                    }
-                } else {
-                    // Imported resource is one without a defined resource index.
-                    // If it is a captured instance (class instance was created externally so had to
-                    // be assigned a rep), and there is a Symbol.dispose handler, call it explicitly
-                    // for imported resources when the resource is dropped.
-                    // Otherwise if it is an instance without a captured class definition, then
-                    // call the low-level bindgen destructor.
-                    let symbol_dispose = self.bindgen.intrinsic(Intrinsic::SymbolDispose);
-                    let symbol_cabi_dispose = self.bindgen.intrinsic(Intrinsic::SymbolCabiDispose);
-
-                    // previous imports walk should define all imported resources which are accessible
-                    if let Some(imported_resource_local_name) =
-                        self.bindgen.local_names.try_get(resource_ty)
-                    {
-                        format!(
-                                            "
-                            const rsc = captureTable{rid}.get(handleEntry.rep);
-                            if (rsc) {{
-                                if (rsc[{symbol_dispose}]) rsc[{symbol_dispose}]();
-                                captureTable{rid}.delete(handleEntry.rep);
-                            }} else if ({imported_resource_local_name}[{symbol_cabi_dispose}]) {{
-                                {imported_resource_local_name}[{symbol_cabi_dispose}](handleEntry.rep);
-                            }}"
-                                        )
-                    } else {
-                        // If not, then capture / disposal paths are never called
-                        format!(
-                            "throw new TypeError('unreachable trampoline for resource [{:?}]')",
-                            resource_ty
-                        )
-                    }
-                };
-
-                let rsc_table_remove = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Resource(ResourceIntrinsic::ResourceTableRemove));
-                uwrite!(
-                    self.src.js,
-                    "function trampoline{i}(handle) {{
-                        const handleEntry = {rsc_table_remove}(handleTable{tid}, handle);
-                        if (handleEntry.own) {{
-                            {dtor}
-                        }}
-                    }}
-                    ",
-                );
-            }
-
-            Trampoline::ResourceTransferOwn => {
-                let resource_transfer = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Resource(ResourceIntrinsic::ResourceTransferOwn));
-                uwriteln!(self.src.js, "const trampoline{i} = {resource_transfer};");
-            }
-
-            Trampoline::ResourceTransferBorrow => {
-                let resource_transfer =
-                    self.bindgen
-                        .intrinsic(if self.bindgen.opts.valid_lifting_optimization {
-                            Intrinsic::Resource(
-                                ResourceIntrinsic::ResourceTransferBorrowValidLifting,
-                            )
-                        } else {
-                            Intrinsic::Resource(ResourceIntrinsic::ResourceTransferBorrow)
-                        });
-                uwriteln!(self.src.js, "const trampoline{i} = {resource_transfer};");
-            }
-
-            Trampoline::TaskReturn {
-                results, options, ..
-            } => {
-                let canon_opts = self
-                    .component
-                    .options
-                    .get(*options)
-                    .expect("failed to find options");
-                let CanonicalOptions {
-                    instance,
-                    async_,
-                    data_model:
-                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
-                    callback,
-                    post_return,
-                    string_encoding,
-                    ..
-                } = canon_opts
-                else {
-                    unreachable!("unexpected memory data model during task.return");
-                };
-
-                // Validate canonopts
-                if realloc.is_some() && memory.is_none() {
-                    panic!("memory must be present if realloc is");
-                }
-                if *async_ && post_return.is_some() {
-                    panic!("async and post return must not be specified together");
-                }
-                if *async_ && callback.is_none() {
-                    panic!("callback must be specified for async");
-                }
-                if let Some(cb_idx) = callback {
-                    let cb_fn = &self.types[TypeFuncIndex::from_u32(cb_idx.as_u32())];
-                    match self.types[cb_fn.params].types[..] {
-                        [InterfaceType::S32, InterfaceType::S32, InterfaceType::S32] => {}
-                        _ => panic!("unexpected params for async callback fn"),
-                    }
-                    match self.types[cb_fn.results].types[..] {
-                        [InterfaceType::S32] => {}
-                        _ => panic!("unexpected results for async callback fn"),
-                    }
-                }
-
-                let result_types = &self.types[*results].types;
-
-                // Calculate the number of parameters required to represent the results,
-                // and whether they'll be stored in memory
-                let result_flat_param_total: usize = result_types
-                    .iter()
-                    .map(|t| {
-                        self.types
-                            .canonical_abi(t)
-                            .flat_count
-                            .map(usize::from)
-                            .unwrap_or(0)
-                    })
-                    .sum();
-                let use_direct_params = result_flat_param_total < MAX_FLAT_PARAMS;
-
-                // Build up a list of all the lifting functions that will be needed for the types
-                // that are actually being passed through task.return
-                let mut lift_fns: Vec<String> = Vec::with_capacity(result_types.len());
-                for result_ty in result_types {
-                    lift_fns.push(gen_flat_lift_fn_js_expr(self, result_ty, &None));
-                }
-                let lift_fns_js = format!("[{}]", lift_fns.join(","));
-
-                // Build up a list of all the lowering functions that will be needed for the types
-                // that are actually being passed through task.return
-                //
-                // This is usually only necessary if this task is part of a guest->guest async call
-                // (i.e. via prepare & async start call)
-                let mut lower_fns: Vec<String> = Vec::with_capacity(result_types.len());
-                for result_ty in result_types {
-                    lower_fns.push(gen_flat_lower_fn_js_expr(self, result_ty, &None));
-                }
-                let lower_fns_js = format!("[{}]", lower_fns.join(","));
-
-                let get_memory_fn_js = memory
-                    .map(|idx| format!("() => memory{}", idx.as_u32()))
-                    .unwrap_or_else(|| "() => null".into());
-                let memory_idx_js = memory
-                    .map(|idx| idx.as_u32().to_string())
-                    .unwrap_or_else(|| "null".into());
-                let component_idx = instance.as_u32();
-                let task_return_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::AsyncTask(AsyncTaskIntrinsic::TaskReturn));
-                let callback_fn_idx = callback
-                    .map(|v| v.as_u32().to_string())
-                    .unwrap_or_else(|| "null".into());
-                let string_encoding_js = string_encoding_js_literal(string_encoding);
-
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {task_return_fn}.bind(
-                         null,
-                         {{
-                             componentIdx: {component_idx},
-                             useDirectParams: {use_direct_params},
-                             getMemoryFn: {get_memory_fn_js},
-                             memoryIdx: {memory_idx_js},
-                             callbackFnIdx: {callback_fn_idx},
-                             liftFns: {lift_fns_js},
-                             lowerFns: {lower_fns_js},
-                             stringEncoding: {string_encoding_js},
-                         }},
-                     );",
-                );
-            }
-
-            Trampoline::BackpressureInc { instance } => {
-                let backpressure_inc_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Component(ComponentIntrinsic::BackpressureInc));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {backpressure_inc_fn}.bind(null, {instance});\n",
-                    instance = instance.as_u32(),
-                );
-            }
-
-            Trampoline::BackpressureDec { instance } => {
-                let backpressure_dec_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Component(ComponentIntrinsic::BackpressureDec));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {backpressure_dec_fn}.bind(null, {instance});\n",
-                    instance = instance.as_u32(),
-                );
-            }
-
-            Trampoline::ThreadYield {
-                cancellable,
-                instance,
-            } => {
-                let yield_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::AsyncTask(AsyncTaskIntrinsic::Yield));
-                let component_instance_idx = instance.as_u32();
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                      const trampoline{i} = new WebAssembly.Suspending({yield_fn}.bind(null, {{
-                          isCancellable: {cancellable},
-                          componentIdx: {component_instance_idx},
-                      }}));
-                    "#,
-                );
-            }
-            Trampoline::ThreadIndex => todo!("Trampoline::ThreadIndex"),
-            Trampoline::ThreadNewIndirect { .. } => todo!("Trampoline::ThreadNewIndirect"),
-            Trampoline::ThreadSuspend { .. } => todo!("Trampoline::ThreadSuspend"),
-            Trampoline::ThreadSuspendTo { .. } => todo!("Trampoline::ThreadSuspendTo"),
-            Trampoline::ThreadUnsuspend { .. } => todo!("Trampoline::ThreadUnsuspend"),
-            Trampoline::ThreadYieldToSuspended { .. } => {
-                todo!("Trampoline::ThreadYieldToSuspended")
-            }
-            Trampoline::ThreadSuspendToSuspended { .. } => {
-                todo!("Trampoline::ThreadYieldToSuspended")
-            }
-
-            Trampoline::Trap => {
-                uwriteln!(
-                    self.src.js,
-                    "function trampoline{i}(rep) {{ throw new TypeError('Trap'); }}"
-                );
-            }
-
-            Trampoline::EnterSyncCall => {
-                let enter_symmetric_sync_guest_call_fn = self.bindgen.intrinsic(
-                    Intrinsic::AsyncTask(AsyncTaskIntrinsic::EnterSymmetricSyncGuestCall),
-                );
-                // Under JSPI, contended entry queues for the callee's per-slice
-                // exclusive lock by returning a promise, which requires the
-                // trampoline to be Suspending (fused sync calls then run inside
-                // promising activations). Outside JSPI a Suspending import
-                // would trap on every call from the plain (non-promising)
-                // stacks such transpiles use, so the trampoline stays plain
-                // and contended entry traps (uncontended entry is fully
-                // synchronous either way).
-                let uses_jspi = matches!(
-                    self.bindgen.opts.async_mode,
-                    Some(AsyncMode::JavaScriptPromiseIntegration { .. })
-                );
-                if uses_jspi {
-                    uwriteln!(
-                        self.src.js,
-                        r#"
-                          const trampoline{i} = new WebAssembly.Suspending({enter_symmetric_sync_guest_call_fn});
-                        "#,
-                    );
-                } else {
-                    uwriteln!(
-                        self.src.js,
-                        r#"
-                          const trampoline{i} = {enter_symmetric_sync_guest_call_fn};
-                        "#,
-                    );
-                }
-
-            Trampoline::SubtaskDrop { instance } => {
-                let component_idx = instance.as_u32();
-                let subtask_drop_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::AsyncTask(AsyncTaskIntrinsic::SubtaskDrop));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {subtask_drop_fn}.bind(
-                         null,
-                         {component_idx},
-                     );"
-                );
-            }
-
-            Trampoline::WaitableSetNew { instance } => {
-                let waitable_set_new_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Waitable(WaitableIntrinsic::WaitableSetNew));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {waitable_set_new_fn}.bind(null, {});\n",
-                    instance.as_u32(),
-                );
-            }
-
-            Trampoline::WaitableSetWait { instance, options } => {
-                let options = self
-                    .component
-                    .options
-                    .get(*options)
-                    .expect("failed to find options");
-                assert_eq!(
-                    instance.as_u32(),
-                    options.instance.as_u32(),
-                    "options index instance must match trampoline"
-                );
-
-                let CanonicalOptions {
-                    instance,
-                    async_,
-                    data_model:
-                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, .. }),
-                    ..
-                } = options
-                else {
-                    panic!("unexpected/missing memory data model during waitable-set.wait");
-                };
-
-                let instance_idx = instance.as_u32();
-                let memory_idx = memory
-                    .expect("missing memory idx for waitable-set.wait")
-                    .as_u32();
-                let waitable_set_wait_fn = self
-                    .bindgen
-                    .intrinsic(Intrinsic::Waitable(WaitableIntrinsic::WaitableSetWait));
                 let suspending_wrap_fn =
                     self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn);
 
@@ -3535,13 +2044,10 @@ impl<'a> Instantiator<'a, '_> {
             }
 
             Trampoline::FutureTransfer => {
-                let future_drop_writable_fn = self
+                let future_transfer_fn = self
                     .bindgen
                     .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureTransfer));
-                uwriteln!(
-                    self.src.js,
-                    "const trampoline{i} = {future_drop_writable_fn};"
-                );
+                uwriteln!(self.src.js, "const trampoline{i} = {future_transfer_fn};");
             }
 
             Trampoline::ErrorContextNew { ty, options, .. } => {
@@ -3746,12 +2252,22 @@ impl<'a> Instantiator<'a, '_> {
                 let sync_start_call_fn = self
                     .bindgen
                     .intrinsic(Intrinsic::Host(HostIntrinsic::SyncStartCall));
+                let (callback_idx, callback_fn) = callback
+                    .map(|v| (v.as_u32().to_string(), format!("callback_{}", v.as_u32())))
+                    .unwrap_or_else(|| ("null".into(), "null".into()));
+
+                // NOTE: the intrinsic blocks the (sync-lowered) caller until the
+                // async-lifted callee resolves via task.return, so it must be
+                // JSPI-wrapped.
                 uwriteln!(
                     self.src.js,
-                    "const trampoline{i} = {sync_start_call_fn}.bind(null, {});",
-                    callback
-                        .map(|v| v.as_u32().to_string())
-                        .unwrap_or_else(|| "null".into()),
+                    "const trampoline{i} = new WebAssembly.Suspending({sync_start_call_fn}.bind(
+                         null,
+                         {{
+                             callbackIdx: {callback_idx},
+                             getCallbackFn: () => {callback_fn},
+                         }},
+                     ));",
                 );
             }
 
@@ -3975,12 +2491,12 @@ impl<'a> Instantiator<'a, '_> {
                               function trampoline{i} (from_ptr, len, to_ptr) {{
                                   const decoder = new TextDecoder();
                                   const content = decoder.decode(new Uint8Array(memory{from}.buffer, from_ptr, len));
-                                  const strlen = content.length
-                                  const view = new Uint16Array(memory{to}.buffer, to_ptr, strlen * 2)
-                                  for (var i = 0; i < strlen; i++) {{
+                                  const codeUnits = content.length;
+                                  const view = new Uint16Array(memory{to}.buffer, to_ptr, codeUnits);
+                                  for (var i = 0; i < codeUnits; i++) {{
                                       view[i] = content.charCodeAt(i);
                                   }}
-                                  return strlen;
+                                  return codeUnits;
                               }}
                             "#,
                         );
@@ -4299,13 +2815,33 @@ impl<'a> Instantiator<'a, '_> {
                 let enter_symmetric_sync_guest_call_fn = self.bindgen.intrinsic(
                     Intrinsic::AsyncTask(AsyncTaskIntrinsic::EnterSymmetricSyncGuestCall),
                 );
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                      const trampoline{i} = {enter_symmetric_sync_guest_call_fn};
-                    "#,
+                // Under JSPI, contended entry queues for the callee's per-slice
+                // exclusive lock by returning a promise, which requires the
+                // trampoline to be Suspending (fused sync calls then run inside
+                // promising activations). Outside JSPI a Suspending import
+                // would trap on every call from the plain (non-promising)
+                // stacks such transpiles use, so the trampoline stays plain
+                // and contended entry traps (uncontended entry is fully
+                // synchronous either way).
+                let uses_jspi = matches!(
+                    self.bindgen.opts.async_mode,
+                    Some(AsyncMode::JavaScriptPromiseIntegration { .. })
                 );
->>>>>>> theirs (trampoline)
+                if uses_jspi {
+                    uwriteln!(
+                        self.src.js,
+                        r#"
+                          const trampoline{i} = new WebAssembly.Suspending({enter_symmetric_sync_guest_call_fn});
+                        "#,
+                    );
+                } else {
+                    uwriteln!(
+                        self.src.js,
+                        r#"
+                          const trampoline{i} = {enter_symmetric_sync_guest_call_fn};
+                        "#,
+                    );
+                }
             }
 
             Trampoline::ExitSyncCall => {
@@ -6751,6 +5287,153 @@ fn flat_count_js_expr(flat_count: &Option<u8>) -> String {
         .unwrap_or_else(|| "null".into())
 }
 
+/// The Canonical ABI `join` operation over flat core types, used when
+/// computing the flat representation of variant payloads.
+fn join_flat_core_types(a: &'static str, b: &'static str) -> &'static str {
+    if a == b {
+        a
+    } else if (a == "i32" && b == "f32") || (a == "f32" && b == "i32") {
+        "i32"
+    } else {
+        "i64"
+    }
+}
+
+/// Compute the flat core types of a type per the Canonical ABI's
+/// `flatten_type` (32-bit memories), for use in lift/lower metadata.
+///
+/// Returns `None` when the type has no flat representation of at most
+/// [`MAX_FLAT_PARAMS`] core values (such types are passed via memory).
+fn flat_core_types(
+    component_types: &ComponentTypes,
+    ty: &InterfaceType,
+) -> Option<Vec<&'static str>> {
+    component_types
+        .canonical_abi(ty)
+        .flat_count(MAX_FLAT_PARAMS)?;
+    let mut flat = Vec::new();
+    push_flat_core_types(component_types, ty, &mut flat);
+    Some(flat)
+}
+
+/// Compute the join of the flat core types of a group of variant case
+/// payloads, per the Canonical ABI's `flatten_variant` (excluding the
+/// discriminant).
+fn flat_core_types_variant_payload_join<'a>(
+    component_types: &ComponentTypes,
+    cases: impl Iterator<Item = Option<&'a InterfaceType>>,
+) -> Vec<&'static str> {
+    let mut joined: Vec<&'static str> = Vec::new();
+    for maybe_ty in cases {
+        let Some(ty) = maybe_ty else { continue };
+        let mut case_flat = Vec::new();
+        push_flat_core_types(component_types, ty, &mut case_flat);
+        for (idx, flat_ty) in case_flat.into_iter().enumerate() {
+            match joined.get_mut(idx) {
+                Some(existing) => {
+                    *existing = join_flat_core_types(existing, flat_ty);
+                }
+                None => joined.push(flat_ty),
+            }
+        }
+    }
+    joined
+}
+
+fn push_flat_core_types(
+    component_types: &ComponentTypes,
+    ty: &InterfaceType,
+    flat: &mut Vec<&'static str>,
+) {
+    match ty {
+        InterfaceType::Bool
+        | InterfaceType::S8
+        | InterfaceType::U8
+        | InterfaceType::S16
+        | InterfaceType::U16
+        | InterfaceType::S32
+        | InterfaceType::U32
+        | InterfaceType::Char
+        | InterfaceType::Flags(_)
+        | InterfaceType::Enum(_)
+        | InterfaceType::Own(_)
+        | InterfaceType::Borrow(_)
+        | InterfaceType::Future(_)
+        | InterfaceType::Stream(_)
+        | InterfaceType::ErrorContext(_) => flat.push("i32"),
+
+        InterfaceType::S64 | InterfaceType::U64 => flat.push("i64"),
+
+        InterfaceType::Float32 => flat.push("f32"),
+        InterfaceType::Float64 => flat.push("f64"),
+
+        InterfaceType::String | InterfaceType::List(_) | InterfaceType::Map(_) => {
+            flat.push("i32");
+            flat.push("i32");
+        }
+
+        InterfaceType::Record(ty_idx) => {
+            for field in &component_types[*ty_idx].fields {
+                push_flat_core_types(component_types, &field.ty, flat);
+            }
+        }
+
+        InterfaceType::Tuple(ty_idx) => {
+            for ty in &component_types[*ty_idx].types {
+                push_flat_core_types(component_types, ty, flat);
+            }
+        }
+
+        InterfaceType::FixedLengthList(ty_idx) => {
+            let list_ty = &component_types[*ty_idx];
+            for _ in 0..list_ty.size {
+                push_flat_core_types(component_types, &list_ty.element, flat);
+            }
+        }
+
+        InterfaceType::Variant(ty_idx) => {
+            let variant_ty = &component_types[*ty_idx];
+            flat.push("i32");
+            flat.extend(flat_core_types_variant_payload_join(
+                component_types,
+                variant_ty.cases.iter().map(|(_, ty)| ty.as_ref()),
+            ));
+        }
+
+        InterfaceType::Option(ty_idx) => {
+            let option_ty = &component_types[*ty_idx];
+            flat.push("i32");
+            flat.extend(flat_core_types_variant_payload_join(
+                component_types,
+                [None, Some(&option_ty.ty)].into_iter(),
+            ));
+        }
+
+        InterfaceType::Result(ty_idx) => {
+            let result_ty = &component_types[*ty_idx];
+            flat.push("i32");
+            flat.extend(flat_core_types_variant_payload_join(
+                component_types,
+                [result_ty.ok.as_ref(), result_ty.err.as_ref()].into_iter(),
+            ));
+        }
+    }
+}
+
+/// Render a (possibly missing) flat core type list as a JS expression
+fn flat_core_types_js_expr(flat: &Option<Vec<&'static str>>) -> String {
+    match flat {
+        Some(flat) => format!(
+            "[{}]",
+            flat.iter()
+                .map(|t| format!("'{t}'"))
+                .collect::<Vec<_>>()
+                .join(",")
+        ),
+        None => "null".into(),
+    }
+}
+
 /// Generate the javascript lifting function for a given type
 ///
 /// This function will a function object that can be executed with the right
@@ -6886,27 +5569,38 @@ pub fn gen_flat_lift_fn_js_expr(
             let variant_size32 = variant_ty.abi.size32;
             let variant_align32 = variant_ty.abi.align32;
             let variant_payload_offset32 = variant_ty.info.payload_offset32;
+            let variant_payload_flat_types = flat_core_types_js_expr(
+                &flat_core_types(component_types, ty).map(|flat| flat[1..].to_vec()),
+            );
 
             let mut lift_metas_expr = String::from("[");
             for (name, maybe_ty) in &variant_ty.cases {
-                let (lift_fn_js, case_size32, case_align32, case_flat_count) = match maybe_ty {
-                    Some(ty) => {
-                        let cabi_info = component_types.canonical_abi(ty);
-                        (
-                            gen_flat_lift_fn_js_expr(instantiator, ty, extra_resource_map),
-                            cabi_info.size32.to_string(),
-                            cabi_info.align32.to_string(),
-                            cabi_info
-                                .flat_count(MAX_FLAT_PARAMS)
-                                .map(|v| v.to_string())
-                                .unwrap_or_else(|| "null".into()),
-                        )
-                    }
-                    None => ("null".into(), "0".into(), "0".into(), "0".into()),
-                };
+                let (lift_fn_js, case_size32, case_align32, case_flat_count, case_flat_types) =
+                    match maybe_ty {
+                        Some(ty) => {
+                            let cabi_info = component_types.canonical_abi(ty);
+                            (
+                                gen_flat_lift_fn_js_expr(instantiator, ty, extra_resource_map),
+                                cabi_info.size32.to_string(),
+                                cabi_info.align32.to_string(),
+                                cabi_info
+                                    .flat_count(MAX_FLAT_PARAMS)
+                                    .map(|v| v.to_string())
+                                    .unwrap_or_else(|| "null".into()),
+                                flat_core_types_js_expr(&flat_core_types(component_types, ty)),
+                            )
+                        }
+                        None => (
+                            "null".into(),
+                            "0".into(),
+                            "0".into(),
+                            "0".into(),
+                            "[]".into(),
+                        ),
+                    };
 
                 lift_metas_expr.push_str(&format!(
-                    "['{name}', {lift_fn_js}, {case_size32}, {case_align32}, {case_flat_count}],",
+                    "['{name}', {lift_fn_js}, {case_size32}, {case_align32}, {case_flat_count}, {case_flat_types}],",
                 ));
             }
             lift_metas_expr.push(']');
@@ -6918,6 +5612,7 @@ pub fn gen_flat_lift_fn_js_expr(
                      variantAlign32: {variant_align32},
                      variantPayloadOffset32: {variant_payload_offset32},
                      variantFlatCount: {variant_flat_count},
+                     variantPayloadFlatTypes: {variant_payload_flat_types},
                  }} )"
             )
         }
@@ -7056,11 +5751,16 @@ pub fn gen_flat_lift_fn_js_expr(
             let option_align32 = option_ty.abi.align32;
             let option_size32 = option_ty.abi.size32;
             let option_flat_count = flat_count_js_expr(&option_ty.abi.flat_count);
+            let option_payload_flat_types = flat_core_types_js_expr(
+                &flat_core_types(component_types, ty).map(|flat| flat[1..].to_vec()),
+            );
 
             let some_ty_abi = component_types.canonical_abi(&option_ty.ty);
             let some_ty_flat_count = flat_count_js_expr(&some_ty_abi.flat_count);
             let some_ty_size32 = some_ty_abi.size32;
             let some_ty_align32 = some_ty_abi.align32;
+            let some_ty_flat_types =
+                flat_core_types_js_expr(&flat_core_types(component_types, &option_ty.ty));
             let some_ty_lift_fn_js =
                 gen_flat_lift_fn_js_expr(instantiator, &option_ty.ty, extra_resource_map);
 
@@ -7068,13 +5768,14 @@ pub fn gen_flat_lift_fn_js_expr(
                 r#"
                 {f}({{
                     caseMetas: [
-                        ['none', null, 0, 0, 0 ],
-                        ['some', {some_ty_lift_fn_js}, {some_ty_size32}, {some_ty_align32}, {some_ty_flat_count} ],
+                        ['none', null, 0, 0, 0, [] ],
+                        ['some', {some_ty_lift_fn_js}, {some_ty_size32}, {some_ty_align32}, {some_ty_flat_count}, {some_ty_flat_types} ],
                     ],
                     variantSize32: {option_size32},
                     variantAlign32: {option_align32},
                     variantPayloadOffset32: {option_payload_offset32},
                     variantFlatCount: {option_flat_count},
+                    variantPayloadFlatTypes: {option_payload_flat_types},
                 }})
                 "#
             )
@@ -7088,6 +5789,9 @@ pub fn gen_flat_lift_fn_js_expr(
             let result_align32 = result_ty.abi.align32;
             let result_payload_offset32 = result_ty.info.payload_offset32;
             let result_flat_count = flat_count_js_expr(&result_ty.abi.flat_count);
+            let result_payload_flat_types = flat_core_types_js_expr(
+                &flat_core_types(component_types, ty).map(|flat| flat[1..].to_vec()),
+            );
 
             let mut cases_and_lifts_expr = String::from("[");
             if let Some(ok_ty) = result_ty.ok {
@@ -7095,13 +5799,15 @@ pub fn gen_flat_lift_fn_js_expr(
                 let ok_ty_size32 = ok_ty_abi.size32;
                 let ok_ty_align32 = ok_ty_abi.align32;
                 let ok_flat_count = flat_count_js_expr(&ok_ty_abi.flat_count);
+                let ok_ty_flat_types =
+                    flat_core_types_js_expr(&flat_core_types(component_types, &ok_ty));
                 let ok_ty_lift_fn =
                     gen_flat_lift_fn_js_expr(instantiator, &ok_ty, extra_resource_map);
                 cases_and_lifts_expr.push_str(&format!(
-                    "['ok', {ok_ty_lift_fn}, {ok_ty_size32}, {ok_ty_align32}, {ok_flat_count}],",
+                    "['ok', {ok_ty_lift_fn}, {ok_ty_size32}, {ok_ty_align32}, {ok_flat_count}, {ok_ty_flat_types}],",
                 ))
             } else {
-                cases_and_lifts_expr.push_str("['ok', null, 0, 0, 0],");
+                cases_and_lifts_expr.push_str("['ok', null, 0, 0, 0, []],");
             }
 
             if let Some(err_ty) = &result_ty.err {
@@ -7109,13 +5815,15 @@ pub fn gen_flat_lift_fn_js_expr(
                 let err_ty_size32 = err_ty_abi.size32;
                 let err_ty_align32 = err_ty_abi.align32;
                 let err_ty_flat_count = flat_count_js_expr(&err_ty_abi.flat_count);
+                let err_ty_flat_types =
+                    flat_core_types_js_expr(&flat_core_types(component_types, err_ty));
                 let err_ty_lift_fn =
                     gen_flat_lift_fn_js_expr(instantiator, err_ty, extra_resource_map);
                 cases_and_lifts_expr.push_str(&format!(
-                    "['err', {err_ty_lift_fn}, {err_ty_size32}, {err_ty_align32}, {err_ty_flat_count}],",
+                    "['err', {err_ty_lift_fn}, {err_ty_size32}, {err_ty_align32}, {err_ty_flat_count}, {err_ty_flat_types}],",
                 ))
             } else {
-                cases_and_lifts_expr.push_str("['err', null, 0, 0, 0],");
+                cases_and_lifts_expr.push_str("['err', null, 0, 0, 0, []],");
             }
             cases_and_lifts_expr.push(']');
 
@@ -7127,6 +5835,7 @@ pub fn gen_flat_lift_fn_js_expr(
                       variantAlign32: {result_align32},
                       variantPayloadOffset32: {result_payload_offset32},
                       variantFlatCount: {result_flat_count},
+                      variantPayloadFlatTypes: {result_payload_flat_types},
                   }})
                 "#
             )

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -1315,12 +1315,14 @@ impl<'a> Instantiator<'a, '_> {
                 let subtask_cancel_fn = self
                     .bindgen
                     .intrinsic(Intrinsic::AsyncTask(AsyncTaskIntrinsic::SubtaskCancel));
+                let suspending_wrap_fn =
+                    self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn);
                 // NOTE: core wasm passes the subtask handle as the remaining argument.
                 // The intrinsic is async (a sync-lowered cancel may need to block until
                 // the subtask resolves), so it must be JSPI-wrapped.
                 uwriteln!(
                     self.src.js,
-                    "const trampoline{i} = new WebAssembly.Suspending({subtask_cancel_fn}.bind(null, {instance_idx}, {async_}));\n",
+                    "const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({instance_idx}, {subtask_cancel_fn}.bind(null, {instance_idx}, {async_})));\n",
                     instance_idx = instance.as_u32(),
                 );
             }
@@ -2815,6 +2817,1495 @@ impl<'a> Instantiator<'a, '_> {
                         "#,
                     );
                 }
+
+            Trampoline::SubtaskDrop { instance } => {
+                let component_idx = instance.as_u32();
+                let subtask_drop_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::AsyncTask(AsyncTaskIntrinsic::SubtaskDrop));
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {subtask_drop_fn}.bind(
+                         null,
+                         {component_idx},
+                     );"
+                );
+            }
+
+            Trampoline::WaitableSetNew { instance } => {
+                let waitable_set_new_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Waitable(WaitableIntrinsic::WaitableSetNew));
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {waitable_set_new_fn}.bind(null, {});\n",
+                    instance.as_u32(),
+                );
+            }
+
+            Trampoline::WaitableSetWait { instance, options } => {
+                let options = self
+                    .component
+                    .options
+                    .get(*options)
+                    .expect("failed to find options");
+                assert_eq!(
+                    instance.as_u32(),
+                    options.instance.as_u32(),
+                    "options index instance must match trampoline"
+                );
+
+                let CanonicalOptions {
+                    instance,
+                    async_,
+                    data_model:
+                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, .. }),
+                    ..
+                } = options
+                else {
+                    panic!("unexpected/missing memory data model during waitable-set.wait");
+                };
+
+                let instance_idx = instance.as_u32();
+                let memory_idx = memory
+                    .expect("missing memory idx for waitable-set.wait")
+                    .as_u32();
+                let waitable_set_wait_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Waitable(WaitableIntrinsic::WaitableSetWait));
+                let suspending_wrap_fn =
+                    self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn);
+
+                uwriteln!(
+                    self.src.js,
+                    r#"
+                    const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({instance_idx}, {waitable_set_wait_fn}.bind(null, {{
+                        componentIdx: {instance_idx},
+                        isAsync: {async_},
+                        memoryIdx: {memory_idx},
+                        getMemoryFn: () => memory{memory_idx},
+                    }})));
+                    "#,
+                );
+            }
+
+            Trampoline::WaitableSetPoll { options, .. } => {
+                let CanonicalOptions {
+                    instance,
+                    async_,
+                    data_model:
+                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, .. }),
+                    cancellable,
+                    ..
+                } = self
+                    .component
+                    .options
+                    .get(*options)
+                    .expect("failed to find options")
+                else {
+                    panic!("unexpected memory data model during waitable-set.poll");
+                };
+
+                let instance_idx = instance.as_u32();
+                let memory_idx = memory
+                    .expect("missing memory idx for waitable-set.poll")
+                    .as_u32();
+                let waitable_set_poll_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Waitable(WaitableIntrinsic::WaitableSetPoll));
+
+                uwriteln!(
+                    self.src.js,
+                    r#"
+                    const trampoline{i} = {waitable_set_poll_fn}.bind(
+                        null,
+                        {{
+                            componentIdx: {instance_idx},
+                            isAsync: {async_},
+                            isCancellable: {cancellable},
+                            memoryIdx: {memory_idx},
+                            getMemoryFn: () => memory{memory_idx},
+                        }}
+                    );
+                    "#,
+                );
+            }
+
+            Trampoline::WaitableSetDrop { instance } => {
+                let waitable_set_drop_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Waitable(WaitableIntrinsic::WaitableSetDrop));
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {waitable_set_drop_fn}.bind(null, {instance_idx});\n",
+                    instance_idx = instance.as_u32(),
+                );
+            }
+
+            Trampoline::WaitableJoin { instance } => {
+                let waitable_join_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Waitable(WaitableIntrinsic::WaitableJoin));
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {waitable_join_fn}.bind(null, {instance_idx});\n",
+                    instance_idx = instance.as_u32(),
+                );
+            }
+
+            Trampoline::StreamNew { ty, instance } => {
+                let stream_new_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamNew));
+                let instance_idx = instance.as_u32();
+                let stream_table_idx = ty.as_u32();
+
+                // Get to the payload type for the given stream table idx
+                let table_ty = &self.types[*ty];
+                let stream_ty_idx = table_ty.ty;
+                let stream_ty = &self.types[stream_ty_idx];
+
+                // TODO(???): do we have no way to go from interface type to in-component type idx?
+                // TODO(???): does this work under type aliases?? we need the type def?
+                // TODO(???): can the stream type be treated as a unique indicator of the payload type? maybe not?
+                // need a way to go from iface type + stream type -> payload type idx?
+                let payload_ty_name_js = stream_ty
+                    .payload
+                    .map(|iface_ty| format!("'{iface_ty:?}'"))
+                    .unwrap_or_else(|| "null".into());
+
+                // Gather type metadata
+                let (
+                    align_32_js,
+                    size_32_js,
+                    flat_count_js,
+                    lift_fn_js,
+                    lower_fn_js,
+                    is_none_js,
+                    is_numeric_type_js,
+                    is_borrow_js,
+                    is_async_value_js,
+                    typed_array_js,
+                ) = match stream_ty.payload {
+                    // If there is no payload for the stream, we know the values
+                    None => (
+                        "0".into(),
+                        "0".into(),
+                        "0".into(),
+                        "null".into(),
+                        "null".into(),
+                        "true",
+                        "false".into(),
+                        "false".into(),
+                        "false".into(),
+                        "undefined",
+                    ),
+                    // If there is a payload, generate relevant lift/lower and other metadata
+                    Some(ty) => (
+                        self.types.canonical_abi(&ty).align32.to_string(),
+                        self.types.canonical_abi(&ty).size32.to_string(),
+                        self.types
+                            .canonical_abi(&ty)
+                            .flat_count
+                            .map(|v| v.to_string())
+                            .unwrap_or_else(|| "null".into()),
+                        gen_flat_lift_fn_js_expr(self, &ty, &None),
+                        gen_flat_lower_fn_js_expr(self, &ty, &None),
+                        "false",
+                        format!(
+                            "{}",
+                            matches!(
+                                ty,
+                                InterfaceType::U8
+                                    | InterfaceType::U16
+                                    | InterfaceType::U32
+                                    | InterfaceType::U64
+                                    | InterfaceType::S8
+                                    | InterfaceType::S16
+                                    | InterfaceType::S32
+                                    | InterfaceType::S64
+                                    | InterfaceType::Float32
+                                    | InterfaceType::Float64
+                            )
+                        ),
+                        format!("{}", matches!(ty, InterfaceType::Borrow(_))),
+                        format!(
+                            "{}",
+                            matches!(ty, InterfaceType::Stream(_) | InterfaceType::Future(_))
+                        ),
+                        js_typed_array_ctor(&ty).unwrap_or("undefined"),
+                    ),
+                };
+
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {stream_new_fn}.bind(null, {{
+                        streamTableIdx: {stream_table_idx},
+                        callerComponentIdx: {instance_idx},
+                        elemMeta: {{
+                            liftFn: {lift_fn_js},
+                            lowerFn: {lower_fn_js},
+                            payloadTypeName: {payload_ty_name_js},
+                            isNone: {is_none_js},
+                            isNumeric: {is_numeric_type_js},
+                            isBorrowed: {is_borrow_js},
+                            isAsyncValue: {is_async_value_js},
+                            typedArray: {typed_array_js},
+                            flatCount: {flat_count_js},
+                            align32: {align_32_js},
+                            size32: {size_32_js},
+                        }},
+                    }});\n",
+                );
+            }
+
+            Trampoline::StreamRead {
+                instance,
+                ty,
+                options,
+            } => {
+                let options = self
+                    .component
+                    .options
+                    .get(*options)
+                    .expect("failed to find options");
+                assert_eq!(
+                    instance.as_u32(),
+                    options.instance.as_u32(),
+                    "options index instance must match trampoline"
+                );
+
+                let CanonicalOptions {
+                    instance,
+                    string_encoding,
+                    async_,
+                    data_model:
+                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
+                    ..
+                } = options
+                else {
+                    unreachable!("missing/invalid data model for options during stream.read")
+                };
+                let memory_idx = memory.expect("missing memory idx for stream.read").as_u32();
+                let (realloc_idx, get_realloc_fn_js) = match realloc {
+                    Some(v) => {
+                        let v = v.as_u32().to_string();
+                        (v.to_string(), format!("() => realloc{v}"))
+                    }
+                    None => ("undefined".into(), "undefined".into()),
+                };
+
+                let component_instance_id = instance.as_u32();
+                let string_encoding = string_encoding_js_literal(string_encoding);
+                let stream_table_idx = ty.as_u32();
+                let stream_read_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamRead));
+
+                // PrepareCall for an async call is sometimes missing memories,
+                // so we augment and save here, knowing that any stream.write/read operation
+                // that uses a memory is indicative of that component's memory
+                //
+                let register_global_memory_for_component_fn =
+                    Intrinsic::RegisterGlobalMemoryForComponent.name();
+                uwriteln!(
+                    self.src.js_init,
+                    r#"{register_global_memory_for_component_fn}({{
+                         componentIdx: {component_instance_id},
+                         memoryIdx: {memory_idx},
+                         memory: memory{memory_idx},
+                     }});"#
+                );
+
+                uwriteln!(
+                    self.src.js,
+                    r#"const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_instance_id}, {stream_read_fn}.bind(
+                         null,
+                         {{
+                             componentIdx: {component_instance_id},
+                             memoryIdx: {memory_idx},
+                             getMemoryFn: () => memory{memory_idx},
+                             reallocIdx: {realloc_idx},
+                             getReallocFn: {get_realloc_fn_js},
+                             stringEncoding: {string_encoding},
+                             isAsync: {async_},
+                             streamTableIdx: {stream_table_idx},
+                         }}
+                     )));
+                    "#,
+                    suspending_wrap_fn =
+                        self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn),
+                );
+            }
+
+            Trampoline::StreamWrite {
+                instance,
+                ty,
+                options,
+            } => {
+                let options = self
+                    .component
+                    .options
+                    .get(*options)
+                    .expect("failed to find options");
+                assert_eq!(
+                    instance.as_u32(),
+                    options.instance.as_u32(),
+                    "options index instance must match trampoline"
+                );
+
+                let CanonicalOptions {
+                    instance,
+                    string_encoding,
+                    async_,
+                    data_model:
+                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
+                    ..
+                } = options
+                else {
+                    unreachable!("unexpected memory data model during stream.write");
+                };
+                let component_instance_id = instance.as_u32();
+                let memory_idx = memory
+                    .expect("missing memory idx for stream.write")
+                    .as_u32();
+                let (realloc_idx, get_realloc_fn_js) = match realloc {
+                    Some(v) => {
+                        let v = v.as_u32().to_string();
+                        (v.to_string(), format!("() => realloc{v}"))
+                    }
+                    None => ("undefined".into(), "undefined".into()),
+                };
+
+                let string_encoding = string_encoding_js_literal(string_encoding);
+                let stream_table_idx = ty.as_u32();
+                let stream_write_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamWrite));
+
+                // PrepareCall for an async call is sometimes missing memories,
+                // so we augment and save here, knowing that any stream.write/read operation
+                // that uses a memory is indicative of that component's memory
+                let register_global_memory_for_component_fn =
+                    Intrinsic::RegisterGlobalMemoryForComponent.name();
+                uwriteln!(
+                    self.src.js_init,
+                    r#"{register_global_memory_for_component_fn}({{
+                         componentIdx: {component_instance_id},
+                         memoryIdx: {memory_idx},
+                         memory: memory{memory_idx},
+                     }});"#
+                );
+
+                uwriteln!(
+                    self.src.js,
+                    r#"
+                     const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_instance_id}, {stream_write_fn}.bind(
+                         null,
+                         {{
+                             componentIdx: {component_instance_id},
+                             memoryIdx: {memory_idx},
+                             getMemoryFn: () => memory{memory_idx},
+                             reallocIdx: {realloc_idx},
+                             getReallocFn: {get_realloc_fn_js},
+                             stringEncoding: {string_encoding},
+                             isAsync: {async_},
+                             streamTableIdx: {stream_table_idx},
+                         }}
+                     )));
+                    "#,
+                    suspending_wrap_fn =
+                        self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn),
+                );
+            }
+
+            Trampoline::StreamCancelRead {
+                instance,
+                ty,
+                async_,
+            }
+            | Trampoline::StreamCancelWrite {
+                instance,
+                ty,
+                async_,
+            } => {
+                let stream_cancel_fn = match trampoline {
+                    Trampoline::StreamCancelRead { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamCancelRead),
+                    ),
+                    Trampoline::StreamCancelWrite { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamCancelWrite),
+                    ),
+                    _ => unreachable!("unexpected trampoline"),
+                };
+
+                let stream_table_idx = ty.as_u32();
+                let component_idx = instance.as_u32();
+                uwriteln!(
+                    self.src.js,
+                    r#"
+                      const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_idx}, {stream_cancel_fn}.bind(null, {{
+                          streamTableIdx: {stream_table_idx},
+                          isAsync: {async_},
+                          componentIdx: {component_idx},
+                      }})));
+                    "#,
+                    suspending_wrap_fn =
+                        self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn),
+                );
+            }
+
+            Trampoline::StreamDropReadable { ty, instance }
+            | Trampoline::StreamDropWritable { ty, instance } => {
+                let intrinsic_fn = match trampoline {
+                    Trampoline::StreamDropReadable { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamDropReadable),
+                    ),
+                    Trampoline::StreamDropWritable { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamDropWritable),
+                    ),
+                    _ => unreachable!("unexpected trampoline"),
+                };
+                let stream_idx = ty.as_u32();
+                let instance_idx = instance.as_u32();
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {intrinsic_fn}.bind(null, {{
+                        streamTableIdx: {stream_idx},
+                        componentIdx: {instance_idx},
+                    }});\n",
+                );
+            }
+
+            Trampoline::StreamTransfer => {
+                let stream_transfer_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::AsyncStream(AsyncStreamIntrinsic::StreamTransfer));
+                uwriteln!(self.src.js, "const trampoline{i} = {stream_transfer_fn};\n",);
+            }
+
+            Trampoline::FutureNew { instance, ty } => {
+                let future_new_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureNew));
+                let future_table_idx = ty.as_u32();
+                let component_idx = instance.as_u32();
+
+                // Build element metadata
+                let future_table_ty = &self.types[*ty];
+                let future_ty = &self.types[future_table_ty.ty];
+                let (
+                    payload_size32,
+                    payload_align32,
+                    payload_flat_count_js,
+                    payload_lift_fn_js,
+                    payload_lower_fn_js,
+                    is_borrowed,
+                    is_none_type,
+                    is_numeric_type,
+                    is_async_value,
+                ) = match future_ty.payload {
+                    None => (
+                        0,
+                        0,
+                        "0".into(),
+                        "() => {{ throw new Error('empty future payload'); }}".into(),
+                        "() => {{ throw new Error('empty future payload'); }}".into(),
+                        false,
+                        true,
+                        false,
+                        false,
+                    ),
+                    Some(payload_ty) => {
+                        let cabi = self.types.canonical_abi(&payload_ty);
+                        (
+                            cabi.size32,
+                            cabi.align32,
+                            cabi.flat_count
+                                .map(|v| format!("{v}"))
+                                .unwrap_or_else(|| "null".into()),
+                            gen_flat_lift_fn_js_expr(self, &payload_ty, &None),
+                            gen_flat_lower_fn_js_expr(self, &payload_ty, &None),
+                            matches!(payload_ty, InterfaceType::Borrow(_)),
+                            false,
+                            matches!(
+                                payload_ty,
+                                InterfaceType::U8
+                                    | InterfaceType::U16
+                                    | InterfaceType::U32
+                                    | InterfaceType::U64
+                                    | InterfaceType::S8
+                                    | InterfaceType::S16
+                                    | InterfaceType::S32
+                                    | InterfaceType::S64
+                                    | InterfaceType::Float32
+                                    | InterfaceType::Float64
+                            ),
+                            matches!(
+                                payload_ty,
+                                InterfaceType::Stream(_) | InterfaceType::Future(_)
+                            ),
+                        )
+                    }
+                };
+                let payload_ty_name_js = future_ty
+                    .payload
+                    .map(|iface_ty| format!("'{iface_ty:?}'"))
+                    .unwrap_or_else(|| "null".into());
+
+                uwriteln!(
+                    self.src.js,
+                    r#"
+                      const trampoline{i} = {future_new_fn}.bind(null, {{
+                          componentIdx: {component_idx},
+                          futureTableIdx: {future_table_idx},
+                          elemMeta: {{
+                              liftFn: {payload_lift_fn_js},
+                              lowerFn: {payload_lower_fn_js},
+                              payloadTypeName: {payload_ty_name_js},
+                              isNone: {is_none_type},
+                              isNumeric: {is_numeric_type},
+                              isBorrowed: {is_borrowed},
+                              isAsyncValue: {is_async_value},
+                              flatCount: {payload_flat_count_js},
+                              align32: {payload_align32},
+                              size32: {payload_size32},
+                          }},
+                      }});
+                    "#,
+                );
+            }
+
+            Trampoline::FutureWrite {
+                instance,
+                ty,
+                options,
+            }
+            | Trampoline::FutureRead {
+                instance,
+                ty,
+                options,
+            } => {
+                let intrinsic_fn = match trampoline {
+                    Trampoline::FutureRead { .. } => self
+                        .bindgen
+                        .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureRead)),
+                    Trampoline::FutureWrite { .. } => self
+                        .bindgen
+                        .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureWrite)),
+                    _ => unreachable!("invalid trampoline"),
+                };
+
+                let options = self
+                    .component
+                    .options
+                    .get(*options)
+                    .expect("failed to find options");
+                let CanonicalOptions {
+                    async_,
+                    string_encoding,
+                    callback,
+                    post_return,
+                    data_model:
+                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
+                    ..
+                } = options
+                else {
+                    unreachable!("unexpected memory data model during future intrinsic");
+                };
+
+                assert_eq!(
+                    *instance, options.instance,
+                    "component instances should match"
+                );
+                assert!(
+                    callback.is_none(),
+                    "callback should not be present for future intrinsic"
+                );
+                assert!(
+                    post_return.is_none(),
+                    "post_return should not be present for future intrinsic"
+                );
+
+                let future_table_idx = ty.as_u32();
+                let component_idx = instance.as_u32();
+                let memory_idx = memory
+                    .expect("missing memory idx for future intrinsic")
+                    .as_u32();
+                let (realloc_idx, get_realloc_fn_js) = match realloc {
+                    Some(idx) => (
+                        idx.as_u32().to_string(),
+                        format!("() => realloc{}", idx.as_u32()),
+                    ),
+                    None => ("undefined".into(), "undefined".to_string()),
+                };
+                let string_encoding = string_encoding_js_literal(string_encoding);
+
+                uwriteln!(
+                    self.src.js,
+                    r#"
+                      const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_idx}, {intrinsic_fn}.bind(
+                          null,
+                          {{
+                              componentIdx: {component_idx},
+                              memoryIdx: {memory_idx},
+                              getMemoryFn: () => memory{memory_idx},
+                              reallocIdx: {realloc_idx},
+                              getReallocFn: {get_realloc_fn_js},
+                              stringEncoding: {string_encoding},
+                              futureTableIdx: {future_table_idx},
+                              isAsync: {async_},
+                          }},
+                      )));
+                    "#,
+                    suspending_wrap_fn =
+                        self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn),
+                );
+            }
+
+            Trampoline::FutureCancelRead {
+                instance,
+                ty,
+                async_,
+            }
+            | Trampoline::FutureCancelWrite {
+                instance,
+                ty,
+                async_,
+            } => {
+                let future_cancel_op_fn = match trampoline {
+                    Trampoline::FutureCancelRead { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureCancelRead),
+                    ),
+                    Trampoline::FutureCancelWrite { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureCancelWrite),
+                    ),
+                    _ => unreachable!(),
+                };
+
+                let component_idx = instance.as_u32();
+                let future_table_idx = ty.as_u32();
+
+                uwriteln!(
+                    self.src.js,
+                    r#"
+                      const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_idx}, {future_cancel_op_fn}.bind(
+                          null,
+                          {{
+                              futureTableIdx: {future_table_idx},
+                              componentIdx: {component_idx},
+                              isAsync: {async_},
+                          }},
+                      )));
+                    "#,
+                    suspending_wrap_fn =
+                        self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn),
+                );
+            }
+
+            Trampoline::FutureDropReadable { instance, ty }
+            | Trampoline::FutureDropWritable { instance, ty } => {
+                let future_drop_op_fn = match trampoline {
+                    Trampoline::FutureDropReadable { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureDropReadable),
+                    ),
+                    Trampoline::FutureDropWritable { .. } => self.bindgen.intrinsic(
+                        Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureDropWritable),
+                    ),
+                    _ => unreachable!(),
+                };
+
+                let component_idx = instance.as_u32();
+                let future_table_idx = ty.as_u32();
+
+                uwriteln!(
+                    self.src.js,
+                    r#"
+                      const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_idx}, {future_drop_op_fn}.bind(
+                          null,
+                          {{
+                              futureTableIdx: {future_table_idx},
+                              componentIdx: {component_idx},
+                          }},
+                      )));
+                "#,
+                    suspending_wrap_fn =
+                        self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn),
+                );
+            }
+
+            Trampoline::FutureTransfer => {
+                let future_drop_writable_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureTransfer));
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {future_drop_writable_fn};"
+                );
+            }
+
+            Trampoline::ErrorContextNew { ty, options, .. } => {
+                let CanonicalOptions {
+                    instance,
+                    string_encoding,
+                    data_model:
+                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, .. }),
+                    ..
+                } = self
+                    .component
+                    .options
+                    .get(*options)
+                    .expect("failed to find options")
+                else {
+                    panic!("unexpected memory data model during error-context.new");
+                };
+
+                self.ensure_error_context_local_table(*instance, *ty);
+
+                let local_err_tbl_idx = ty.as_u32();
+                let component_idx = instance.as_u32();
+
+                let memory_idx = memory
+                    .expect("missing realloc fn idx for error-context.debug-message")
+                    .as_u32();
+
+                // Generate a string decoding function to match this trampoline that does appropriate encoding
+                let decoder = match string_encoding {
+                    wasmtime_environ::component::StringEncoding::Utf8 => self
+                        .bindgen
+                        .intrinsic(Intrinsic::String(StringIntrinsic::GlobalTextDecoderUtf8)),
+                    wasmtime_environ::component::StringEncoding::Utf16 => self
+                        .bindgen
+                        .intrinsic(Intrinsic::String(StringIntrinsic::Utf16Decoder)),
+                    enc => panic!(
+                        "unsupported string encoding [{enc:?}] for error-context.debug-message"
+                    ),
+                };
+                uwriteln!(
+                    self.src.js,
+                    "function trampoline{i}InputStr(ptr, len) {{
+                         return {decoder}.decode(new DataView(memory{memory_idx}.buffer, ptr, len));
+                    }}"
+                );
+
+                let err_ctx_new_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::ErrCtx(ErrCtxIntrinsic::ErrorContextNew));
+                // Store the options associated with this new error context for later use in the global array
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {err_ctx_new_fn}.bind(
+                         null,
+                         {{
+                             componentIdx: {component_idx},
+                             localTableIdx: {local_err_tbl_idx},
+                             readStrFn: trampoline{i}InputStr,
+                         }}
+                     );
+                    "
+                );
+            }
+
+            Trampoline::ErrorContextDebugMessage {
+                instance, options, ..
+            } => {
+                let CanonicalOptions {
+                    async_,
+                    callback,
+                    post_return,
+                    string_encoding,
+                    data_model:
+                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
+                    ..
+                } = self
+                    .component
+                    .options
+                    .get(*options)
+                    .expect("failed to find options")
+                else {
+                    panic!("unexpected memory data model during error-context.debug-message");
+                };
+
+                let debug_message_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::ErrCtx(ErrCtxIntrinsic::ErrorContextDebugMessage));
+
+                let realloc_fn_idx = realloc
+                    .expect("missing realloc fn idx for error-context.debug-message")
+                    .as_u32();
+                let memory_idx = memory
+                    .expect("missing realloc fn idx for error-context.debug-message")
+                    .as_u32();
+
+                // Generate a string encoding function to match this trampoline that does appropriate encoding
+                match string_encoding {
+                    wasmtime_environ::component::StringEncoding::Utf8 => {
+                        let encode_fn = self
+                            .bindgen
+                            .intrinsic(Intrinsic::String(StringIntrinsic::Utf8Encode));
+                        uwriteln!(
+                            self.src.js,
+                            "function trampoline{i}OutputStr(s, outputPtr) {{
+                                 const memory = memory{memory_idx};
+                                 const reallocFn = realloc{realloc_fn_idx};
+                                 let {{ ptr, len }} = {encode_fn}(s, reallocFn, memory);
+                                 new DataView(memory.buffer).setUint32(outputPtr, ptr, true)
+                                 new DataView(memory.buffer).setUint32(outputPtr + 4, len, true)
+                             }}"
+                        );
+                    }
+                    wasmtime_environ::component::StringEncoding::Utf16 => {
+                        let encode_fn = self
+                            .bindgen
+                            .intrinsic(Intrinsic::String(StringIntrinsic::Utf16Encode));
+                        uwriteln!(
+                            self.src.js,
+                            "function trampoline{i}OutputStr(s, outputPtr) {{
+                                 const memory = memory{memory_idx};
+                                 const reallocFn = realloc{realloc_fn_idx};
+                                 let ptr = {encode_fn}(s, reallocFn, memory);
+                                 let len = s.length;
+                                 new DataView(memory.buffer).setUint32(outputPtr, ptr, true)
+                                 new DataView(memory.buffer).setUint32(outputPtr + 4, len, true)
+                             }}"
+                        );
+                    }
+                    enc => panic!(
+                        "unsupported string encoding [{enc:?}] for error-context.debug-message"
+                    ),
+                };
+
+                let options_obj = format!(
+                    "{{callback:{callback}, postReturn: {post_return}, async: {async_}}}",
+                    callback = callback
+                        .map(|v| v.as_u32().to_string())
+                        .unwrap_or_else(|| "null".into()),
+                    post_return = post_return
+                        .map(|v| v.as_u32().to_string())
+                        .unwrap_or_else(|| "null".into()),
+                );
+
+                let component_idx = instance.as_u32();
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {debug_message_fn}.bind(
+                         null,
+                         {{
+                             componentIdx: {component_idx},
+                             options: {options_obj},
+                             writeStrFn: trampoline{i}OutputStr,
+                         }}
+                     );"
+                );
+            }
+
+            Trampoline::ErrorContextDrop { instance, ty } => {
+                let drop_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::ErrCtx(ErrCtxIntrinsic::ErrorContextDrop));
+                let local_err_tbl_idx = ty.as_u32();
+                let component_idx = instance.as_u32();
+                uwriteln!(
+                    self.src.js,
+                    r#"
+                      const trampoline{i} = {drop_fn}.bind(
+                          null,
+                          {{ componentIdx: {component_idx}, localTableIdx: {local_err_tbl_idx} }},
+                      );
+                    "#
+                );
+            }
+
+            Trampoline::ErrorContextTransfer => {
+                let transfer_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::ErrCtx(ErrCtxIntrinsic::ErrorContextTransfer));
+                uwriteln!(self.src.js, "const trampoline{i} = {transfer_fn};");
+            }
+
+            // This sets up a subtask (sets parent, etc) for guest -> guest calls
+            Trampoline::PrepareCall { memory } => {
+                let prepare_call_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Host(HostIntrinsic::PrepareCall));
+                let (memory_idx_js, memory_fn_js) = memory
+                    .map(|v| {
+                        (
+                            v.as_u32().to_string(),
+                            format!("() => memory{}", v.as_u32()),
+                        )
+                    })
+                    .unwrap_or_else(|| ("null".into(), "() => null".into()));
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {prepare_call_fn}.bind(null, {memory_idx_js}, {memory_fn_js});",
+                )
+            }
+
+            Trampoline::SyncStartCall { callback } => {
+                let sync_start_call_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Host(HostIntrinsic::SyncStartCall));
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {sync_start_call_fn}.bind(null, {});",
+                    callback
+                        .map(|v| v.as_u32().to_string())
+                        .unwrap_or_else(|| "null".into()),
+                );
+            }
+
+            // This actually starts a Task (whose parent is a subtask generated during PrepareCall)
+            // for a from-component async import call
+            Trampoline::AsyncStartCall {
+                callback,
+                post_return,
+            } => {
+                let async_start_call_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Host(HostIntrinsic::AsyncStartCall));
+                let (callback_idx, callback_fn) = callback
+                    .map(|v| (v.as_u32().to_string(), format!("callback_{}", v.as_u32())))
+                    .unwrap_or_else(|| ("null".into(), "null".into()));
+                let (post_return_idx, post_return_fn) = post_return
+                    .map(|v| (v.as_u32().to_string(), format!("postReturn{}", v.as_u32())))
+                    .unwrap_or_else(|| ("null".into(), "null".into()));
+
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {async_start_call_fn}.bind(
+                         null,
+                         {{
+                             postReturnIdx: {post_return_idx},
+                             getPostReturnFn: () => {post_return_fn},
+                             callbackIdx: {callback_idx},
+                             getCallbackFn: () => {callback_fn},
+                         }},
+                     );",
+                );
+            }
+
+            Trampoline::LowerImport {
+                index: _,
+                lower_ty,
+                options,
+            } => {
+                let canon_opts = self
+                    .component
+                    .options
+                    .get(*options)
+                    .expect("failed to find options");
+
+                // TODO(fix): remove Global lowers, should enable using just exports[x] to export[y] call
+                // TODO(fix): promising for the run (*as well as exports*)
+                // TODO(fix): delete all asyncImports/exports
+                // TODO(opt): opt-in sync import
+
+                let component_idx = canon_opts.instance.as_u32();
+                let is_async = canon_opts.async_;
+
+                let cancellable = canon_opts.cancellable;
+
+                let func_ty = self.types.index(*lower_ty);
+
+                // Build list of lift functions for the params of the lowered import
+                let param_types = &self.types.index(func_ty.params).types;
+                let param_lift_fns_js =
+                    gen_flat_lift_fn_list_js_expr(self, param_types.iter().as_slice(), &None);
+
+                // Build list of lower functions for the results of the lowered import
+                let result_types = &self.types.index(func_ty.results).types;
+                let result_lower_fns_js =
+                    gen_flat_lower_fn_list_js_expr(self, result_types.iter().as_slice(), &None);
+                let result_flat_count = result_types.iter().try_fold(0usize, |count, ty| {
+                    self.types
+                        .canonical_abi(ty)
+                        .flat_count
+                        .map(|flat_count| count + usize::from(flat_count))
+                });
+
+                let get_callback_fn_js = canon_opts
+                    .callback
+                    .map(|idx| format!("() => callback_{}", idx.as_u32()))
+                    .unwrap_or_else(|| "() => null".into());
+                let get_post_return_fn_js = canon_opts
+                    .post_return
+                    .map(|idx| format!("() => postReturn{}", idx.as_u32()))
+                    .unwrap_or_else(|| "() => null".into());
+
+                // Build the memory and realloc js expressions, retrieving the memory index and getter functions
+                let (memory_exprs, realloc_expr_js) =
+                    if let CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions {
+                        memory,
+                        realloc,
+                    }) = canon_opts.data_model
+                    {
+                        (
+                            memory.map(|idx| {
+                                (
+                                    idx.as_u32().to_string(),
+                                    format!("() => memory{}", idx.as_u32()),
+                                )
+                            }),
+                            realloc.map(|idx| format!("() => realloc{}", idx.as_u32())),
+                        )
+                    } else {
+                        (None, None)
+                    };
+                let (memory_idx_js, memory_expr_js) =
+                    memory_exprs.unwrap_or_else(|| ("null".into(), "() => null".into()));
+                let realloc_expr_js = realloc_expr_js.unwrap_or_else(|| "undefined".into());
+                let string_encoding_js = string_encoding_js_literal(&canon_opts.string_encoding);
+
+                // Build the lower import call that will wrap the actual trampoline
+                let func_ty_async = func_ty.async_;
+                let max_direct_results = if is_async || func_ty_async {
+                    0
+                } else {
+                    MAX_FLAT_RESULTS
+                };
+                let has_result_pointer = result_flat_count
+                    .map(|count| count > max_direct_results)
+                    .unwrap_or(true);
+                let call = format!(
+                    r#"{lower_import_intrinsic}.bind(
+                        null,
+                        {{
+                            trampolineIdx: {i},
+                            componentIdx: {component_idx},
+                            isAsync: {is_async},
+                            isManualAsync: _trampoline{i}.manuallyAsync,
+                            paramLiftFns: {param_lift_fns_js},
+                            resultLowerFns: {result_lower_fns_js},
+                            hasResultPointer: {has_result_pointer},
+                            funcTypeIsAsync: {func_ty_async},
+                            getCallbackFn: {get_callback_fn_js},
+                            getPostReturnFn: {get_post_return_fn_js},
+                            isCancellable: {cancellable},
+                            memoryIdx: {memory_idx_js},
+                            stringEncoding: {string_encoding_js},
+                            getMemoryFn: {memory_expr_js},
+                            getReallocFn: {realloc_expr_js},
+                            importFn: _trampoline{i},
+                        }},
+                    )"#,
+                    lower_import_intrinsic = if is_async || func_ty_async {
+                        self.bindgen
+                            .intrinsic(Intrinsic::AsyncTask(AsyncTaskIntrinsic::LowerImport))
+                    } else {
+                        self.bindgen.intrinsic(Intrinsic::AsyncTask(
+                            AsyncTaskIntrinsic::LowerImportBackwardsCompat,
+                        ))
+                    }
+                );
+
+                // NOTE: For Trampoline::LowerImport, the trampoline index is actually already defined,
+                // but we *redefine* it to call the lower import function first.
+                let suspending_wrap_fn =
+                    self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn);
+                if is_async || func_ty_async {
+                    uwriteln!(
+                        self.src.js,
+                        "let trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_idx}, {call}));"
+                    );
+                } else {
+                    // TODO(breaking): once manually specifying async imports is removed,
+                    // we can avoid the second check below.
+                    uwriteln!(
+                        self.src.js,
+                        "let trampoline{i} = _trampoline{i}.manuallyAsync ? new WebAssembly.Suspending({suspending_wrap_fn}({component_idx}, {call})) : {call};"
+                    );
+                }
+            }
+
+            Trampoline::Transcoder {
+                op,
+                from,
+                from64,
+                to,
+                to64,
+            } => {
+                if *from64 || *to64 {
+                    unimplemented!("memory 64 transcoder");
+                }
+                let from = from.as_u32();
+                let to = to.as_u32();
+                match op {
+                    Transcode::Copy(FixedEncoding::Utf8) => {
+                        uwriteln!(
+                            self.src.js,
+                            r#"
+                              function trampoline{i} (from_ptr, len, to_ptr) {{
+                                  new Uint8Array(memory{to}.buffer, to_ptr, len).set(new Uint8Array(memory{from}.buffer, from_ptr, len));
+                              }}
+                            "#
+                        );
+                    }
+                    Transcode::Copy(FixedEncoding::Utf16) => unimplemented!("utf16 copier"),
+                    Transcode::Copy(FixedEncoding::Latin1) => unimplemented!("latin1 copier"),
+                    Transcode::Latin1ToUtf16 => unimplemented!("latin to utf16 transcoder"),
+                    Transcode::Latin1ToUtf8 => unimplemented!("latin to utf8 transcoder"),
+                    Transcode::Utf16ToCompactProbablyUtf16 => {
+                        unimplemented!("utf16 to compact wtf16 transcoder")
+                    }
+                    Transcode::Utf16ToCompactUtf16 => {
+                        unimplemented!("utf16 to compact utf16 transcoder")
+                    }
+                    Transcode::Utf16ToLatin1 => unimplemented!("utf16 to latin1 transcoder"),
+                    Transcode::Utf16ToUtf8 => {
+                        uwriteln!(
+                            self.src.js,
+                            r#"
+                              function trampoline{i} (src, src_len, dst, dst_len) {{
+                                  const encoder = new TextEncoder();
+                                  const {{ read, written }} = encoder.encodeInto(String.fromCharCode.apply(null, new Uint16Array(memory{from}.buffer, src, src_len)), new Uint8Array(memory{to}.buffer, dst, dst_len));
+                                  return [read, written];
+                              }}
+                            "#,
+                        );
+                    }
+                    Transcode::Utf8ToCompactUtf16 => {
+                        unimplemented!("utf8 to compact utf16 transcoder")
+                    }
+                    Transcode::Utf8ToLatin1 => unimplemented!("utf8 to latin1 transcoder"),
+                    Transcode::Utf8ToUtf16 => {
+                        uwriteln!(
+                            self.src.js,
+                            r#"
+                              function trampoline{i} (from_ptr, len, to_ptr) {{
+                                  const decoder = new TextDecoder();
+                                  const content = decoder.decode(new Uint8Array(memory{from}.buffer, from_ptr, len));
+                                  const strlen = content.length
+                                  const view = new Uint16Array(memory{to}.buffer, to_ptr, strlen * 2)
+                                  for (var i = 0; i < strlen; i++) {{
+                                      view[i] = content.charCodeAt(i);
+                                  }}
+                                  return strlen;
+                              }}
+                            "#,
+                        );
+                    }
+                };
+            }
+
+            Trampoline::ResourceNew {
+                ty: resource_ty_idx,
+                ..
+            } => {
+                self.ensure_resource_table(*resource_ty_idx);
+                let rid = resource_ty_idx.as_u32();
+                let rsc_table_create_own = self.bindgen.intrinsic(Intrinsic::Resource(
+                    ResourceIntrinsic::ResourceTableCreateOwn,
+                ));
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {rsc_table_create_own}.bind(null, handleTable{rid});"
+                );
+            }
+
+            Trampoline::ResourceRep {
+                ty: resource_ty_idx,
+                ..
+            } => {
+                self.ensure_resource_table(*resource_ty_idx);
+                let rid = resource_ty_idx.as_u32();
+                let rsc_flag = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Resource(ResourceIntrinsic::ResourceTableFlag));
+                uwriteln!(
+                    self.src.js,
+                    "function trampoline{i} (handle) {{
+                        return handleTable{rid}[(handle << 1) + 1] & ~{rsc_flag};
+                    }}"
+                );
+            }
+
+            Trampoline::ResourceDrop {
+                ty: resource_table_ty_idx,
+                ..
+            } => {
+                self.ensure_resource_table(*resource_table_ty_idx);
+                let tid = resource_table_ty_idx.as_u32();
+                let resource_table_ty = &self.types[*resource_table_ty_idx];
+                let resource_ty = resource_table_ty.unwrap_concrete_ty();
+                let rid = resource_ty.as_u32();
+
+                // Build the code fragment that encapsulates calling the destructor
+                let dtor = if let Some(resource_idx) =
+                    self.component.defined_resource_index(resource_ty)
+                {
+                    let resource_def = self
+                        .component
+                        .initializers
+                        .iter()
+                        .find_map(|i| match i {
+                            GlobalInitializer::Resource(r) if r.index == resource_idx => Some(r),
+                            _ => None,
+                        })
+                        .unwrap();
+
+                    // If a destructor index is defined for the resource, call it
+                    if let Some(dtor) = &resource_def.dtor {
+                        format!(
+                            "
+                            {}(handleEntry.rep);",
+                            self.core_def(dtor)
+                        )
+                    } else {
+                        "".into()
+                    }
+                } else {
+                    // Imported resource is one without a defined resource index.
+                    // If it is a captured instance (class instance was created externally so had to
+                    // be assigned a rep), and there is a Symbol.dispose handler, call it explicitly
+                    // for imported resources when the resource is dropped.
+                    // Otherwise if it is an instance without a captured class definition, then
+                    // call the low-level bindgen destructor.
+                    let symbol_dispose = self.bindgen.intrinsic(Intrinsic::SymbolDispose);
+                    let symbol_cabi_dispose = self.bindgen.intrinsic(Intrinsic::SymbolCabiDispose);
+
+                    // previous imports walk should define all imported resources which are accessible
+                    if let Some(imported_resource_local_name) =
+                        self.bindgen.local_names.try_get(resource_ty)
+                    {
+                        format!(
+                                            "
+                            const rsc = captureTable{rid}.get(handleEntry.rep);
+                            if (rsc) {{
+                                if (rsc[{symbol_dispose}]) rsc[{symbol_dispose}]();
+                                captureTable{rid}.delete(handleEntry.rep);
+                            }} else if ({imported_resource_local_name}[{symbol_cabi_dispose}]) {{
+                                {imported_resource_local_name}[{symbol_cabi_dispose}](handleEntry.rep);
+                            }}"
+                                        )
+                    } else {
+                        // If not, then capture / disposal paths are never called
+                        format!(
+                            "throw new TypeError('unreachable trampoline for resource [{:?}]')",
+                            resource_ty
+                        )
+                    }
+                };
+
+                let rsc_table_remove = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Resource(ResourceIntrinsic::ResourceTableRemove));
+                uwrite!(
+                    self.src.js,
+                    "function trampoline{i}(handle) {{
+                        const handleEntry = {rsc_table_remove}(handleTable{tid}, handle);
+                        if (handleEntry.own) {{
+                            {dtor}
+                        }}
+                    }}
+                    ",
+                );
+            }
+
+            Trampoline::ResourceTransferOwn => {
+                let resource_transfer = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Resource(ResourceIntrinsic::ResourceTransferOwn));
+                uwriteln!(self.src.js, "const trampoline{i} = {resource_transfer};");
+            }
+
+            Trampoline::ResourceTransferBorrow => {
+                let resource_transfer =
+                    self.bindgen
+                        .intrinsic(if self.bindgen.opts.valid_lifting_optimization {
+                            Intrinsic::Resource(
+                                ResourceIntrinsic::ResourceTransferBorrowValidLifting,
+                            )
+                        } else {
+                            Intrinsic::Resource(ResourceIntrinsic::ResourceTransferBorrow)
+                        });
+                uwriteln!(self.src.js, "const trampoline{i} = {resource_transfer};");
+            }
+
+            Trampoline::TaskReturn {
+                results, options, ..
+            } => {
+                let canon_opts = self
+                    .component
+                    .options
+                    .get(*options)
+                    .expect("failed to find options");
+                let CanonicalOptions {
+                    instance,
+                    async_,
+                    data_model:
+                        CanonicalOptionsDataModel::LinearMemory(LinearMemoryOptions { memory, realloc }),
+                    callback,
+                    post_return,
+                    string_encoding,
+                    ..
+                } = canon_opts
+                else {
+                    unreachable!("unexpected memory data model during task.return");
+                };
+
+                // Validate canonopts
+                if realloc.is_some() && memory.is_none() {
+                    panic!("memory must be present if realloc is");
+                }
+                if *async_ && post_return.is_some() {
+                    panic!("async and post return must not be specified together");
+                }
+                if *async_ && callback.is_none() {
+                    panic!("callback must be specified for async");
+                }
+                if let Some(cb_idx) = callback {
+                    let cb_fn = &self.types[TypeFuncIndex::from_u32(cb_idx.as_u32())];
+                    match self.types[cb_fn.params].types[..] {
+                        [InterfaceType::S32, InterfaceType::S32, InterfaceType::S32] => {}
+                        _ => panic!("unexpected params for async callback fn"),
+                    }
+                    match self.types[cb_fn.results].types[..] {
+                        [InterfaceType::S32] => {}
+                        _ => panic!("unexpected results for async callback fn"),
+                    }
+                }
+
+                let result_types = &self.types[*results].types;
+
+                // Calculate the number of parameters required to represent the results,
+                // and whether they'll be stored in memory
+                let result_flat_param_total: usize = result_types
+                    .iter()
+                    .map(|t| {
+                        self.types
+                            .canonical_abi(t)
+                            .flat_count
+                            .map(usize::from)
+                            .unwrap_or(0)
+                    })
+                    .sum();
+                let use_direct_params = result_flat_param_total < MAX_FLAT_PARAMS;
+
+                // Build up a list of all the lifting functions that will be needed for the types
+                // that are actually being passed through task.return
+                let mut lift_fns: Vec<String> = Vec::with_capacity(result_types.len());
+                for result_ty in result_types {
+                    lift_fns.push(gen_flat_lift_fn_js_expr(self, result_ty, &None));
+                }
+                let lift_fns_js = format!("[{}]", lift_fns.join(","));
+
+                // Build up a list of all the lowering functions that will be needed for the types
+                // that are actually being passed through task.return
+                //
+                // This is usually only necessary if this task is part of a guest->guest async call
+                // (i.e. via prepare & async start call)
+                let mut lower_fns: Vec<String> = Vec::with_capacity(result_types.len());
+                for result_ty in result_types {
+                    lower_fns.push(gen_flat_lower_fn_js_expr(self, result_ty, &None));
+                }
+                let lower_fns_js = format!("[{}]", lower_fns.join(","));
+
+                let get_memory_fn_js = memory
+                    .map(|idx| format!("() => memory{}", idx.as_u32()))
+                    .unwrap_or_else(|| "() => null".into());
+                let memory_idx_js = memory
+                    .map(|idx| idx.as_u32().to_string())
+                    .unwrap_or_else(|| "null".into());
+                let component_idx = instance.as_u32();
+                let task_return_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::AsyncTask(AsyncTaskIntrinsic::TaskReturn));
+                let callback_fn_idx = callback
+                    .map(|v| v.as_u32().to_string())
+                    .unwrap_or_else(|| "null".into());
+                let string_encoding_js = string_encoding_js_literal(string_encoding);
+
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {task_return_fn}.bind(
+                         null,
+                         {{
+                             componentIdx: {component_idx},
+                             useDirectParams: {use_direct_params},
+                             getMemoryFn: {get_memory_fn_js},
+                             memoryIdx: {memory_idx_js},
+                             callbackFnIdx: {callback_fn_idx},
+                             liftFns: {lift_fns_js},
+                             lowerFns: {lower_fns_js},
+                             stringEncoding: {string_encoding_js},
+                         }},
+                     );",
+                );
+            }
+
+            Trampoline::BackpressureInc { instance } => {
+                let backpressure_inc_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Component(ComponentIntrinsic::BackpressureInc));
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {backpressure_inc_fn}.bind(null, {instance});\n",
+                    instance = instance.as_u32(),
+                );
+            }
+
+            Trampoline::BackpressureDec { instance } => {
+                let backpressure_dec_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::Component(ComponentIntrinsic::BackpressureDec));
+                uwriteln!(
+                    self.src.js,
+                    "const trampoline{i} = {backpressure_dec_fn}.bind(null, {instance});\n",
+                    instance = instance.as_u32(),
+                );
+            }
+
+            Trampoline::ThreadYield {
+                cancellable,
+                instance,
+            } => {
+                let yield_fn = self
+                    .bindgen
+                    .intrinsic(Intrinsic::AsyncTask(AsyncTaskIntrinsic::Yield));
+                let suspending_wrap_fn =
+                    self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn);
+                let component_instance_idx = instance.as_u32();
+                uwriteln!(
+                    self.src.js,
+                    r#"
+                      const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_instance_idx}, {yield_fn}.bind(null, {{
+                          isCancellable: {cancellable},
+                          componentIdx: {component_instance_idx},
+                      }})));
+                    "#,
+                );
+            }
+            Trampoline::ThreadIndex => todo!("Trampoline::ThreadIndex"),
+            Trampoline::ThreadNewIndirect { .. } => todo!("Trampoline::ThreadNewIndirect"),
+            Trampoline::ThreadSuspend { .. } => todo!("Trampoline::ThreadSuspend"),
+            Trampoline::ThreadSuspendTo { .. } => todo!("Trampoline::ThreadSuspendTo"),
+            Trampoline::ThreadUnsuspend { .. } => todo!("Trampoline::ThreadUnsuspend"),
+            Trampoline::ThreadYieldToSuspended { .. } => {
+                todo!("Trampoline::ThreadYieldToSuspended")
+            }
+            Trampoline::ThreadSuspendToSuspended { .. } => {
+                todo!("Trampoline::ThreadYieldToSuspended")
+            }
+
+            Trampoline::Trap => {
+                uwriteln!(
+                    self.src.js,
+                    "function trampoline{i}(rep) {{ throw new TypeError('Trap'); }}"
+                );
+            }
+
+            Trampoline::EnterSyncCall => {
+                let enter_symmetric_sync_guest_call_fn = self.bindgen.intrinsic(
+                    Intrinsic::AsyncTask(AsyncTaskIntrinsic::EnterSymmetricSyncGuestCall),
+                );
+                uwriteln!(
+                    self.src.js,
+                    r#"
+                      const trampoline{i} = {enter_symmetric_sync_guest_call_fn};
+                    "#,
+                );
+>>>>>>> theirs (trampoline)
             }
 
             Trampoline::ExitSyncCall => {

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -5639,7 +5639,7 @@ pub fn gen_flat_lift_fn_js_expr(
                 None => format!(
                     r#"{f}({{
                        componentIdx: {component_idx},
-                       className: null,
+                       classNameFn: () => null,
                        createResourceFn: () => {{ throw new Error('invalid/missing resource type data'); }},
                     }})
                 "#,
@@ -5752,7 +5752,7 @@ pub fn gen_flat_lift_fn_js_expr(
                     format!(
                         r#"{f}({{
                        componentIdx: {component_idx},
-                       className: {resource_class_name},
+                       classNameFn: () => {resource_class_name},
                        createResourceFn: {create_resource_fn_js},
                     }})
                 "#,

--- a/crates/test-components/src/bin/async_result_scalars.rs
+++ b/crates/test-components/src/bin/async_result_scalars.rs
@@ -1,0 +1,56 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "async-result-scalars",
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::result_scalars_api::{Guest, NestedU64};
+
+struct Component;
+
+impl Guest for Component {
+    async fn get_u64_ok(v: u64) -> Result<u64, String> {
+        Ok(v)
+    }
+
+    async fn get_u64_err(msg: String) -> Result<u64, String> {
+        Err(msg)
+    }
+
+    async fn get_s64_ok(v: i64) -> Result<i64, String> {
+        Ok(v)
+    }
+
+    async fn get_f64_ok(v: f64) -> Result<f64, String> {
+        Ok(v)
+    }
+
+    async fn get_f64_only(v: f64) -> Result<f64, f64> {
+        Ok(v)
+    }
+
+    async fn get_f32_only(v: f32) -> Result<f32, f32> {
+        Ok(v)
+    }
+
+    async fn get_option_u64(v: u64) -> Option<u64> {
+        Some(v)
+    }
+
+    async fn get_option_f64(v: f64) -> Option<f64> {
+        Some(v)
+    }
+
+    async fn get_option_f32(v: f32) -> Option<f32> {
+        Some(v)
+    }
+
+    async fn get_record_u64(v: u64) -> Result<NestedU64, String> {
+        Ok(NestedU64 { val: v, tag: 7 })
+    }
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/src/bin/resource_reexport_g2g_callee.rs
+++ b/crates/test-components/src/bin/resource_reexport_g2g_callee.rs
@@ -1,0 +1,34 @@
+//! Callee for the composed resource-reexport regression (lann/jco#51):
+//! exports a resource together with an async function that returns an
+//! owned instance of it across the (to-be-fused) component boundary.
+
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "resource-reexport-callee",
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::reexport_source::{Guest, GuestWidget, Widget};
+
+struct Component;
+
+struct WidgetRes(u32);
+
+impl GuestWidget for WidgetRes {
+    fn poke(&self) -> u32 {
+        self.0
+    }
+}
+
+impl Guest for Component {
+    type Widget = WidgetRes;
+
+    async fn make_widget() -> Result<Widget, String> {
+        Ok(Widget::new(WidgetRes(42)))
+    }
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/src/bin/resource_reexport_g2g_callee.rs
+++ b/crates/test-components/src/bin/resource_reexport_g2g_callee.rs
@@ -1,4 +1,4 @@
-//! Callee for the composed resource-reexport regression (lann/jco#51):
+//! Callee for the composed resource-reexport regression:
 //! exports a resource together with an async function that returns an
 //! owned instance of it across the (to-be-fused) component boundary.
 

--- a/crates/test-components/src/bin/resource_reexport_g2g_caller.rs
+++ b/crates/test-components/src/bin/resource_reexport_g2g_caller.rs
@@ -1,4 +1,4 @@
-//! Caller for the composed resource-reexport regression (lann/jco#51):
+//! Caller for the composed resource-reexport regression:
 //! calls the callee's async widget constructor across the fused boundary
 //! and re-exports the callee's resource type in its own exported
 //! interface (`reexport-handoff`) — the combination that makes the

--- a/crates/test-components/src/bin/resource_reexport_g2g_caller.rs
+++ b/crates/test-components/src/bin/resource_reexport_g2g_caller.rs
@@ -1,0 +1,37 @@
+//! Caller for the composed resource-reexport regression (lann/jco#51):
+//! calls the callee's async widget constructor across the fused boundary
+//! and re-exports the callee's resource type in its own exported
+//! interface (`reexport-handoff`) — the combination that makes the
+//! generated taskReturn lift metadata reference the resource class above
+//! its declaration (TDZ ReferenceError at import).
+
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "resource-reexport-caller",
+        generate_all,
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::reexport_handoff::Guest as HandoffGuest;
+use bindings::exports::jco::test_components::reexport_runner::Guest;
+use bindings::jco::test_components::reexport_source::{Widget, make_widget};
+
+struct Component;
+
+impl Guest for Component {
+    async fn run_reexport() -> Result<u32, String> {
+        let widget = make_widget().await?;
+        Ok(widget.poke())
+    }
+}
+
+impl HandoffGuest for Component {
+    async fn poke_widget(w: Widget) -> u32 {
+        w.poke()
+    }
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/src/bin/stream_echo_g2g_callee.rs
+++ b/crates/test-components/src/bin/stream_echo_g2g_callee.rs
@@ -1,0 +1,49 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "stream-echo-g2g-callee",
+    });
+    export!(Component);
+}
+
+use wit_bindgen::StreamReader;
+
+use bindings::exports::jco::test_components::stream_echo_source::Guest;
+use bindings::wit_stream;
+
+struct Component;
+
+impl Guest for Component {
+    // Echo pump across the composition: parks a read on the (transferred-in)
+    // input stream before the caller performs its first write, echoing each
+    // value +1 into the returned stream. The exporting task stays alive
+    // (callback protocol) until the pump completes, which happens when the
+    // input stream closes. See lann/jco#40.
+    async fn make_echo(mut input: StreamReader<u8>) -> StreamReader<u8> {
+        let (mut tx, rx) = wit_stream::new();
+        wit_bindgen::spawn_local(async move {
+            while let Some(v) = input.next().await {
+                let remaining = tx.write_all(vec![v + 1]).await;
+                assert!(remaining.is_empty(), "echo value should be written");
+            }
+            // input closed: dropping tx closes the echoed stream
+        });
+        rx
+    }
+
+    // Producer for the relay shape (lann/jco#40): the returned read end is
+    // transferred out to the caller and then handed straight back into
+    // make-echo, so both ends of this stream live inside this component
+    // while the writer pump runs.
+    async fn make_source(seed: u8) -> StreamReader<u8> {
+        let (mut tx, rx) = wit_stream::new();
+        wit_bindgen::spawn_local(async move {
+            let remaining = tx.write_all(vec![seed, seed + 1, seed + 2]).await;
+            assert!(remaining.is_empty(), "all source values should be written");
+        });
+        rx
+    }
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/src/bin/stream_echo_g2g_callee.rs
+++ b/crates/test-components/src/bin/stream_echo_g2g_callee.rs
@@ -18,7 +18,7 @@ impl Guest for Component {
     // input stream before the caller performs its first write, echoing each
     // value +1 into the returned stream. The exporting task stays alive
     // (callback protocol) until the pump completes, which happens when the
-    // input stream closes. See lann/jco#40.
+    // input stream closes.
     async fn make_echo(mut input: StreamReader<u8>) -> StreamReader<u8> {
         let (mut tx, rx) = wit_stream::new();
         wit_bindgen::spawn_local(async move {
@@ -31,7 +31,7 @@ impl Guest for Component {
         rx
     }
 
-    // Producer for the relay shape (lann/jco#40): the returned read end is
+    // Producer for the relay shape: the returned read end is
     // transferred out to the caller and then handed straight back into
     // make-echo, so both ends of this stream live inside this component
     // while the writer pump runs.

--- a/crates/test-components/src/bin/stream_echo_g2g_caller.rs
+++ b/crates/test-components/src/bin/stream_echo_g2g_caller.rs
@@ -19,7 +19,7 @@ impl Guest for Component {
         // The callee's echo pump parks a read on `input_rx` (transferred in
         // argument position) during this call, before our first write below:
         // the write must rendezvous with that parked cross-component read
-        // and wake it (see lann/jco#40).
+        // and wake it.
         let echoed = stream_echo_source::make_echo(input_rx).await;
 
         // Write and read concurrently: the pump only reads the next input
@@ -43,7 +43,7 @@ impl Guest for Component {
         // The source stream's read end is transferred out of the callee
         // (return position) and straight back in (argument position of
         // make-echo), so both of its ends end up inside the callee while
-        // the source's writer pump runs (see lann/jco#40).
+        // the source's writer pump runs.
         let src = stream_echo_source::make_source(seed).await;
         let echoed = stream_echo_source::make_echo(src).await;
         let vals: Vec<u8> = echoed.collect().await;

--- a/crates/test-components/src/bin/stream_echo_g2g_caller.rs
+++ b/crates/test-components/src/bin/stream_echo_g2g_caller.rs
@@ -1,0 +1,55 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "stream-echo-g2g-caller",
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::stream_echo_runner::Guest;
+use bindings::jco::test_components::stream_echo_source;
+use bindings::wit_stream;
+
+struct Component;
+
+impl Guest for Component {
+    async fn run_stream_echo(seed: u8) -> u32 {
+        let (mut tx, input_rx) = wit_stream::new();
+
+        // The callee's echo pump parks a read on `input_rx` (transferred in
+        // argument position) during this call, before our first write below:
+        // the write must rendezvous with that parked cross-component read
+        // and wake it (see lann/jco#40).
+        let echoed = stream_echo_source::make_echo(input_rx).await;
+
+        // Write and read concurrently: the pump only reads the next input
+        // value after its previous echo write completes, so the writer and
+        // reader sides must both make progress for the exchange to finish.
+        let write_side = async move {
+            let remaining = tx.write_all(vec![seed, seed + 1, seed + 2]).await;
+            assert!(remaining.is_empty(), "all values should be written");
+            // dropping tx closes the input; the pump then closes the echoed
+            // stream
+        };
+        let read_side = async move {
+            let vals: Vec<u8> = echoed.collect().await;
+            vals.into_iter().map(u32::from).sum::<u32>()
+        };
+        let ((), sum) = futures::join!(write_side, read_side);
+        sum
+    }
+
+    async fn run_stream_relay(seed: u8) -> u32 {
+        // The source stream's read end is transferred out of the callee
+        // (return position) and straight back in (argument position of
+        // make-echo), so both of its ends end up inside the callee while
+        // the source's writer pump runs (see lann/jco#40).
+        let src = stream_echo_source::make_source(seed).await;
+        let echoed = stream_echo_source::make_echo(src).await;
+        let vals: Vec<u8> = echoed.collect().await;
+        vals.into_iter().map(u32::from).sum()
+    }
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/src/bin/stream_lower.rs
+++ b/crates/test-components/src/bin/stream_lower.rs
@@ -38,6 +38,21 @@ impl stream_lower_async::Guest for Component {
         read_async_values(rx).await
     }
 
+    async fn read_stream_values_u8_bulk_chunks(mut rx: StreamReader<u8>) -> Vec<Vec<u8>> {
+        let mut chunks = Vec::new();
+        loop {
+            let (result, vals) = rx.read(Vec::with_capacity(4096)).await;
+            if !vals.is_empty() {
+                chunks.push(vals);
+            }
+            match result {
+                StreamResult::Complete(_) => {}
+                StreamResult::Dropped | StreamResult::Cancelled => break,
+            }
+        }
+        chunks
+    }
+
     async fn read_stream_values_s8(rx: StreamReader<i8>) -> Vec<i8> {
         read_async_values(rx).await
     }

--- a/crates/test-components/src/bin/stream_transfer_g2g_callee.rs
+++ b/crates/test-components/src/bin/stream_transfer_g2g_callee.rs
@@ -17,16 +17,14 @@ struct Component;
 impl Guest for Component {
     // NOTE: this export is *sync-lifted*: when composed with a caller, the
     // returned stream end crosses the component boundary on the return path
-    // of the fused call, *after* this component's task has been torn down
-    // (see lann/jco#35).
+    // of the fused call, *after* this component's task has been torn down.
     //
     // A sync-lifted export cannot leave detached work behind (there is no
-    // async computation scope to adopt it -- see lann/jco#39): the
-    // `start_task` here gets exactly one inline poll (registering the
-    // pending stream write, which later rendezvouses with the caller's
-    // read), and is never polled again, so the writable end is never
-    // dropped. Callers must therefore do bounded reads, not read to close.
-    // wasmtime behaves identically for this shape.
+    // async computation scope to adopt it): the `start_task` here gets exactly 
+    // one inline poll (registering the pending stream write, which later 
+    // rendezvouses with the caller's read), and is never polled again, so 
+    // the writable end is never dropped. Callers must therefore do bounded 
+    // reads, not read to close.
     fn make_stream(seed: u8) -> StreamReader<u8> {
         let (mut tx, rx) = wit_stream::new();
         start_task(async move {

--- a/crates/test-components/src/bin/stream_transfer_g2g_callee.rs
+++ b/crates/test-components/src/bin/stream_transfer_g2g_callee.rs
@@ -19,9 +19,30 @@ impl Guest for Component {
     // returned stream end crosses the component boundary on the return path
     // of the fused call, *after* this component's task has been torn down
     // (see lann/jco#35).
+    //
+    // A sync-lifted export cannot leave detached work behind (there is no
+    // async computation scope to adopt it -- see lann/jco#39): the
+    // `start_task` here gets exactly one inline poll (registering the
+    // pending stream write, which later rendezvouses with the caller's
+    // read), and is never polled again, so the writable end is never
+    // dropped. Callers must therefore do bounded reads, not read to close.
+    // wasmtime behaves identically for this shape.
     fn make_stream(seed: u8) -> StreamReader<u8> {
         let (mut tx, rx) = wit_stream::new();
         start_task(async move {
+            let remaining = tx.write_all(vec![seed, seed + 1, seed + 2]).await;
+            assert!(remaining.is_empty(), "all values should be written");
+        });
+        rx
+    }
+
+    // The async-lifted shape for "return a stream, then keep writing": the
+    // component-model task stays alive after returning the stream (callback
+    // protocol) until the writer spawned via `spawn_local` completes, at
+    // which point the writable end drops and the stream closes.
+    async fn make_stream_async(seed: u8) -> StreamReader<u8> {
+        let (mut tx, rx) = wit_stream::new();
+        wit_bindgen::spawn_local(async move {
             let remaining = tx.write_all(vec![seed, seed + 1, seed + 2]).await;
             assert!(remaining.is_empty(), "all values should be written");
         });

--- a/crates/test-components/src/bin/stream_transfer_g2g_callee.rs
+++ b/crates/test-components/src/bin/stream_transfer_g2g_callee.rs
@@ -1,0 +1,32 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "stream-transfer-g2g-callee",
+    });
+    export!(Component);
+}
+
+use wit_bindgen::StreamReader;
+use wit_bindgen::rt::async_support::start_task;
+
+use bindings::exports::jco::test_components::stream_transfer_source::Guest;
+use bindings::wit_stream;
+
+struct Component;
+
+impl Guest for Component {
+    // NOTE: this export is *sync-lifted*: when composed with a caller, the
+    // returned stream end crosses the component boundary on the return path
+    // of the fused call, *after* this component's task has been torn down
+    fn make_stream(seed: u8) -> StreamReader<u8> {
+        let (mut tx, rx) = wit_stream::new();
+        start_task(async move {
+            let remaining = tx.write_all(vec![seed, seed + 1, seed + 2]).await;
+            assert!(remaining.is_empty(), "all values should be written");
+        });
+        rx
+    }
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/src/bin/stream_transfer_g2g_callee.rs
+++ b/crates/test-components/src/bin/stream_transfer_g2g_callee.rs
@@ -18,6 +18,7 @@ impl Guest for Component {
     // NOTE: this export is *sync-lifted*: when composed with a caller, the
     // returned stream end crosses the component boundary on the return path
     // of the fused call, *after* this component's task has been torn down
+    // (see lann/jco#35).
     fn make_stream(seed: u8) -> StreamReader<u8> {
         let (mut tx, rx) = wit_stream::new();
         start_task(async move {

--- a/crates/test-components/src/bin/stream_transfer_g2g_caller.rs
+++ b/crates/test-components/src/bin/stream_transfer_g2g_caller.rs
@@ -14,8 +14,7 @@ struct Component;
 impl Guest for Component {
     async fn run_stream_transfer(seed: u8) -> u32 {
         // Sync-lowered call to the composed callee; the returned stream end
-        // is transferred into this component on the fused return path
-        // (see lann/jco#35).
+        // is transferred into this component on the fused return path.
         let mut rx = stream_transfer_source::make_stream(seed);
 
         // Read exactly the three values the callee writes without waiting
@@ -32,8 +31,7 @@ impl Guest for Component {
     async fn run_stream_transfer_all(seed: u8) -> u32 {
         // Async-lowered call to the async-lifted callee export: the callee
         // task stays alive until its spawned writer completes, so the
-        // transferred stream reaches close and collect() terminates
-        // (see lann/jco#39).
+        // transferred stream reaches close and collect() terminates.
         let rx = stream_transfer_source::make_stream_async(seed).await;
         let vals: Vec<u8> = rx.collect().await;
         vals.into_iter().map(u32::from).sum()

--- a/crates/test-components/src/bin/stream_transfer_g2g_caller.rs
+++ b/crates/test-components/src/bin/stream_transfer_g2g_caller.rs
@@ -18,18 +18,25 @@ impl Guest for Component {
         // (see lann/jco#35).
         let mut rx = stream_transfer_source::make_stream(seed);
 
-        // NOTE: read exactly the three values the callee writes, rather than
-        // collecting to stream close: the callee's detached writer task is
-        // never driven again after its sync-lifted export returns, so the
-        // writable end is never dropped and waiting for stream close would
-        // park forever (a separate defect from the return-position transfer
-        // exercised here).
+        // Read exactly the three values the callee writes without waiting
+        // for stream close (a bounded read that stays deterministic even if
+        // the callee's writer never runs again).
         let mut sum = 0u32;
         for _ in 0..3 {
             let v = rx.next().await.expect("stream should yield a value");
             sum += u32::from(v);
         }
         sum
+    }
+
+    async fn run_stream_transfer_all(seed: u8) -> u32 {
+        // Async-lowered call to the async-lifted callee export: the callee
+        // task stays alive until its spawned writer completes, so the
+        // transferred stream reaches close and collect() terminates
+        // (see lann/jco#39).
+        let rx = stream_transfer_source::make_stream_async(seed).await;
+        let vals: Vec<u8> = rx.collect().await;
+        vals.into_iter().map(u32::from).sum()
     }
 }
 

--- a/crates/test-components/src/bin/stream_transfer_g2g_caller.rs
+++ b/crates/test-components/src/bin/stream_transfer_g2g_caller.rs
@@ -1,0 +1,36 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "stream-transfer-g2g-caller",
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::stream_transfer_runner::Guest;
+use bindings::jco::test_components::stream_transfer_source;
+
+struct Component;
+
+impl Guest for Component {
+    async fn run_stream_transfer(seed: u8) -> u32 {
+        // Sync-lowered call to the composed callee; the returned stream end
+        // is transferred into this component on the fused return path
+        let mut rx = stream_transfer_source::make_stream(seed);
+
+        // NOTE: read exactly the three values the callee writes, rather than
+        // collecting to stream close: the callee's detached writer task is
+        // never driven again after its sync-lifted export returns, so the
+        // writable end is never dropped and waiting for stream close would
+        // park forever (a separate defect from the return-position transfer
+        // exercised here).
+        let mut sum = 0u32;
+        for _ in 0..3 {
+            let v = rx.next().await.expect("stream should yield a value");
+            sum += u32::from(v);
+        }
+        sum
+    }
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/src/bin/stream_transfer_g2g_caller.rs
+++ b/crates/test-components/src/bin/stream_transfer_g2g_caller.rs
@@ -15,6 +15,7 @@ impl Guest for Component {
     async fn run_stream_transfer(seed: u8) -> u32 {
         // Sync-lowered call to the composed callee; the returned stream end
         // is transferred into this component on the fused return path
+        // (see lann/jco#35).
         let mut rx = stream_transfer_source::make_stream(seed);
 
         // NOTE: read exactly the three values the callee writes, rather than

--- a/crates/test-components/src/bin/sync_to_async_callee.rs
+++ b/crates/test-components/src/bin/sync_to_async_callee.rs
@@ -13,7 +13,7 @@ struct Component;
 impl Guest for Component {
     // WIT-async export: async-lifted with the callback protocol. A composed
     // caller that *sync-lowers* this import reaches it through the fused
-    // [sync-start] path (see lann/jco#45).
+    // [sync-start] pathk.
     async fn compute(x: u32) -> u32 {
         x + 3
     }

--- a/crates/test-components/src/bin/sync_to_async_callee.rs
+++ b/crates/test-components/src/bin/sync_to_async_callee.rs
@@ -1,0 +1,29 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "sync-to-async-callee",
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::sync_lower_compute::Guest;
+
+struct Component;
+
+impl Guest for Component {
+    // WIT-async export: async-lifted with the callback protocol. A composed
+    // caller that *sync-lowers* this import reaches it through the fused
+    // [sync-start] path (see lann/jco#45).
+    async fn compute(x: u32) -> u32 {
+        x + 3
+    }
+
+    // List results exceed one flat value, so the caller's sync lowering
+    // receives them through a trailing return pointer.
+    async fn compute_list(x: u32) -> Vec<u32> {
+        vec![x, x + 1, x + 2]
+    }
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/src/bin/sync_to_async_caller.rs
+++ b/crates/test-components/src/bin/sync_to_async_caller.rs
@@ -5,7 +5,6 @@ mod bindings {
         // Force the (WIT-async) compute import to be *sync-lowered*: the
         // binding blocks until the callee resolves, and the fused adapter
         // routes the call through PrepareCall + SyncStartCall
-        // (see lann/jco#45).
         async: [
             "-import:jco:test-components/sync-lower-compute#compute",
             "-import:jco:test-components/sync-lower-compute#compute-list",

--- a/crates/test-components/src/bin/sync_to_async_caller.rs
+++ b/crates/test-components/src/bin/sync_to_async_caller.rs
@@ -1,0 +1,36 @@
+mod bindings {
+    use super::Component;
+    wit_bindgen::generate!({
+        world: "sync-to-async-caller",
+        // Force the (WIT-async) compute import to be *sync-lowered*: the
+        // binding blocks until the callee resolves, and the fused adapter
+        // routes the call through PrepareCall + SyncStartCall
+        // (see lann/jco#45).
+        async: [
+            "-import:jco:test-components/sync-lower-compute#compute",
+            "-import:jco:test-components/sync-lower-compute#compute-list",
+        ],
+    });
+    export!(Component);
+}
+
+use bindings::exports::jco::test_components::sync_lower_runner::Guest;
+use bindings::jco::test_components::sync_lower_compute;
+
+struct Component;
+
+impl Guest for Component {
+    async fn run_compute(x: u32) -> u32 {
+        // Blocking (sync-lowered) call to the composed callee's async-lifted
+        // export: single flat result, returned directly by the fused
+        // [sync-start] built-in.
+        let direct = sync_lower_compute::compute(x);
+        // Spilled results: the list comes back through the sync lowering's
+        // trailing return pointer.
+        let list = sync_lower_compute::compute_list(direct);
+        list.into_iter().sum()
+    }
+}
+
+// Stub only to ensure this works as a binary
+fn main() {}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -508,6 +508,9 @@ interface stream-lower-async {
     read-stream-values-bool: async func(s: stream<bool>) -> list<bool>;
 
     read-stream-values-u8: async func(s: stream<u8>) -> list<u8>;
+    // Reads with a large per-read count and returns each canonical read's
+    // values as a separate chunk
+    read-stream-values-u8-bulk-chunks: async func(s: stream<u8>) -> list<list<u8>>;
     read-stream-values-s8: async func(s: stream<s8>) -> list<s8>;
 
     read-stream-values-u16: async func(s: stream<u16>) -> list<u16>;

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -808,6 +808,26 @@ interface future-transfer-source {
   make-future: func(value: u32) -> future<u32>;
 }
 
+interface sync-lower-compute {
+  compute: async func(x: u32) -> u32;
+  // results wider than one flat value: the sync lowering spills them
+  // through a trailing return pointer
+  compute-list: async func(x: u32) -> list<u32>;
+}
+
+interface sync-lower-runner {
+  run-compute: async func(x: u32) -> u32;
+}
+
+world sync-to-async-callee {
+  export sync-lower-compute;
+}
+
+world sync-to-async-caller {
+  import sync-lower-compute;
+  export sync-lower-runner;
+}
+
 interface future-transfer-runner {
   run-future-transfer: async func(value: u32) -> u32;
 }

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -804,51 +804,26 @@ world async-export-future-result {
   export async-export-future-result-api;
 }
 
-interface future-transfer-source {
-  make-future: func(value: u32) -> future<u32>;
+interface result-scalars-api {
+  get-u64-ok: async func(v: u64) -> result<u64, string>;
+  get-u64-err: async func(msg: string) -> result<u64, string>;
+  get-s64-ok: async func(v: s64) -> result<s64, string>;
+  get-f64-ok: async func(v: f64) -> result<f64, string>;
+  get-f64-only: async func(v: f64) -> result<f64, f64>;
+  get-f32-only: async func(v: f32) -> result<f32, f32>;
+  get-option-u64: async func(v: u64) -> option<u64>;
+  get-option-f64: async func(v: f64) -> option<f64>;
+  get-option-f32: async func(v: f32) -> option<f32>;
+  get-record-u64: async func(v: u64) -> result<nested-u64, string>;
+
+  record nested-u64 {
+    val: u64,
+    tag: u32,
+  }
 }
 
-interface sync-lower-compute {
-  compute: async func(x: u32) -> u32;
-  // results wider than one flat value: the sync lowering spills them
-  // through a trailing return pointer
-  compute-list: async func(x: u32) -> list<u32>;
-}
-
-interface sync-lower-runner {
-  run-compute: async func(x: u32) -> u32;
-}
-
-world sync-to-async-callee {
-  export sync-lower-compute;
-}
-
-world sync-to-async-caller {
-  import sync-lower-compute;
-  export sync-lower-runner;
-}
-
-interface future-transfer-runner {
-  run-future-transfer: async func(value: u32) -> u32;
-}
-
-world future-transfer-g2g-callee {
-  export future-transfer-source;
-}
-
-world future-transfer-g2g-caller {
-  import future-transfer-source;
-  export future-transfer-runner;
-}
-
-// wit-bindgen inter-task-wakeup (guest-internal unit stream): one export
-// spawns a detached pump task that parks on a host import; a second export
-// parks on a purely Rust-originating waker that the pump fires when the
-// import resolves
-world inter-task-wakeup {
-  import wakeup-tick: async func() -> u32;
-  export start-pump: async func();
-  export await-wake: async func() -> u32;
+world async-result-scalars {
+  export result-scalars-api;
 }
 
 // Guest->guest async calls whose flat param count exceeds
@@ -875,30 +850,31 @@ world async-g2g-spillover-caller {
   export run-add5-parked: async func(p1: u32, p2: u32, p3: u32, p4: u32, p5: u32) -> u32;
 }
 
-interface reexport-source {
-  resource widget {
-    poke: func() -> u32;
-  }
-  make-widget: async func() -> result<widget, string>;
+// wit-bindgen inter-task-wakeup (guest-internal unit stream): one export
+// spawns a detached pump task that parks on a host import; a second export
+// parks on a purely Rust-originating waker that the pump fires when the
+// import resolves.
+world inter-task-wakeup {
+  import wakeup-tick: async func() -> u32;
+  export start-pump: async func();
+  export await-wake: async func() -> u32;
 }
 
-interface reexport-runner {
-  run-reexport: async func() -> result<u32, string>;
+interface future-transfer-source {
+  make-future: func(value: u32) -> future<u32>;
 }
 
-interface reexport-handoff {
-  use reexport-source.{widget};
-  poke-widget: async func(w: widget) -> u32;
+interface future-transfer-runner {
+  run-future-transfer: async func(value: u32) -> u32;
 }
 
-world resource-reexport-callee {
-  export reexport-source;
+world future-transfer-g2g-callee {
+  export future-transfer-source;
 }
 
-world resource-reexport-caller {
-  import reexport-source;
-  export reexport-runner;
-  export reexport-handoff;
+world future-transfer-g2g-caller {
+  import future-transfer-source;
+  export future-transfer-runner;
 }
 
 interface stream-transfer-source {
@@ -947,4 +923,50 @@ world stream-echo-g2g-callee {
 world stream-echo-g2g-caller {
   import stream-echo-source;
   export stream-echo-runner;
+}
+
+interface sync-lower-compute {
+  compute: async func(x: u32) -> u32;
+  // results wider than one flat value: the sync lowering spills them
+  // through a trailing return pointer
+  compute-list: async func(x: u32) -> list<u32>;
+}
+
+interface sync-lower-runner {
+  run-compute: async func(x: u32) -> u32;
+}
+
+world sync-to-async-callee {
+  export sync-lower-compute;
+}
+
+world sync-to-async-caller {
+  import sync-lower-compute;
+  export sync-lower-runner;
+}
+
+interface reexport-source {
+  resource widget {
+    poke: func() -> u32;
+  }
+  make-widget: async func() -> result<widget, string>;
+}
+
+interface reexport-runner {
+  run-reexport: async func() -> result<u32, string>;
+}
+
+interface reexport-handoff {
+  use reexport-source.{widget};
+  poke-widget: async func(w: widget) -> u32;
+}
+
+world resource-reexport-callee {
+  export reexport-source;
+}
+
+world resource-reexport-caller {
+  import reexport-source;
+  export reexport-runner;
+  export reexport-handoff;
 }

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -923,3 +923,28 @@ world stream-transfer-g2g-caller {
   import stream-transfer-source;
   export stream-transfer-runner;
 }
+
+interface stream-echo-source {
+  // echoes each input value +1 into the returned stream, closing it when
+  // the input closes
+  make-echo: async func(input: stream<u8>) -> stream<u8>;
+  // produces [seed, seed+1, seed+2] then closes
+  make-source: async func(seed: u8) -> stream<u8>;
+}
+
+interface stream-echo-runner {
+  run-stream-echo: async func(seed: u8) -> u32;
+  // wires make-source's output back into make-echo: the source stream's
+  // read end is transferred out of the callee (return position) and back
+  // in (argument position), leaving both ends inside the callee
+  run-stream-relay: async func(seed: u8) -> u32;
+}
+
+world stream-echo-g2g-callee {
+  export stream-echo-source;
+}
+
+world stream-echo-g2g-caller {
+  import stream-echo-source;
+  export stream-echo-runner;
+}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -900,3 +900,20 @@ world resource-reexport-caller {
   export reexport-runner;
   export reexport-handoff;
 }
+
+interface stream-transfer-source {
+  make-stream: func(seed: u8) -> stream<u8>;
+}
+
+interface stream-transfer-runner {
+  run-stream-transfer: async func(seed: u8) -> u32;
+}
+
+world stream-transfer-g2g-callee {
+  export stream-transfer-source;
+}
+
+world stream-transfer-g2g-caller {
+  import stream-transfer-source;
+  export stream-transfer-runner;
+}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -824,7 +824,7 @@ world future-transfer-g2g-caller {
 // wit-bindgen inter-task-wakeup (guest-internal unit stream): one export
 // spawns a detached pump task that parks on a host import; a second export
 // parks on a purely Rust-originating waker that the pump fires when the
-// import resolves (see lann/jco#13, lann/jco#11)
+// import resolves
 world inter-task-wakeup {
   import wakeup-tick: async func() -> u32;
   export start-pump: async func();
@@ -833,7 +833,7 @@ world inter-task-wakeup {
 
 // Guest->guest async calls whose flat param count exceeds
 // MAX_FLAT_ASYNC_PARAMS (4), forcing the caller side to spill params to
-// memory while the callee still receives them flat (see lann/jco#14)
+// memory while the callee still receives them flat
 interface spillover-g2g-api {
   add5: async func(p1: u32, p2: u32, p3: u32, p4: u32, p5: u32) -> u32;
   concat3: async func(a: string, b: string, c: u8) -> string;
@@ -866,10 +866,6 @@ interface reexport-runner {
   run-reexport: async func() -> result<u32, string>;
 }
 
-// Naming the fused component's resource type in an exported interface is
-// the lann/jco#51 trigger: the composition's taskReturn lift metadata for
-// make-widget then references the resource class generated for this
-// export, above its declaration.
 interface reexport-handoff {
   use reexport-source.{widget};
   poke-widget: async func(w: widget) -> u32;

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -854,3 +854,33 @@ world async-g2g-spillover-caller {
   export run-concat3: async func(a: string, b: string, c: u8) -> string;
   export run-add5-parked: async func(p1: u32, p2: u32, p3: u32, p4: u32, p5: u32) -> u32;
 }
+
+interface reexport-source {
+  resource widget {
+    poke: func() -> u32;
+  }
+  make-widget: async func() -> result<widget, string>;
+}
+
+interface reexport-runner {
+  run-reexport: async func() -> result<u32, string>;
+}
+
+// Naming the fused component's resource type in an exported interface is
+// the lann/jco#51 trigger: the composition's taskReturn lift metadata for
+// make-widget then references the resource class generated for this
+// export, above its declaration.
+interface reexport-handoff {
+  use reexport-source.{widget};
+  poke-widget: async func(w: widget) -> u32;
+}
+
+world resource-reexport-callee {
+  export reexport-source;
+}
+
+world resource-reexport-caller {
+  import reexport-source;
+  export reexport-runner;
+  export reexport-handoff;
+}

--- a/crates/test-components/wit/all.wit
+++ b/crates/test-components/wit/all.wit
@@ -903,10 +903,16 @@ world resource-reexport-caller {
 
 interface stream-transfer-source {
   make-stream: func(seed: u8) -> stream<u8>;
+  // async-lifted variant: the exporting task stays alive (callback protocol)
+  // until its spawned writer completes, so the stream reaches close
+  make-stream-async: async func(seed: u8) -> stream<u8>;
 }
 
 interface stream-transfer-runner {
   run-stream-transfer: async func(seed: u8) -> u32;
+  // reads the composed stream to close (callee task must outlive its
+  // return to drive the spawned writer -- async-lifted callee export)
+  run-stream-transfer-all: async func(seed: u8) -> u32;
 }
 
 world stream-transfer-g2g-callee {

--- a/packages/jco-transpile/test/jspi.ts
+++ b/packages/jco-transpile/test/jspi.ts
@@ -146,7 +146,7 @@ suite('Host Import Async (JSPI)', () => {
         } catch {}
     });
 
-    // Ensure async imports whose promises settle without ever yielding to 
+    // Ensure async imports whose promises settle without ever yielding to
     // the macrotask queue must still resume the suspended guest,
     // on every call (not just the first).
     test.concurrent('Transpile async, import settles without macrotask yield, repeated calls (NodeJS, JSPI)', async () => {

--- a/packages/jco-transpile/test/jspi.ts
+++ b/packages/jco-transpile/test/jspi.ts
@@ -145,4 +145,63 @@ suite('Host Import Async (JSPI)', () => {
             await rm(outFile);
         } catch {}
     });
+
+    // Regression test for https://github.com/lann/jco/issues/5 -- async imports whose
+    // promise settles without ever yielding to the macrotask queue must still resume
+    // the suspended guest, on every call (not just the first).
+    test.concurrent('Transpile async, import settles without macrotask yield, repeated calls (NodeJS, JSPI)', async () => {
+        if (typeof WebAssembly?.Suspending !== 'function') {
+            return;
+        }
+        const tmpDir = await getTmpDir();
+        const outDir = resolve(tmpDir, 'out-component-dir');
+        const outFile = resolve(tmpDir, 'out-component-file');
+
+        const modulesDir = resolve(tmpDir, 'node_modules', '@bytecodealliance');
+        await mkdir(modulesDir, { recursive: true });
+        await symlink(
+            fileURLToPath(new URL('../packages/preview2-shim', import.meta.url)),
+            resolve(modulesDir, 'preview2-shim'),
+            'dir',
+        );
+
+        let calls = 0;
+        const { instance, cleanup } = await setupAsyncTest({
+            asyncMode: 'jspi',
+            component: {
+                name: 'async_call',
+                path: resolve('test/fixtures/components/runtime/async_call.component.wasm'),
+                imports: {
+                    'something:test/test-interface': {
+                        // NOTE: intentionally an already-settled promise with no
+                        // intervening macrotask hop
+                        callAsync: () => {
+                            calls += 1;
+                            return Promise.resolve(`called async ${calls}`);
+                        },
+                        callSync: () => 'called sync',
+                    },
+                },
+            },
+            jco: {
+                transpile: {
+                    extraArgs: {
+                        asyncImports: ['something:test/test-interface#call-async'],
+                        asyncExports: ['run-async'],
+                    },
+                },
+            },
+        });
+
+        for (let i = 1; i <= 3; i++) {
+            assert.strictEqual(await instance.runAsync(), `called async ${i}`);
+        }
+
+        await cleanup();
+
+        try {
+            await rm(outDir, { recursive: true });
+            await rm(outFile);
+        } catch {}
+    });
 });

--- a/packages/jco-transpile/test/jspi.ts
+++ b/packages/jco-transpile/test/jspi.ts
@@ -146,9 +146,9 @@ suite('Host Import Async (JSPI)', () => {
         } catch {}
     });
 
-    // Regression test for https://github.com/lann/jco/issues/5 -- async imports whose
-    // promise settles without ever yielding to the macrotask queue must still resume
-    // the suspended guest, on every call (not just the first).
+    // Ensure async imports whose promises settle without ever yielding to 
+    // the macrotask queue must still resume the suspended guest,
+    // on every call (not just the first).
     test.concurrent('Transpile async, import settles without macrotask yield, repeated calls (NodeJS, JSPI)', async () => {
         if (typeof WebAssembly?.Suspending !== 'function') {
             return;

--- a/packages/jco-transpile/test/p3/async-g2g-spillover.ts
+++ b/packages/jco-transpile/test/p3/async-g2g-spillover.ts
@@ -7,14 +7,16 @@ import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR } from '../common.js';
 import { WASIShim } from '@bytecodealliance/preview2-shim/instantiation';
 
 // Regression tests for guest->guest async calls through a composition whose
-// flat param count exceeds MAX_FLAT_ASYNC_PARAMS (4): the caller's async
-// lower spills its arguments to memory (passing a single pointer), while
-// the async-lifted callee still receives up to MAX_FLAT_PARAMS (16) flat
-// params. The fused [async-start] adapter converts between the two;
+// flat param count exceeds different thresholds:
+//
+// MAX_FLAT_ASYNC_PARAMS (4): the caller's async
+// lower spills its arguments to memory (passing a single pointer).
+// The async-lifted callee still receives up to MAX_FLAT_PARAMS (16) flat
+// params.
+//
+// The fused [async-start] adapter converts between the two;
 // _asyncStartCall previously asserted the two counts were equal and threw
 // 'unexpected callee param count [1], expected [5]'.
-//
-// See lann/jco#14
 suite('guest->guest async calls with spilled params', () => {
     test('5 x u32 params through a composition', async () => {
         const componentPath = await composeCallerCallee({

--- a/packages/jco-transpile/test/p3/async-result-scalars.ts
+++ b/packages/jco-transpile/test/p3/async-result-scalars.ts
@@ -1,0 +1,94 @@
+import { join } from 'node:path';
+
+import { suite, test, assert, beforeAll, afterAll } from 'vitest';
+
+import { setupAsyncTest } from '../helpers.js';
+import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR } from '../common.js';
+import { WASIShim } from '@bytecodealliance/preview2-shim/instantiation';
+
+// Regression tests for lifting variant payloads from direct params
+// (e.g. small results returned by async exports via `task.return`).
+//
+// In the flat representation, a variant's payload slots are the *join* of
+// all case representations: a slot whose joined core type differs from the
+// selected case's core type must be reinterpreted, not merely converted
+// (see CanonicalABI `lift_flat_variant`). Previously any leading BigInt
+// param was coerced to a Number unless the payload was exactly f64,
+// breaking i64 payloads ('expected bigint' for result<u64, string>,
+// option<u64>, and records with a leading u64 field), throwing for
+// all-f64 joins ('Cannot convert 1.5 to a BigInt'), and silently
+// corrupting all-f32 joins (1.5 -> 1.4e-45).
+//
+suite('async export scalar results (direct-param task.return)', () => {
+    let instance, cleanup;
+
+    beforeAll(async () => {
+        const setupRes = await setupAsyncTest({
+            asyncMode: 'jspi',
+            component: {
+                name: 'async-result-scalars',
+                path: join(LOCAL_TEST_COMPONENTS_DIR, 'async-result-scalars.wasm'),
+                imports: { ...new WASIShim().getImportObject() },
+            },
+        });
+        instance = setupRes.instance;
+        cleanup = setupRes.cleanup;
+    });
+
+    afterAll(async () => {
+        await cleanup();
+    });
+
+    const api = () => instance['jco:test-components/result-scalars-api'];
+
+    test('result<u64, string> ok', async () => {
+        assert.instanceOf(api().getU64Ok, AsyncFunction);
+        assert.strictEqual(await api().getU64Ok(42n), 42n);
+        assert.strictEqual(await api().getU64Ok(2n ** 64n - 1n), 2n ** 64n - 1n);
+    });
+
+    test('result<u64, string> err', async () => {
+        try {
+            await api().getU64Err('boom');
+            assert.fail('expected err result to throw');
+        } catch (err) {
+            assert.strictEqual(err.payload ?? err, 'boom');
+        }
+    });
+
+    test('result<s64, string> ok', async () => {
+        assert.strictEqual(await api().getS64Ok(-42n), -42n);
+        assert.strictEqual(await api().getS64Ok(-(2n ** 63n)), -(2n ** 63n));
+    });
+
+    test('result<f64, string> ok (payload joined through i64)', async () => {
+        assert.strictEqual(await api().getF64Ok(1.5), 1.5);
+        assert.strictEqual(await api().getF64Ok(-0.25), -0.25);
+    });
+
+    test('result<f64, f64> ok (join stays f64)', async () => {
+        assert.strictEqual(await api().getF64Only(1.5), 1.5);
+    });
+
+    test('result<f32, f32> ok (join stays f32)', async () => {
+        assert.strictEqual(await api().getF32Only(1.5), 1.5);
+    });
+
+    // NOTE: non-nullable option<T> lifts are currently represented as
+    // tagged objects rather than smoothed to the payload value
+    test('option<u64>', async () => {
+        assert.deepEqual(await api().getOptionU64(42n), { tag: 'some', val: 42n });
+    });
+
+    test('option<f64>', async () => {
+        assert.deepEqual(await api().getOptionF64(2.5), { tag: 'some', val: 2.5 });
+    });
+
+    test('option<f32>', async () => {
+        assert.deepEqual(await api().getOptionF32(2.5), { tag: 'some', val: 2.5 });
+    });
+
+    test('result<record{u64, u32}, string> ok (joined slots inside a record payload)', async () => {
+        assert.deepEqual(await api().getRecordU64(43n), { val: 43n, tag: 7 });
+    });
+});

--- a/packages/jco-transpile/test/p3/future-transfer-g2g.ts
+++ b/packages/jco-transpile/test/p3/future-transfer-g2g.ts
@@ -18,13 +18,13 @@ suite('guest->guest future transfer', () => {
     // setupAsyncTest) throws:
     //   ReferenceError: Cannot access 'trampolineN' before initialization
     //
-    // NOTE: this test only asserts successful instantiation and export
-    // shape. Actually *calling* runFutureTransfer does not work yet: the
-    // futureTransfer intrinsic is currently a stub that returns undefined
-    // (the receiving component then traps on future rep [0]). Once future
-    // transfer is implemented, this test should be extended to assert
-    // `await instance[EXPORT_NAME].runFutureTransfer(41) === 42`.
-    test('composed component with cross-component future instantiates', async () => {
+    // The value assertion covers the futureTransfer intrinsic itself
+    // (formerly an unimplemented stub that handed the receiving component
+    // future rep [0]): the callee's sync-lifted
+    // `make-future` returns a future written by a spawned task, the read
+    // end is transferred to the caller on the fused return path, and the
+    // caller awaits the value (seed + 1).
+    test('composed component with cross-component future round trip', async () => {
         const componentPath = await composeCallerCallee({
             callerPath: join(LOCAL_TEST_COMPONENTS_DIR, 'future-transfer-g2g-caller.wasm'),
             calleePath: join(LOCAL_TEST_COMPONENTS_DIR, 'future-transfer-g2g-callee.wasm'),
@@ -46,6 +46,7 @@ suite('guest->guest future transfer', () => {
         });
         try {
             assert.instanceOf(instance[EXPORT_NAME].runFutureTransfer, AsyncFunction);
+            assert.strictEqual(await instance[EXPORT_NAME].runFutureTransfer(41), 42);
         } finally {
             await cleanup();
         }

--- a/packages/jco-transpile/test/p3/inter-task-wakeup.ts
+++ b/packages/jco-transpile/test/p3/inter-task-wakeup.ts
@@ -24,7 +24,6 @@ function withTimeout(promise, ms, label) {
 // import across an export-call boundary, with a subsequent export call on
 // the same instance.
 //
-// See lann/jco#13 and lann/jco#11
 suite('guest inter-task wakeup', () => {
     test('detached pump task wakes a parked Rust waker across CM tasks', async () => {
         let resolveTick;

--- a/packages/jco-transpile/test/p3/resource-reexport-tdz.ts
+++ b/packages/jco-transpile/test/p3/resource-reexport-tdz.ts
@@ -10,13 +10,13 @@ const RUNNER_EXPORT = 'jco:test-components/reexport-runner';
 const HANDOFF_EXPORT = 'jco:test-components/reexport-handoff';
 
 suite('composed component re-exporting a fused resource type', () => {
-    // When an async cross-component call returns an owned resource across the fused 
+    // When an async cross-component call returns an owned resource across the fused
     // boundary AND the same resource type is re-exported by one of the composition's
     // exported interfaces, the taskReturn trampoline's lift metadata used to
     // reference the resource class directly (`className: Widget`) above
-    // the `class Widget { ... }` declaration. 
+    // the `class Widget { ... }` declaration.
     //
-    // Trampoline binds were previously evaluated at the module top level rather than the 
+    // Trampoline binds were previously evaluated at the module top level rather than the
     // call site, the class was not available for creation. With the fix in,
     // the class is referred to at the time of creation (not at bind time).
     test('instantiates and returns the owned resource across the boundary', async () => {

--- a/packages/jco-transpile/test/p3/resource-reexport-tdz.ts
+++ b/packages/jco-transpile/test/p3/resource-reexport-tdz.ts
@@ -1,0 +1,54 @@
+import { join } from 'node:path';
+
+import { assert, suite, test } from 'vitest';
+import { WASIShim } from '@bytecodealliance/preview2-shim/instantiation';
+
+import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR } from '../common.js';
+import { composeCallerCallee, setupAsyncTest } from '../helpers.js';
+
+const RUNNER_EXPORT = 'jco:test-components/reexport-runner';
+const HANDOFF_EXPORT = 'jco:test-components/reexport-handoff';
+
+suite('composed component re-exporting a fused resource type', () => {
+    // Regression test for lann/jco#51: when an async cross-component call
+    // returns an owned resource across the fused boundary AND the same
+    // resource type is re-exported by one of the composition's exported
+    // interfaces, the taskReturn trampoline's lift metadata used to
+    // reference the resource class directly (`className: Widget`) above
+    // the `class Widget { ... }` declaration. Trampoline binds evaluate at
+    // module top level (plain ESM) or at instantiation, so the module
+    // died with:
+    //   ReferenceError: Cannot access 'Widget' before initialization
+    // The metadata now defers the reference behind a thunk (classNameFn).
+    test('instantiates and returns the owned resource across the boundary', async () => {
+        const componentPath = await composeCallerCallee({
+            callerPath: join(LOCAL_TEST_COMPONENTS_DIR, 'resource-reexport-g2g-caller.wasm'),
+            calleePath: join(LOCAL_TEST_COMPONENTS_DIR, 'resource-reexport-g2g-callee.wasm'),
+        });
+        const { instance, cleanup } = await setupAsyncTest({
+            asyncMode: 'jspi',
+            component: {
+                name: 'resource-reexport-g2g',
+                path: componentPath,
+                imports: { ...new WASIShim().getImportObject() },
+            },
+            jco: {
+                transpile: {
+                    extraArgs: {
+                        minify: false,
+                        asyncExports: [`${RUNNER_EXPORT}#run-reexport`, `${HANDOFF_EXPORT}#poke-widget`],
+                    },
+                },
+            },
+        });
+        try {
+            assert.instanceOf(instance[RUNNER_EXPORT].runReexport, AsyncFunction);
+            assert.isFunction(instance[HANDOFF_EXPORT].pokeWidget);
+            // The call rides the once-TDZ'd lift metadata: the callee's
+            // widget is lifted through the composition's taskReturn path.
+            assert.strictEqual(await instance[RUNNER_EXPORT].runReexport(), 42);
+        } finally {
+            await cleanup();
+        }
+    });
+});

--- a/packages/jco-transpile/test/p3/resource-reexport-tdz.ts
+++ b/packages/jco-transpile/test/p3/resource-reexport-tdz.ts
@@ -10,16 +10,15 @@ const RUNNER_EXPORT = 'jco:test-components/reexport-runner';
 const HANDOFF_EXPORT = 'jco:test-components/reexport-handoff';
 
 suite('composed component re-exporting a fused resource type', () => {
-    // Regression test for lann/jco#51: when an async cross-component call
-    // returns an owned resource across the fused boundary AND the same
-    // resource type is re-exported by one of the composition's exported
-    // interfaces, the taskReturn trampoline's lift metadata used to
+    // When an async cross-component call returns an owned resource across the fused 
+    // boundary AND the same resource type is re-exported by one of the composition's
+    // exported interfaces, the taskReturn trampoline's lift metadata used to
     // reference the resource class directly (`className: Widget`) above
-    // the `class Widget { ... }` declaration. Trampoline binds evaluate at
-    // module top level (plain ESM) or at instantiation, so the module
-    // died with:
-    //   ReferenceError: Cannot access 'Widget' before initialization
-    // The metadata now defers the reference behind a thunk (classNameFn).
+    // the `class Widget { ... }` declaration. 
+    //
+    // Trampoline binds were previously evaluated at the module top level rather than the 
+    // call site, the class was not available for creation. With the fix in,
+    // the class is referred to at the time of creation (not at bind time).
     test('instantiates and returns the owned resource across the boundary', async () => {
         const componentPath = await composeCallerCallee({
             callerPath: join(LOCAL_TEST_COMPONENTS_DIR, 'resource-reexport-g2g-caller.wasm'),

--- a/packages/jco-transpile/test/p3/stream-echo-g2g.ts
+++ b/packages/jco-transpile/test/p3/stream-echo-g2g.ts
@@ -1,0 +1,67 @@
+import { join } from 'node:path';
+
+import { afterAll, assert, beforeAll, suite, test } from 'vitest';
+import { WASIShim } from '@bytecodealliance/preview2-shim/instantiation';
+
+import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR } from '../common.js';
+import { composeCallerCallee, setupAsyncTest } from '../helpers.js';
+
+const EXPORT_NAME = 'jco:test-components/stream-echo-runner';
+
+suite('guest->guest stream echo pumps', () => {
+    let instance;
+    let cleanup;
+
+    beforeAll(async () => {
+        const componentPath = await composeCallerCallee({
+            callerPath: join(LOCAL_TEST_COMPONENTS_DIR, 'stream-echo-g2g-caller.wasm'),
+            calleePath: join(LOCAL_TEST_COMPONENTS_DIR, 'stream-echo-g2g-callee.wasm'),
+        });
+        ({ instance, cleanup } = await setupAsyncTest({
+            asyncMode: 'jspi',
+            component: {
+                name: 'stream-echo-g2g',
+                path: componentPath,
+                imports: { ...new WASIShim().getImportObject() },
+            },
+            jco: {
+                transpile: {
+                    extraArgs: {
+                        minify: false,
+                    },
+                },
+            },
+        }));
+    });
+
+    afterAll(async () => {
+        await cleanup?.();
+    });
+
+    // The callee's echo pump parks a read on the argument stream before the
+    // caller's first write; the write must rendezvous with the parked
+    // cross-component read and wake it, and the echoed values must flow
+    // back until close. Caller writes [seed, seed+1, seed+2]; the pump
+    // echoes each value +1.
+    test('echo pump across a composition', async () => {
+        assert.instanceOf(instance[EXPORT_NAME].runStreamEcho, AsyncFunction);
+        assert.strictEqual(await instance[EXPORT_NAME].runStreamEcho(7), 8 + 9 + 10);
+    });
+
+    // Regression test for the execution-slot deadlock (lann/jco#40,
+    // lann/jco#11): make-source's task legally outlives its return (its
+    // adopted writer pump stays parked), and make-echo then enters the same
+    // component while it is still live. Task entry must be governed by
+    // backpressure + the per-slice exclusive lock, not serialized on the
+    // previous task's exit -- otherwise make-echo never runs, the source's
+    // writer never finds a reader, and both components poll their waitable
+    // sets forever. The source stream's read end is also transferred out of
+    // the callee (return position) and straight back in (argument position),
+    // leaving both of its ends inside the callee, matching the wedged-stream
+    // topology from lann/jco#40. Verified to match wasmtime 47
+    // (`--invoke run-stream-relay(7)` returns 27).
+    test('relay through two live callee tasks', async () => {
+        assert.instanceOf(instance[EXPORT_NAME].runStreamRelay, AsyncFunction);
+        assert.strictEqual(await instance[EXPORT_NAME].runStreamRelay(7), 8 + 9 + 10);
+    });
+});

--- a/packages/jco-transpile/test/p3/stream-echo-g2g.ts
+++ b/packages/jco-transpile/test/p3/stream-echo-g2g.ts
@@ -48,18 +48,21 @@ suite('guest->guest stream echo pumps', () => {
         assert.strictEqual(await instance[EXPORT_NAME].runStreamEcho(7), 8 + 9 + 10);
     });
 
-    // Regression test for the execution-slot deadlock (lann/jco#40,
-    // lann/jco#11): make-source's task legally outlives its return (its
-    // adopted writer pump stays parked), and make-echo then enters the same
-    // component while it is still live. Task entry must be governed by
-    // backpressure + the per-slice exclusive lock, not serialized on the
-    // previous task's exit -- otherwise make-echo never runs, the source's
-    // writer never finds a reader, and both components poll their waitable
-    // sets forever. The source stream's read end is also transferred out of
-    // the callee (return position) and straight back in (argument position),
-    // leaving both of its ends inside the callee, matching the wedged-stream
-    // topology from lann/jco#40. Verified to match wasmtime 47
-    // (`--invoke run-stream-relay(7)` returns 27).
+    // Regression test for execution-slot deadlock
+    //
+    // make-source's task legally outlives its return (its adopted writer
+    // pump stays parked), and  make-echo then enters the same component
+    // while it is still live.
+    //
+    // Task entry must be governed by backpressure + the per-slice exclusive lock,
+    // not serialized on the previous task's exit -- otherwise make-echo never runs,
+    // the source's writer never finds a reader, and both components poll their waitable
+    // sets forever.
+    //
+    // The source stream's read end is also transferred out of the callee (return position)
+    // and straight back in (argument position), leaving both of its ends inside the callee.,
+    //
+    // Verified to match wasmtime 47 (`--invoke run-stream-relay(7)` returns 27).
     test('relay through two live callee tasks', async () => {
         assert.instanceOf(instance[EXPORT_NAME].runStreamRelay, AsyncFunction);
         assert.strictEqual(await instance[EXPORT_NAME].runStreamRelay(7), 8 + 9 + 10);

--- a/packages/jco-transpile/test/p3/stream-lifts.ts
+++ b/packages/jco-transpile/test/p3/stream-lifts.ts
@@ -126,6 +126,31 @@ suite('stream<T> lifts', () => {
         assert.deepEqual(await stream.next(), { value: undefined, done: true });
     });
 
+    // Regression test for stream read batching: a read with an explicit count
+    // must transfer up to that many elements per canonical read, not one
+    // element at a time
+    test.concurrent('u8 reads are batched up to the requested count', async () => {
+        const instance = await getInstance();
+        const vals = Array.from({ length: 5000 }, (_, i) => i % 256);
+        const stream = await instance['jco:test-components/get-stream-async'].getStreamU8(vals);
+
+        const chunks = [];
+        let total = 0;
+        while (total < vals.length) {
+            const { value, done } = await stream.read({ count: 4096 });
+            if (done) { break; }
+            assert.instanceOf(value, Uint8Array);
+            chunks.push(value);
+            total += value.length;
+            // The guest writes all 5000 elements in a single write; reads of
+            // count=4096 must complete in a small number of large chunks
+            assert.isBelow(chunks.length, 10, 'too many reads: stream reads are not batching');
+        }
+        assert.strictEqual(total, vals.length);
+        assert.isAtLeast(chunks[0].length, 1000, 'first read returned a small chunk despite count=4096');
+        assert.deepEqual(new Uint8Array(chunks.flatMap((c) => [...c])), new Uint8Array(vals));
+    });
+
     test.concurrent('u16/s16', async () => {
         const instance = await getInstance();
         assert.instanceOf(instance['jco:test-components/get-stream-async'].getStreamU16, AsyncFunction);

--- a/packages/jco-transpile/test/p3/stream-lifts.ts
+++ b/packages/jco-transpile/test/p3/stream-lifts.ts
@@ -138,7 +138,9 @@ suite('stream<T> lifts', () => {
         let total = 0;
         while (total < vals.length) {
             const { value, done } = await stream.read({ count: 4096 });
-            if (done) { break; }
+            if (done) {
+                break;
+            }
             assert.instanceOf(value, Uint8Array);
             chunks.push(value);
             total += value.length;

--- a/packages/jco-transpile/test/p3/stream-lowers.ts
+++ b/packages/jco-transpile/test/p3/stream-lowers.ts
@@ -204,7 +204,10 @@ suite('stream<T> lowers', () => {
             assert.isBelow(chunks.length, 4, 'sync iterable was pumped one element per canonical write');
             assert.isAtLeast(chunks[0].length, 100, 'first chunk unexpectedly small');
             assert.deepEqual(
-                toTypedArray(Uint8Array, chunks.flatMap((c) => [...c])),
+                toTypedArray(
+                    Uint8Array,
+                    chunks.flatMap((c) => [...c]),
+                ),
                 toTypedArray(Uint8Array, vals),
             );
         });

--- a/packages/jco-transpile/test/p3/stream-lowers.ts
+++ b/packages/jco-transpile/test/p3/stream-lowers.ts
@@ -186,6 +186,29 @@ suite('stream<T> lowers', () => {
             assert.deepEqual(returnedVals, toTypedArray(Int8Array, vals));
         });
 
+        // Regression test for host->guest pumping of synchronous iterables:
+        // sync sources must be drained eagerly up to the guest's requested
+        // count instead of one item per canonical write.
+        //
+        // The guest reads with count=4096 and reports each canonical read's
+        // values as a separate chunk; pre-fix every chunk contained a single
+        // element (500 canonical writes at ~12ms each).
+        test.concurrent('u8 sync iterable is drained in batches', async () => {
+            const instance = await getInstance();
+            assert.instanceOf(
+                instance['jco:test-components/stream-lower-async'].readStreamValuesU8BulkChunks,
+                AsyncFunction,
+            );
+            const vals = Array.from({ length: 500 }, (_, i) => i % 256);
+            const chunks = await instance['jco:test-components/stream-lower-async'].readStreamValuesU8BulkChunks(vals);
+            assert.isBelow(chunks.length, 4, 'sync iterable was pumped one element per canonical write');
+            assert.isAtLeast(chunks[0].length, 100, 'first chunk unexpectedly small');
+            assert.deepEqual(
+                toTypedArray(Uint8Array, chunks.flatMap((c) => [...c])),
+                toTypedArray(Uint8Array, vals),
+            );
+        });
+
         test.concurrent('u16/s16', async () => {
             const instance = await getInstance();
             assert.instanceOf(instance['jco:test-components/stream-lower-async'].readStreamValuesU16, AsyncFunction);

--- a/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
+++ b/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
@@ -70,4 +70,22 @@ suite('guest->guest stream transfer', () => {
         // callee writes [seed, seed+1, seed+2] then closes; caller sums them
         assert.strictEqual(await instance[EXPORT_NAME].runStreamTransferAll(7), 7 + 8 + 9);
     });
+
+    // When round-tripped read ends go back to the callee in argument
+    // position, completing the stream needs *two* live tasks on the
+    // callee instance — make-stream-async (alive until its spawned
+    // writer finishes) and sum-stream (whose read is the only thing
+    // that can finish that writer).
+    //
+    // Previously when one task was created per instance, the second
+    // task (sum-stream) would enter but could not be driven.
+    //
+    // To fix this we added concurrent task lifetimes that coordinate reads
+    // with pending writes so the stream can close.
+    // See: wasmtime 47's `--invoke run-stream-transfer-roundtrip(7)`
+    test('async call: round-tripped stream read to close across a composition', async () => {
+        assert.instanceOf(instance[EXPORT_NAME].runStreamTransferRoundtrip, AsyncFunction);
+        // callee writes [seed, seed+1, seed+2] then closes; callee sums them
+        assert.strictEqual(await instance[EXPORT_NAME].runStreamTransferRoundtrip(7), 7 + 8 + 9);
+    });
 });

--- a/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
+++ b/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
@@ -45,13 +45,12 @@ suite('guest->guest stream transfer', () => {
     // context from that register (it previously threw
     // 'missing global current task'). Per the Canonical ABI the transfer is
     // a pure table operation between the source and destination components.
-    // See lann/jco#35.
     //
     // The caller does a *bounded* read of the three values: a sync-lifted
     // export cannot leave detached work behind, so the callee's writer gets
     // exactly one inline poll (registering the pending write, which the
     // caller's read rendezvouses with) and the stream never reaches close.
-    // wasmtime behaves identically for this shape (see lann/jco#39).
+    // wasmtime behaves identically for this shape.
     test('sync call: stream in return position across a composition', async () => {
         assert.instanceOf(instance[EXPORT_NAME].runStreamTransfer, AsyncFunction);
         // callee writes [seed, seed+1, seed+2]; caller sums them
@@ -64,28 +63,9 @@ suite('guest->guest stream transfer', () => {
     // completes, so the writable end drops, the transferred stream reaches
     // close, and the caller's collect() terminates. Verified to match
     // wasmtime 47 (`--invoke run-stream-transfer-all(7)` returns 24).
-    // See lann/jco#39.
     test('async call: stream read to close across a composition', async () => {
         assert.instanceOf(instance[EXPORT_NAME].runStreamTransferAll, AsyncFunction);
         // callee writes [seed, seed+1, seed+2] then closes; caller sums them
         assert.strictEqual(await instance[EXPORT_NAME].runStreamTransferAll(7), 7 + 8 + 9);
-    });
-
-    // When round-tripped read ends go back to the callee in argument
-    // position, completing the stream needs *two* live tasks on the
-    // callee instance — make-stream-async (alive until its spawned
-    // writer finishes) and sum-stream (whose read is the only thing
-    // that can finish that writer).
-    //
-    // Previously when one task was created per instance, the second
-    // task (sum-stream) would enter but could not be driven.
-    //
-    // To fix this we added concurrent task lifetimes that coordinate reads
-    // with pending writes so the stream can close.
-    // See: wasmtime 47's `--invoke run-stream-transfer-roundtrip(7)`
-    test('async call: round-tripped stream read to close across a composition', async () => {
-        assert.instanceOf(instance[EXPORT_NAME].runStreamTransferRoundtrip, AsyncFunction);
-        // callee writes [seed, seed+1, seed+2] then closes; callee sums them
-        assert.strictEqual(await instance[EXPORT_NAME].runStreamTransferRoundtrip(7), 7 + 8 + 9);
     });
 });

--- a/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
+++ b/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
@@ -1,6 +1,6 @@
 import { join } from 'node:path';
 
-import { assert, suite, test } from 'vitest';
+import { afterAll, assert, beforeAll, suite, test } from 'vitest';
 import { WASIShim } from '@bytecodealliance/preview2-shim/instantiation';
 
 import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR } from '../common.js';
@@ -9,20 +9,15 @@ import { composeCallerCallee, setupAsyncTest } from '../helpers.js';
 const EXPORT_NAME = 'jco:test-components/stream-transfer-runner';
 
 suite('guest->guest stream transfer', () => {
-    // Regression test: the return-position stream transfer of a fused
-    // *sync* guest->guest call runs after the callee task's teardown has
-    // already cleared the per-component current-task register
-    // (_symmetricSyncGuestCallExit), so streamTransfer must not derive its
-    // context from that register (it previously threw
-    // 'missing global current task'). Per the Canonical ABI the transfer is
-    // a pure table operation between the source and destination components.
-    // See lann/jco#35.
-    test('stream in return position across a composition', async () => {
+    let instance;
+    let cleanup;
+
+    beforeAll(async () => {
         const componentPath = await composeCallerCallee({
             callerPath: join(LOCAL_TEST_COMPONENTS_DIR, 'stream-transfer-g2g-caller.wasm'),
             calleePath: join(LOCAL_TEST_COMPONENTS_DIR, 'stream-transfer-g2g-callee.wasm'),
         });
-        const { instance, cleanup } = await setupAsyncTest({
+        ({ instance, cleanup } = await setupAsyncTest({
             asyncMode: 'jspi',
             component: {
                 name: 'stream-transfer-g2g',
@@ -36,13 +31,43 @@ suite('guest->guest stream transfer', () => {
                     },
                 },
             },
-        });
-        try {
-            assert.instanceOf(instance[EXPORT_NAME].runStreamTransfer, AsyncFunction);
-            // callee writes [seed, seed+1, seed+2]; caller sums them
-            assert.strictEqual(await instance[EXPORT_NAME].runStreamTransfer(7), 7 + 8 + 9);
-        } finally {
-            await cleanup();
-        }
+        }));
+    });
+
+    afterAll(async () => {
+        await cleanup?.();
+    });
+
+    // Regression test: the return-position stream transfer of a fused
+    // *sync* guest->guest call runs after the callee task's teardown has
+    // already cleared the per-component current-task register
+    // (_symmetricSyncGuestCallExit), so streamTransfer must not derive its
+    // context from that register (it previously threw
+    // 'missing global current task'). Per the Canonical ABI the transfer is
+    // a pure table operation between the source and destination components.
+    // See lann/jco#35.
+    //
+    // The caller does a *bounded* read of the three values: a sync-lifted
+    // export cannot leave detached work behind, so the callee's writer gets
+    // exactly one inline poll (registering the pending write, which the
+    // caller's read rendezvouses with) and the stream never reaches close.
+    // wasmtime behaves identically for this shape (see lann/jco#39).
+    test('sync call: stream in return position across a composition', async () => {
+        assert.instanceOf(instance[EXPORT_NAME].runStreamTransfer, AsyncFunction);
+        // callee writes [seed, seed+1, seed+2]; caller sums them
+        assert.strictEqual(await instance[EXPORT_NAME].runStreamTransfer(7), 7 + 8 + 9);
+    });
+
+    // Regression test for the async-lifted shape of "return a stream, then
+    // keep writing": the callee task stays alive after returning the stream
+    // (callback protocol) until its writer spawned via `spawn_local`
+    // completes, so the writable end drops, the transferred stream reaches
+    // close, and the caller's collect() terminates. Verified to match
+    // wasmtime 47 (`--invoke run-stream-transfer-all(7)` returns 24).
+    // See lann/jco#39.
+    test('async call: stream read to close across a composition', async () => {
+        assert.instanceOf(instance[EXPORT_NAME].runStreamTransferAll, AsyncFunction);
+        // callee writes [seed, seed+1, seed+2] then closes; caller sums them
+        assert.strictEqual(await instance[EXPORT_NAME].runStreamTransferAll(7), 7 + 8 + 9);
     });
 });

--- a/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
+++ b/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
@@ -10,11 +10,11 @@ const EXPORT_NAME = 'jco:test-components/stream-transfer-runner';
 
 suite('guest->guest stream transfer', () => {
     // When streams are returned from fused sync guest->guest calls,
-    // the callee task's teardown has already cleared the per-component 
+    // the callee task's teardown has already cleared the per-component
     // current-task register (`_symmetricSyncGuestCallExit`).
     //
     // This means stream.transfer cannot get its context from that register,
-    // and should match the Canonical ABI in being a pure table operation 
+    // and should match the Canonical ABI in being a pure table operation
     // between the source and destination components.
     test('stream in return position across a composition', async () => {
         const componentPath = await composeCallerCallee({

--- a/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
+++ b/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
@@ -1,0 +1,47 @@
+import { join } from 'node:path';
+
+import { assert, suite, test } from 'vitest';
+import { WASIShim } from '@bytecodealliance/preview2-shim/instantiation';
+
+import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR } from '../common.js';
+import { composeCallerCallee, setupAsyncTest } from '../helpers.js';
+
+const EXPORT_NAME = 'jco:test-components/stream-transfer-runner';
+
+suite('guest->guest stream transfer', () => {
+    // When streams are returned from fused sync guest->guest calls,
+    // the callee task's teardown has already cleared the per-component 
+    // current-task register (`_symmetricSyncGuestCallExit`).
+    //
+    // This means stream.transfer cannot get its context from that register,
+    // and should match the Canonical ABI in being a pure table operation 
+    // between the source and destination components.
+    test('stream in return position across a composition', async () => {
+        const componentPath = await composeCallerCallee({
+            callerPath: join(LOCAL_TEST_COMPONENTS_DIR, 'stream-transfer-g2g-caller.wasm'),
+            calleePath: join(LOCAL_TEST_COMPONENTS_DIR, 'stream-transfer-g2g-callee.wasm'),
+        });
+        const { instance, cleanup } = await setupAsyncTest({
+            asyncMode: 'jspi',
+            component: {
+                name: 'stream-transfer-g2g',
+                path: componentPath,
+                imports: { ...new WASIShim().getImportObject() },
+            },
+            jco: {
+                transpile: {
+                    extraArgs: {
+                        minify: false,
+                    },
+                },
+            },
+        });
+        try {
+            assert.instanceOf(instance[EXPORT_NAME].runStreamTransfer, AsyncFunction);
+            // callee writes [seed, seed+1, seed+2]; caller sums them
+            assert.strictEqual(await instance[EXPORT_NAME].runStreamTransfer(7), 7 + 8 + 9);
+        } finally {
+            await cleanup();
+        }
+    });
+});

--- a/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
+++ b/packages/jco-transpile/test/p3/stream-transfer-g2g.ts
@@ -9,13 +9,14 @@ import { composeCallerCallee, setupAsyncTest } from '../helpers.js';
 const EXPORT_NAME = 'jco:test-components/stream-transfer-runner';
 
 suite('guest->guest stream transfer', () => {
-    // When streams are returned from fused sync guest->guest calls,
-    // the callee task's teardown has already cleared the per-component
-    // current-task register (`_symmetricSyncGuestCallExit`).
-    //
-    // This means stream.transfer cannot get its context from that register,
-    // and should match the Canonical ABI in being a pure table operation
-    // between the source and destination components.
+    // Regression test: the return-position stream transfer of a fused
+    // *sync* guest->guest call runs after the callee task's teardown has
+    // already cleared the per-component current-task register
+    // (_symmetricSyncGuestCallExit), so streamTransfer must not derive its
+    // context from that register (it previously threw
+    // 'missing global current task'). Per the Canonical ABI the transfer is
+    // a pure table operation between the source and destination components.
+    // See lann/jco#35.
     test('stream in return position across a composition', async () => {
         const componentPath = await composeCallerCallee({
             callerPath: join(LOCAL_TEST_COMPONENTS_DIR, 'stream-transfer-g2g-caller.wasm'),

--- a/packages/jco-transpile/test/p3/sync-to-async-g2g.ts
+++ b/packages/jco-transpile/test/p3/sync-to-async-g2g.ts
@@ -1,0 +1,48 @@
+import { join } from 'node:path';
+
+import { assert, suite, test } from 'vitest';
+import { WASIShim } from '@bytecodealliance/preview2-shim/instantiation';
+
+import { AsyncFunction, LOCAL_TEST_COMPONENTS_DIR } from '../common.js';
+import { composeCallerCallee, setupAsyncTest } from '../helpers.js';
+
+const EXPORT_NAME = 'jco:test-components/sync-lower-runner';
+
+suite('guest->guest sync-lowered call to async-lifted callee', () => {
+    // Regression test for the fused [sync-start] path (lann/jco#45): a
+    // sync-lowered import of an async-lifted export goes through
+    // PrepareCall + SyncStartCall, and the SyncStartCall intrinsic must
+    // block the caller (JSPI) until the callee resolves via task.return,
+    // then return the sync lowering's flat result. Previously an
+    // unimplemented stub ('synchronous start call not implemented!').
+    test('blocking call returns the callee result across a composition', async () => {
+        const componentPath = await composeCallerCallee({
+            callerPath: join(LOCAL_TEST_COMPONENTS_DIR, 'sync-to-async-caller.wasm'),
+            calleePath: join(LOCAL_TEST_COMPONENTS_DIR, 'sync-to-async-callee.wasm'),
+        });
+        const { instance, cleanup } = await setupAsyncTest({
+            asyncMode: 'jspi',
+            component: {
+                name: 'sync-to-async-g2g',
+                path: componentPath,
+                imports: { ...new WASIShim().getImportObject() },
+            },
+            jco: {
+                transpile: {
+                    extraArgs: {
+                        minify: false,
+                    },
+                },
+            },
+        });
+        try {
+            assert.instanceOf(instance[EXPORT_NAME].runCompute, AsyncFunction);
+            // compute(13) -> 16 (direct flat result), then
+            // compute-list(16) -> [16, 17, 18] (spilled via return pointer),
+            // summed by the caller
+            assert.strictEqual(await instance[EXPORT_NAME].runCompute(13), 16 + 17 + 18);
+        } finally {
+            await cleanup();
+        }
+    });
+});

--- a/packages/jco-transpile/test/p3/sync-to-async-g2g.ts
+++ b/packages/jco-transpile/test/p3/sync-to-async-g2g.ts
@@ -9,7 +9,7 @@ import { composeCallerCallee, setupAsyncTest } from '../helpers.js';
 const EXPORT_NAME = 'jco:test-components/sync-lower-runner';
 
 suite('guest->guest sync-lowered call to async-lifted callee', () => {
-    // Regression test for the fused [sync-start] path (lann/jco#45): a
+    // Regression test for the fused [sync-start] path: a
     // sync-lowered import of an async-lifted export goes through
     // PrepareCall + SyncStartCall, and the SyncStartCall intrinsic must
     // block the caller (JSPI) until the callee resolves via task.return,


### PR DESCRIPTION
A second slug of corner case bugfixes (including one completely missing `future.transfer` impl :sweat_smile: ) contributed by @lann -- thanks again for the contributions.