### PR TITLE
fix(bindgen): emit FutureEnd classes when only FutureRead/FutureWrite are used

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -1147,14 +1147,8 @@ mod tests {
     #[test]
     fn future_read_write_emit_future_end_classes() {
         for (op, end_class) in [
-            (
-                AsyncFutureIntrinsic::FutureRead,
-                "class FutureReadableEnd",
-            ),
-            (
-                AsyncFutureIntrinsic::FutureWrite,
-                "class FutureWritableEnd",
-            ),
+            (AsyncFutureIntrinsic::FutureRead, "class FutureReadableEnd"),
+            (AsyncFutureIntrinsic::FutureWrite, "class FutureWritableEnd"),
         ] {
             let mut intrinsics = BTreeSet::from([Intrinsic::AsyncFuture(op)]);
             let opts = TranspileOpts::default();

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -1140,6 +1140,35 @@ mod tests {
         assert!(source.contains("const { rep, own } = rscTableGet(fromTable, handle);"));
         assert!(source.contains("if (!own) rscTableRemove(fromTable, handle);"));
     }
+
+    /// Future read/write trampoline code references the future end classes
+    /// (`instanceof FutureReadableEnd`, `FutureEnd.CopyState`), so the classes
+    /// must be emitted even when `FutureNew` is absent (see #1898).
+    #[test]
+    fn future_read_write_emit_future_end_classes() {
+        for (op, end_class) in [
+            (
+                AsyncFutureIntrinsic::FutureRead,
+                "class FutureReadableEnd",
+            ),
+            (
+                AsyncFutureIntrinsic::FutureWrite,
+                "class FutureWritableEnd",
+            ),
+        ] {
+            let mut intrinsics = BTreeSet::from([Intrinsic::AsyncFuture(op)]);
+            let opts = TranspileOpts::default();
+            let source = render_intrinsics(
+                RenderIntrinsicsArgs::builder()
+                    .intrinsics(&mut intrinsics)
+                    .transpile_opts(&opts)
+                    .build(),
+            );
+
+            assert!(source.contains(end_class), "missing {end_class}");
+            assert!(source.contains("class FutureEnd"), "missing FutureEnd");
+        }
+    }
 }
 
 /// Profile for determinism to be used by async implementation
@@ -1703,6 +1732,32 @@ pub fn render_intrinsics(args: RenderIntrinsicsArgs) -> Source {
             &Intrinsic::AsyncTask(AsyncTaskIntrinsic::AsyncBlockedConstant),
             &Intrinsic::AsyncEventCodeEnum,
         ]);
+    }
+
+    // Future read/write trampolines (`Trampoline::FutureRead`/`FutureWrite`)
+    // emit code that references the future end classes directly
+    // (e.g. `futureEnd instanceof FutureReadableEnd`, `FutureEnd.CopyState`),
+    // so the end classes must be emitted even when the component does not use
+    // `future.new` (i.e. `FutureNew` is absent). Without this, transpiled
+    // output for such components fails at runtime with
+    // `ReferenceError: FutureReadableEnd is not defined` on the first future
+    // read/write (see #1898).
+    if args
+        .intrinsics
+        .contains(&Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureWrite))
+    {
+        args.intrinsics.insert(Intrinsic::AsyncFuture(
+            AsyncFutureIntrinsic::FutureWritableEndClass,
+        ));
+    }
+
+    if args
+        .intrinsics
+        .contains(&Intrinsic::AsyncFuture(AsyncFutureIntrinsic::FutureRead))
+    {
+        args.intrinsics.insert(Intrinsic::AsyncFuture(
+            AsyncFutureIntrinsic::FutureReadableEndClass,
+        ));
     }
 
     if args


### PR DESCRIPTION
Fixes bug 5 of #1898.

## Problem

The `FutureRead`/`FutureWrite` intrinsics (requested from `transpile_bindgen.rs` for `Trampoline::FutureRead`/`FutureWrite`) render code that references the future end classes directly:

```js
if (!(futureEnd instanceof FutureReadableEnd)) { ... }
futureEnd.setCopyState(FutureEnd.CopyState.ASYNC_COPYING);
```

but `render_intrinsics` only added `FutureReadableEndClass`/`FutureWritableEndClass` to the emission set when `AsyncFutureIntrinsic::FutureNew` was present. A component that contains `future.read`/`future.write` canonical builtins but **no** `future.new` — e.g. a host-lowered `future<result<...>>` read by the guest, as produced by wasi 0.3 functions like `wasi:filesystem` 0.3's stream/future pairs — gets transpiled output that emits `InternalFuture` and the future intrinsics but no end-class definitions, failing at runtime with:

```
ReferenceError: FutureReadableEnd is not defined
```

(Streams don't have this hole: `StreamNew` similarly pulls in the stream end classes, but the stream read/write paths apparently always co-occur with `StreamNew` in practice — futures don't.)

## Repro

See #1898: `jco transpile` (1.29.0, also bindgen @ main faca7e5d) on the linked public wasip3 component; output contains `InternalFuture` but zero `class FutureReadableEnd`/`FutureEnd` definitions, and instantiation + first future read throws the `ReferenceError` above (both `--async-mode sync` and `--async-mode jspi`).

## Fix

In the `render_intrinsics` dependency pass, add `FutureWritableEndClass` when `FutureWrite` is present and `FutureReadableEndClass` when `FutureRead` is present. The existing block that handles the end classes then supplies `FutureEndClass`, `FutureValueClass`, `InternalFutureClass`, `NestedFutureSymbol`, and `AsyncEventCodeEnum`. Placement is before that block so the single sequential pass picks up the transitive deps.

## Tests

Added a unit test in the existing `intrinsics/mod.rs` test module (`future_read_write_emit_future_end_classes`) following the established `render_intrinsics` assertion pattern: rendering with only `FutureRead` (resp. `FutureWrite`) requested must emit `class FutureReadableEnd` (resp. `class FutureWritableEnd`) and `class FutureEnd`.

An end-to-end runtime test would need a p3 fixture component that exercises host-lowered future reads without `future.new`; the existing p3 fixtures don't cover this (the bug survived to `main`). Happy to add one with maintainer guidance on the fixture build.

No local Rust toolchain was available; relying on CI for `cargo test`.
