### PR TITLE
fix(bindgen): sort RESERVED_KEYWORDS so binary_search finds `eval`

### DIFF
--- a/crates/js-component-bindgen/src/names.rs
+++ b/crates/js-component-bindgen/src/names.rs
@@ -178,9 +178,9 @@ pub(crate) const RESERVED_KEYWORDS: &[&str] = &[
     "default",
     "delete",
     "do",
-    "eval",
     "else",
     "enum",
+    "eval",
     "export",
     "extends",
     "false",
@@ -215,3 +215,38 @@ pub(crate) const RESERVED_KEYWORDS: &[&str] = &[
     "with",
     "yield",
 ];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// RESERVED_KEYWORDS must stay sorted: `is_js_reserved_word` relies on
+    /// `binary_search`, and a misplaced entry makes the search miss keywords
+    /// (e.g. `eval` when placed before `else`/`enum`).
+    #[test]
+    fn reserved_keywords_are_sorted_and_searchable() {
+        assert!(
+            RESERVED_KEYWORDS.windows(2).all(|w| w[0] < w[1]),
+            "RESERVED_KEYWORDS must be sorted for binary_search"
+        );
+        for keyword in RESERVED_KEYWORDS {
+            assert!(
+                is_js_reserved_word(keyword),
+                "binary_search must find reserved keyword: {keyword}"
+            );
+            assert!(
+                !is_valid_js_identifier(keyword),
+                "reserved keyword must not be a valid JS identifier: {keyword}"
+            );
+        }
+    }
+
+    /// Regression test: a component export named `eval` must be renamed to a
+    /// valid strict-mode-safe binding (see #1898).
+    #[test]
+    fn eval_is_sanitized() {
+        assert!(!is_valid_js_identifier("eval"));
+        assert_ne!(to_js_identifier("eval"), "eval");
+        assert!(is_valid_js_identifier(&to_js_identifier("eval")));
+    }
+}


### PR DESCRIPTION
Fixes bug 1 of #1898.

## Problem

`RESERVED_KEYWORDS` in `crates/js-component-bindgen/src/names.rs` was not sorted: `"eval"` was placed before `"else"`/`"enum"`, but sorts after both. `is_js_reserved_word()` uses `RESERVED_KEYWORDS.binary_search(...)`, and with the misordered list the search never finds `"eval"` — replaying Rust's `slice::binary_search` probe sequence over the list shows `eval` was the **only** keyword missed.

As a result, `to_js_identifier("eval")` returned `"eval"` unchanged, and a component export named `eval` was emitted verbatim into generated ESM:

```js
async function eval(arg0) { ... }
```

which fails to parse (ESM is strict mode):

```
SyntaxError: Unexpected eval or arguments in strict mode
```

## Repro

WIT:

```wit
package repro:eval@0.1.0;
interface driver { eval: func(src: string) -> string; }
world w { export driver; }
```

Embed into any core module (`wasm-tools component embed` + `wasm-tools component new`), then `jco transpile` — output contains `function eval(`. Reproduced with `@bytecodealliance/jco@1.29.0` and with bindgen built from `main` (see #1898 for full details and a public repro component).

## Fix

Move `"eval"` to its sorted position (after `"enum"`). With the fix, `to_js_identifier("eval")` produces `_eval` and the export mapping becomes `eval: _eval`, which is valid strict-mode JS.

## Tests

Added `#[cfg(test)]` unit tests in `names.rs`:

- `reserved_keywords_are_sorted_and_searchable` — asserts the list is sorted and that `binary_search` finds every entry (prevents this class of bug for any future mis-insertion).
- `eval_is_sanitized` — regression test that `eval` is treated as reserved and sanitized to a valid identifier.

No local Rust toolchain was available; relying on CI for `cargo test`.
