### PR TITLE
feat(std): add synchronous-scope node:async_hooks support

### DIFF
--- a/docs/src/interop/nodejs-builtins.md
+++ b/docs/src/interop/nodejs-builtins.md
@@ -102,6 +102,7 @@ is planned.
 | ------------------------------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
 | `node:assert`, `node:assert/strict`               | `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/assert`        | Adapted from the MIT-licensed Node.js 24 implementation. Requires no WIT capability.                                     |
 | `node:path`, `node:path/posix`, `node:path/win32` | `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/path`          | Jco's portable path implementation, connected to `wasi:cli/environment` for the guest working directory and environment. |
+| `node:async_hooks`                                | `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/async-hooks`   | Synchronous scopes only. Requires no WIT capability. Asynchronous use is refused rather than silently losing the store -- see below. |
 | `node:child_process`                              | `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/child-process` | Synchronous APIs over an explicit application-provided host capability; denied by default.                               |
 | `node:cluster`                                    | `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/cluster`       | Primary/worker control over an explicit host capability. Partly unsupported -- see below.                                |
 | `node:buffer`                                     | unenv's portable Buffer core with a Jco public adapter           | Covers the commonly used modern Buffer operations. Jco controls deprecated and runtime-dependent exports.                |
@@ -231,6 +232,25 @@ These throw `ERR_JCO_UNSUPPORTED_NODE_API` rather than failing quietly:
 `cluster.isMaster` and `cluster.setupMaster()` are deprecated in Node, so they throw
 `ERR_JCO_UNSUPPORTED_DEPRECATED_NODE_API` and point at `isPrimary`/`setupPrimary`.
 
+### Async hooks and synchronous scopes
+
+`AsyncLocalStorage` works within a synchronous scope: `run`, `getStore`, `exit`, `enterWith`,
+nesting, `snapshot` and `bind` all behave as Node does, and `AsyncResource` binds to the context it
+was constructed in.
+
+What it cannot do is carry a store across an asynchronous boundary. `await` resolves through the
+engine's internal `PerformPromiseThen`, which JavaScript cannot intercept -- patching
+`Promise.prototype.then` does not see it -- and StarlingMonkey exposes no TC39 `AsyncContext` to
+carry the value instead.
+
+Rather than return an empty store after an `await`, Jco refuses at the call site: any callback
+given to `run`, `exit`, `withScope` or a snapshot that returns a promise throws
+`ERR_JCO_UNSUPPORTED_NODE_API`, naming the reason. A failure at the call site is easier to act on
+than a store that silently disappears somewhere else.
+
+`createHook`, `executionAsyncId`, `triggerAsyncId` and `executionAsyncResource` describe the async
+resource graph and always throw: nothing tracks that graph in a component.
+
 ### Buffer
 
 The Buffer core comes from `unenv`'s wrapper around the MIT-licensed Feross
@@ -315,7 +335,6 @@ the module or upstream project.
 
 | Modules                                   | Why they are not enabled yet                                                                                                                                                                                                |
 | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `node:async_hooks`                        | The portable fallback does not preserve async context across asynchronous work, and `AsyncLocalStorage.snapshot()` is not implemented.                                                                                      |
 | `node:events`                             | Much of EventEmitter is useful, but the public module includes placeholder exports and depends on the current async-hooks fallback.                                                                                         |
 | `node:diagnostics_channel`                | Core channel behavior exists, while tracing and async-context portions are incomplete.                                                                                                                                      |
 | `node:readline`, `node:readline/promises` | Interactive terminal behavior needs real guest streams and input handling; current fallbacks cannot reproduce it.                                                                                                           |

--- a/packages/jco-std/README.md
+++ b/packages/jco-std/README.md
@@ -25,6 +25,7 @@ Below is a list of utilties provided by `@bytecodealliance/jco-std`:
 | `wasi/0.2.x/node/24.x.x/assert`        | `node:assert` adapter, Node 24 on WASI p2                                     |
 | `wasi/0.2.x/node/24.x.x/console`       | `node:console` guest adapter over an explicit host capability                 |
 | `wasi/0.2.x/node/24.x.x/path`          | `node:path` adapter, Node 24 on WASI p2                                       |
+| `wasi/0.2.x/node/24.x.x/async-hooks`   | `node:async_hooks` guest adapter, Node 24, synchronous scopes only            |
 | `wasi/0.2.x/node/24.x.x/child-process` | `node:child_process` guest adapter, Node 24 over an explicit host capability  |
 | `wasi/0.2.x/node/24.x.x/cluster`       | `node:cluster` guest adapter, Node 24 over an explicit host capability        |
 
@@ -77,6 +78,8 @@ Jco can bundle the following Node.js APIs into JavaScript WebAssembly components
 - synchronous `node:child_process` operations, implemented by
   `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/child-process` and the
   `jco:node/child-process@0.1.0` host capability;
+- `node:async_hooks`, implemented by
+  `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/async-hooks`, for synchronous scopes;
 - `node:cluster`, implemented by
   `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/cluster` and the
   `jco:node/cluster@0.1.0` host capability;

--- a/packages/jco-std/package.json
+++ b/packages/jco-std/package.json
@@ -66,6 +66,11 @@
       "browser": "./dist/wasi/0.2.x/node/24.x.x/path.js",
       "default": "./dist/wasi/0.2.x/node/24.x.x/path.js"
     },
+    "./wasi/0.2.x/node/24.x.x/async-hooks": {
+      "types": "./dist/wasi/0.2.x/node/24.x.x/async-hooks.d.ts",
+      "browser": "./dist/wasi/0.2.x/node/24.x.x/async-hooks.js",
+      "default": "./dist/wasi/0.2.x/node/24.x.x/async-hooks.js"
+    },
     "./wasi/0.2.x/node/24.x.x/child-process": {
       "types": "./dist/wasi/0.2.x/node/24.x.x/child-process.d.ts",
       "browser": "./dist/wasi/0.2.x/node/24.x.x/child-process.js",

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks.ts
@@ -1,0 +1,37 @@
+/**
+ * `node:async_hooks`, limited to synchronous scopes.
+ *
+ * `AsyncLocalStorage` works within a synchronous scope: `run`, `getStore`, `exit`, `enterWith`,
+ * nesting, `snapshot` and `bind` all behave as Node does. What it cannot do is carry a store across
+ * an asynchronous boundary, and that limitation is not a shortcut -- it is currently unreachable:
+ *
+ * - `await` resolves through the engine's internal `PerformPromiseThen`. Patching
+ *   `Promise.prototype.then` does not intercept it; measured in a componentized fixture, an
+ *   `await` never calls the patched method at all.
+ * - StarlingMonkey exposes no TC39 `AsyncContext`, so there is no supported hook to carry the
+ *   value instead.
+ *
+ * TODO(async): revisit once componentize-js gains async support -- and note this likely also needs
+ * bindgen support in Jco, so a guest's async continuations are threaded through something the
+ * runtime can track. Until then, any callback returning a thenable is refused with
+ * `ERR_JCO_UNSUPPORTED_NODE_API` rather than silently producing an empty store later.
+ *
+ * `createHook`, `executionAsyncId`, `triggerAsyncId` and `executionAsyncResource` describe the async
+ * resource graph and always throw: nothing tracks it here.
+ */
+
+export {
+  AsyncLocalStorage,
+  AsyncResource,
+  ASYNC_REASON,
+  UNSUPPORTED_CODE,
+  asyncWrapProviders,
+  createHook,
+  executionAsyncId,
+  executionAsyncResource,
+  triggerAsyncId,
+} from "./async-hooks/index.js";
+
+import * as asyncHooks from "./async-hooks/index.js";
+
+export default asyncHooks;

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks.ts
@@ -11,10 +11,13 @@
  * - StarlingMonkey exposes no TC39 `AsyncContext`, so there is no supported hook to carry the
  *   value instead.
  *
- * TODO(async): revisit once componentize-js gains async support -- and note this likely also needs
- * bindgen support in Jco, so a guest's async continuations are threaded through something the
- * runtime can track. Until then, any callback returning a thenable is refused with
- * `ERR_JCO_UNSUPPORTED_NODE_API` rather than silently producing an empty store later.
+ * TODO(async): this needs `AsyncContext` at the engine level; generated glue cannot substitute for
+ * it. Bindgen only wraps the boundaries it emits, so it could carry context across a host call but
+ * not across a plain `await` in user code -- and a store has to survive every await in a chain, so
+ * one unwrapped await is enough to break it. (As of componentize-js 0.22.0 the question is moot
+ * anyway: its splicer panics with `not yet implemented` on an async export.) Until an engine-level
+ * hook exists, any callback returning a thenable is refused with `ERR_JCO_UNSUPPORTED_NODE_API`
+ * rather than silently producing an empty store later.
  *
  * `createHook`, `executionAsyncId`, `triggerAsyncId` and `executionAsyncResource` describe the async
  * resource graph and always throw: nothing tracks it here.

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks/async-local-storage.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks/async-local-storage.ts
@@ -1,0 +1,129 @@
+import { ASYNC_REASON, unsupported } from "./errors.js";
+import {
+  captureAll,
+  clear,
+  createKey,
+  current,
+  setCurrent,
+  withCaptured,
+  withStore,
+  type ContextKey,
+  type Store,
+} from "./context.js";
+
+/** Anything with a `then` is a continuation this module cannot follow. */
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    (typeof value === "object" &&
+      value !== null &&
+      typeof (value as { then?: unknown }).then === "function") ||
+    (typeof value === "function" && typeof (value as { then?: unknown }).then === "function")
+  );
+}
+
+/**
+ * Refuse work that would outlive the synchronous scope.
+ *
+ * Returning a thenable is the exact moment the store stops being reliable: the continuation runs
+ * after this scope has exited. Failing here points at the call site instead of surfacing later as
+ * an empty store somewhere unrelated.
+ */
+function rejectAsync(api: string, result: unknown): void {
+  if (isThenable(result)) {
+    throw unsupported(api, ASYNC_REASON);
+  }
+}
+
+/**
+ * Node's `AsyncLocalStorage`, limited to synchronous scopes.
+ *
+ * Node propagates the store across asynchronous continuations. This engine cannot (see
+ * `ASYNC_REASON`), so rather than silently yielding an empty store after an `await`, any callback
+ * that returns a thenable is rejected outright.
+ */
+export class AsyncLocalStorage<T = unknown> {
+  readonly #key: ContextKey = createKey();
+  #disabled = false;
+
+  /** Optional label, matching Node's `name` accessor. */
+  get name(): string {
+    return "AsyncLocalStorage";
+  }
+
+  /** The store for the current synchronous scope, or `undefined` outside one. */
+  getStore(): T | undefined {
+    if (this.#disabled) {
+      return undefined;
+    }
+    return current(this.#key) as T | undefined;
+  }
+
+  /**
+   * Run `callback` with `store` in scope.
+   *
+   * @throws when `callback` returns a thenable, which this engine cannot follow
+   */
+  run<R>(store: T, callback: (...args: never[]) => R, ...args: never[]): R {
+    if (this.#disabled) {
+      return callback(...args);
+    }
+    const result = withStore(this.#key, store as Store, () => callback(...args));
+    rejectAsync("AsyncLocalStorage.run(store, callback)", result);
+    return result;
+  }
+
+  /** Run `callback` with no store in scope. */
+  exit<R>(callback: (...args: never[]) => R, ...args: never[]): R {
+    const result = withStore(this.#key, undefined, () => callback(...args));
+    rejectAsync("AsyncLocalStorage.exit(callback)", result);
+    return result;
+  }
+
+  /**
+   * Set the store for the remainder of the current synchronous scope.
+   *
+   * In Node this also reaches asynchronous continuations of the current context; here it does not,
+   * and unlike `run` there is no return value to inspect, so the difference cannot be detected.
+   */
+  enterWith(store: T): void {
+    if (this.#disabled) {
+      return;
+    }
+    setCurrent(this.#key, store as Store);
+  }
+
+  /** Run `callback` with `store` in scope, matching Node's `withScope`. */
+  withScope<R>(callback: (...args: never[]) => R, ...args: never[]): R {
+    const result = withStore(this.#key, current(this.#key), () => callback(...args));
+    rejectAsync("AsyncLocalStorage.withScope(callback)", result);
+    return result;
+  }
+
+  /** Discard every store and make `getStore` return `undefined`. */
+  disable(): void {
+    this.#disabled = true;
+    clear(this.#key);
+  }
+
+  /**
+   * Capture the active stores so they can be restored inside another scope.
+   *
+   * Useful synchronously; it cannot restore context into an asynchronous continuation.
+   */
+  static snapshot(): <R>(callback: (...args: never[]) => R, ...args: never[]) => R {
+    const captured = captureAll();
+    return function runInSnapshot(callback, ...args) {
+      const result = withCaptured(captured, () => callback(...args));
+      rejectAsync("the callback given to AsyncLocalStorage.snapshot()", result);
+      return result;
+    };
+  }
+
+  /** Bind `fn` to the stores active now, so a later synchronous call sees them. */
+  static bind<F extends (...args: never[]) => unknown>(fn: F): F {
+    const runInSnapshot = AsyncLocalStorage.snapshot();
+    return function bound(this: unknown, ...args: never[]) {
+      return runInSnapshot(() => Reflect.apply(fn, this, args) as never);
+    } as unknown as F;
+  }
+}

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks/async-resource.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks/async-resource.ts
@@ -1,0 +1,86 @@
+import { AsyncLocalStorage } from "./async-local-storage.js";
+import { unsupported } from "./errors.js";
+
+let nextAsyncId = 1;
+
+/**
+ * Node's `AsyncResource`, limited to synchronous scopes.
+ *
+ * Node ties a resource into the async id graph so hooks can observe its lifetime. There is no such
+ * graph here, so the ids are locally unique and stable but describe nothing the runtime tracks.
+ */
+export class AsyncResource {
+  readonly #type: string;
+  readonly #asyncId: number;
+  readonly #triggerAsyncId: number;
+  /**
+   * Stores active when the resource was constructed.
+   *
+   * Node binds a resource to the context it was created in, not the one it is later called from,
+   * so this is captured here rather than in `runInAsyncScope`.
+   */
+  readonly #scope: ReturnType<typeof AsyncLocalStorage.snapshot>;
+
+  constructor(type: string, options?: { triggerAsyncId?: number }) {
+    if (typeof type !== "string") {
+      const error = new TypeError(
+        `The "type" argument must be of type string. Received ${typeof type}`,
+      ) as TypeError & {
+        code: string;
+      };
+      error.code = "ERR_INVALID_ARG_TYPE";
+      throw error;
+    }
+    this.#type = type;
+    this.#asyncId = nextAsyncId++;
+    this.#triggerAsyncId = options?.triggerAsyncId ?? 0;
+    this.#scope = AsyncLocalStorage.snapshot();
+  }
+
+  /** The resource type given to the constructor. */
+  get type(): string {
+    return this.#type;
+  }
+
+  /** Locally unique id. Stable, but not part of any runtime-tracked graph. */
+  asyncId(): number {
+    return this.#asyncId;
+  }
+
+  /** The id this resource was created under, or `0` when none was supplied. */
+  triggerAsyncId(): number {
+    return this.#triggerAsyncId;
+  }
+
+  /** Call `fn` with the stores that were active when this resource was constructed. */
+  runInAsyncScope<R>(fn: (...args: never[]) => R, thisArg?: unknown, ...args: never[]): R {
+    return this.#scope(() => Reflect.apply(fn, thisArg, args) as R);
+  }
+
+  /** Bind `fn` so a later synchronous call runs in this resource's scope. */
+  bind<F extends (...args: never[]) => unknown>(fn: F): F {
+    // Capture the scope rather than the resource, so `this` inside `bound` stays the caller's.
+    const scope = this.#scope;
+    return function bound(this: unknown, ...args: never[]) {
+      return scope(() => Reflect.apply(fn, this, args) as never);
+    } as unknown as F;
+  }
+
+  /** Bind `fn` to the stores active now. */
+  static bind<F extends (...args: never[]) => unknown>(fn: F, type = "bound-anonymous-fn"): F {
+    return new AsyncResource(type).bind(fn);
+  }
+
+  /**
+   * Node emits a `destroy` hook here.
+   *
+   * There are no hooks to notify, so this would be a silent no-op; it throws instead, because a
+   * caller emitting destroy is expecting an observer that does not exist.
+   */
+  emitDestroy(): never {
+    throw unsupported(
+      "asyncResource.emitDestroy()",
+      "it notifies async hooks, and createHook is not supported in a component",
+    );
+  }
+}

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks/context.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks/context.ts
@@ -1,0 +1,90 @@
+/**
+ * Synchronous context stack shared by `AsyncLocalStorage` and `AsyncResource`.
+ *
+ * Each storage keeps its own stack of active values. Entering pushes, leaving pops, so nesting
+ * behaves like Node's for synchronous code. There is deliberately no asynchronous propagation --
+ * see `errors.ts` and the module docs for why it cannot be done here.
+ */
+
+/** A value bound to a storage for the duration of a scope. */
+export type Store = unknown;
+
+/** Identifies one storage's stack without exposing the storage object itself. */
+export interface ContextKey {
+  readonly id: number;
+}
+
+const stacks = new Map<number, Store[]>();
+let nextId = 1;
+
+/** Create a key with its own independent stack. */
+export function createKey(): ContextKey {
+  const key = { id: nextId++ };
+  stacks.set(key.id, []);
+  return key;
+}
+
+/** The value currently in scope, or `undefined` outside any scope. */
+export function current(key: ContextKey): Store {
+  const stack = stacks.get(key.id);
+  return stack && stack.length > 0 ? stack[stack.length - 1] : undefined;
+}
+
+/** Run `fn` with `store` in scope, restoring the previous scope afterwards. */
+export function withStore<T>(key: ContextKey, store: Store, fn: () => T): T {
+  const stack = stacks.get(key.id);
+  if (!stack) {
+    throw new Error("async context used after its storage was disabled");
+  }
+  stack.push(store);
+  try {
+    return fn();
+  } finally {
+    stack.pop();
+  }
+}
+
+/** Replace the value in the innermost scope, as `enterWith` does. */
+export function setCurrent(key: ContextKey, store: Store): void {
+  const stack = stacks.get(key.id);
+  if (!stack) {
+    return;
+  }
+  if (stack.length === 0) {
+    stack.push(store);
+  } else {
+    stack[stack.length - 1] = store;
+  }
+}
+
+/** Drop every value, as `disable` does. */
+export function clear(key: ContextKey): void {
+  stacks.set(key.id, []);
+}
+
+/** Capture every storage's current value, for `snapshot`. */
+export function captureAll(): Map<number, Store> {
+  const captured = new Map<number, Store>();
+  for (const [id, stack] of stacks) {
+    if (stack.length > 0) {
+      captured.set(id, stack[stack.length - 1]);
+    }
+  }
+  return captured;
+}
+
+/** Run `fn` with a previously captured set of values in scope. */
+export function withCaptured<T>(captured: Map<number, Store>, fn: () => T): T {
+  const entered: number[] = [];
+  for (const [id, stack] of stacks) {
+    stack.push(captured.get(id));
+    entered.push(id);
+  }
+  try {
+    return fn();
+  } finally {
+    for (const id of entered) {
+      stacks.get(id)?.pop();
+    }
+  }
+}

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks/errors.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks/errors.ts
@@ -1,0 +1,29 @@
+/** Error code carried by every unsupported-API failure Jco raises for Node builtins. */
+export const UNSUPPORTED_CODE = "ERR_JCO_UNSUPPORTED_NODE_API";
+
+/**
+ * Thrown for `node:async_hooks` behavior that cannot work in a component.
+ *
+ * @param api - the public API being used, as a user would write it
+ * @param reason - why it cannot work here
+ */
+export function unsupported(api: string, reason: string): Error & { code: string } {
+  const error = new Error(
+    `${api} is not supported in a WebAssembly component: ${reason}`,
+  ) as Error & {
+    code: string;
+  };
+  error.code = UNSUPPORTED_CODE;
+  return error;
+}
+
+/**
+ * Why asynchronous context propagation is refused, quoted into the errors users see.
+ *
+ * Kept in one place because it is the single reason this module is limited, and every affected API
+ * should say the same thing.
+ */
+export const ASYNC_REASON =
+  "the store cannot survive an await. `await` resolves through the engine's internal " +
+  "PerformPromiseThen, which JavaScript cannot intercept, and this engine exposes no AsyncContext " +
+  "to carry the value instead. Rather than return an empty store later, Jco refuses here";

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks/index.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/async-hooks/index.ts
@@ -1,0 +1,33 @@
+import { unsupported } from "./errors.js";
+
+export { AsyncLocalStorage } from "./async-local-storage.js";
+export { AsyncResource } from "./async-resource.js";
+export { ASYNC_REASON, UNSUPPORTED_CODE } from "./errors.js";
+
+/**
+ * The async id graph does not exist in a component.
+ *
+ * These APIs describe resources the engine would have to track for us. Nothing does, and reporting
+ * a constant would quietly misdescribe the program, so each says so instead.
+ */
+const NO_GRAPH =
+  "it reports the async resource graph, which requires runtime hooks this engine does not expose";
+
+export function createHook(): never {
+  throw unsupported("async_hooks.createHook(callbacks)", NO_GRAPH);
+}
+
+export function executionAsyncId(): never {
+  throw unsupported("async_hooks.executionAsyncId()", NO_GRAPH);
+}
+
+export function triggerAsyncId(): never {
+  throw unsupported("async_hooks.triggerAsyncId()", NO_GRAPH);
+}
+
+export function executionAsyncResource(): never {
+  throw unsupported("async_hooks.executionAsyncResource()", NO_GRAPH);
+}
+
+/** Node's internal provider table; empty here, since no providers are tracked. */
+export const asyncWrapProviders: Readonly<Record<string, number>> = Object.freeze({});

--- a/packages/jco-std/test/wasi/0.2.x/node/24.x.x/async-hooks/async-local-storage.ts
+++ b/packages/jco-std/test/wasi/0.2.x/node/24.x.x/async-hooks/async-local-storage.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "vitest";
+
+import { AsyncLocalStorage as NodeALS } from "node:async_hooks";
+
+import { AsyncLocalStorage } from "../../../../../../src/wasi/0.2.x/node/24.x.x/async-hooks/async-local-storage.js";
+
+/**
+ * Synchronous behavior, asserted against Node's own `AsyncLocalStorage` so the two agree rather
+ * than merely matching a written-down expectation.
+ */
+describe("AsyncLocalStorage synchronous scopes", () => {
+  const cases: [string, (ALS: typeof NodeALS | typeof AsyncLocalStorage) => unknown][] = [
+    [
+      "store inside run",
+      (ALS) => {
+        const s = new ALS();
+        return s.run({ v: 1 }, () => s.getStore());
+      },
+    ],
+    [
+      "undefined outside run",
+      (ALS) => {
+        const s = new ALS();
+        return s.getStore() ?? null;
+      },
+    ],
+    [
+      "restores the outer scope",
+      (ALS) => {
+        const s = new ALS();
+        return s.run({ v: 1 }, () => {
+          s.run({ v: 2 }, () => undefined);
+          return s.getStore();
+        });
+      },
+    ],
+    [
+      "innermost wins when nested",
+      (ALS) => {
+        const s = new ALS();
+        return s.run({ v: 1 }, () => s.run({ v: 2 }, () => s.getStore()));
+      },
+    ],
+    [
+      "exit clears the store",
+      (ALS) => {
+        const s = new ALS();
+        return s.run({ v: 1 }, () => s.exit(() => s.getStore() ?? null));
+      },
+    ],
+    [
+      "enterWith sets the current scope",
+      (ALS) => {
+        const s = new ALS();
+        return s.run({ v: 1 }, () => {
+          s.enterWith({ v: 9 });
+          return s.getStore();
+        });
+      },
+    ],
+    [
+      "disable clears the store",
+      (ALS) => {
+        const s = new ALS();
+        return s.run({ v: 1 }, () => {
+          s.disable();
+          return s.getStore() ?? null;
+        });
+      },
+    ],
+    [
+      "run forwards extra arguments",
+      (ALS) => {
+        const s = new ALS();
+        return s.run({ v: 1 }, (a: never, b: never) => [a, b], 1 as never, 2 as never);
+      },
+    ],
+    [
+      "storages are independent",
+      (ALS) => {
+        const a = new ALS();
+        const b = new ALS();
+        return a.run({ v: "a" }, () => b.run({ v: "b" }, () => [a.getStore(), b.getStore()]));
+      },
+    ],
+    [
+      "snapshot restores the captured store",
+      (ALS) => {
+        const s = new ALS();
+        const snap = s.run({ v: 1 }, () => (ALS as typeof NodeALS).snapshot());
+        return snap(() => s.getStore());
+      },
+    ],
+  ];
+
+  test.each(cases)("%s matches Node", (_name, run) => {
+    expect(JSON.stringify(run(AsyncLocalStorage))).toBe(JSON.stringify(run(NodeALS)));
+  });
+});

--- a/packages/jco-std/test/wasi/0.2.x/node/24.x.x/async-hooks/async-resource.ts
+++ b/packages/jco-std/test/wasi/0.2.x/node/24.x.x/async-hooks/async-resource.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "vitest";
+
+import { AsyncLocalStorage as NodeALS, AsyncResource as NodeAR } from "node:async_hooks";
+
+import { AsyncLocalStorage } from "../../../../../../src/wasi/0.2.x/node/24.x.x/async-hooks/async-local-storage.js";
+import { AsyncResource } from "../../../../../../src/wasi/0.2.x/node/24.x.x/async-hooks/async-resource.js";
+
+/**
+ * Scope capture is compared against Node rather than asserted from memory: Node binds a resource to
+ * the context it was *constructed* in, not the one it is later called from, which is easy to get
+ * backwards.
+ */
+describe("AsyncResource scope capture matches Node", () => {
+  const cases: [string, (ALS: typeof NodeALS, AR: typeof NodeAR) => unknown][] = [
+    [
+      "created outside a scope, run inside",
+      (ALS, AR) => {
+        const s = new ALS();
+        const resource = new AR("a");
+        return s.run({ v: 1 }, () => resource.runInAsyncScope(() => s.getStore()) ?? null);
+      },
+    ],
+    [
+      "created inside a scope, run outside",
+      (ALS, AR) => {
+        const s = new ALS();
+        const resource = s.run({ v: 2 }, () => new AR("b"));
+        return resource.runInAsyncScope(() => s.getStore()) ?? null;
+      },
+    ],
+    [
+      "bound inside a scope, called outside",
+      (ALS, AR) => {
+        const s = new ALS();
+        const bound = s.run({ v: 3 }, () => new AR("c").bind(() => s.getStore()));
+        return bound() ?? null;
+      },
+    ],
+    [
+      "static bind captures the calling scope",
+      (ALS, AR) => {
+        const s = new ALS();
+        const bound = s.run({ v: 4 }, () => AR.bind(() => s.getStore()));
+        return bound() ?? null;
+      },
+    ],
+    [
+      "forwards thisArg and arguments",
+      (_ALS, AR) => {
+        const target = { self: true };
+        return new AR("d").runInAsyncScope(
+          function (this: unknown, a: never, b: never) {
+            return [this === target, a, b];
+          },
+          target,
+          1 as never,
+          2 as never,
+        );
+      },
+    ],
+  ];
+
+  test.each(cases)("%s", (_name, run) => {
+    const ours = run(
+      AsyncLocalStorage as unknown as typeof NodeALS,
+      AsyncResource as unknown as typeof NodeAR,
+    );
+    expect(JSON.stringify(ours)).toBe(JSON.stringify(run(NodeALS, NodeAR)));
+  });
+});
+
+describe("AsyncResource identity", () => {
+  test.each([42, undefined, null])("rejects a non-string type, as Node does: %s", (type) => {
+    expect(() => new AsyncResource(type as never)).toThrow(TypeError);
+    expect(() => new NodeAR(type as never)).toThrow(TypeError);
+  });
+
+  test("accepts an empty type, as Node does", () => {
+    expect(() => new AsyncResource("")).not.toThrow();
+    expect(() => new NodeAR("")).not.toThrow();
+  });
+
+  test("ids are stable per resource and unique across them", () => {
+    const a = new AsyncResource("a");
+    const b = new AsyncResource("b");
+    expect(a.asyncId()).toBe(a.asyncId());
+    expect(a.asyncId()).not.toBe(b.asyncId());
+  });
+
+  test("triggerAsyncId defaults to 0 and honours the option", () => {
+    expect(new AsyncResource("a").triggerAsyncId()).toBe(0);
+    expect(new AsyncResource("a", { triggerAsyncId: 7 }).triggerAsyncId()).toBe(7);
+  });
+});

--- a/packages/jco-std/test/wasi/0.2.x/node/24.x.x/async-hooks/module.ts
+++ b/packages/jco-std/test/wasi/0.2.x/node/24.x.x/async-hooks/module.ts
@@ -1,0 +1,30 @@
+import { describe, expect, test } from "vitest";
+
+import * as asyncHooks from "../../../../../../src/wasi/0.2.x/node/24.x.x/async-hooks.js";
+import nodeAsyncHooks from "node:async_hooks";
+
+// Driven against the real module surface: what these compare is Node's own contract.
+describe("node:async_hooks module contract", () => {
+  test("exposes Node's export surface", () => {
+    for (const key of Object.keys(nodeAsyncHooks).filter((k) => k !== "default")) {
+      expect(asyncHooks, key).toHaveProperty(key);
+    }
+  });
+
+  test("AsyncLocalStorage carries Node's prototype surface", () => {
+    const ours = Object.getOwnPropertyNames(asyncHooks.AsyncLocalStorage.prototype);
+    for (const member of ["run", "getStore", "exit", "enterWith", "disable", "withScope"]) {
+      expect(ours, member).toContain(member);
+    }
+    expect(typeof asyncHooks.AsyncLocalStorage.snapshot).toBe("function");
+    expect(typeof asyncHooks.AsyncLocalStorage.bind).toBe("function");
+  });
+
+  test("AsyncResource carries Node's prototype surface", () => {
+    const ours = Object.getOwnPropertyNames(asyncHooks.AsyncResource.prototype);
+    for (const member of ["runInAsyncScope", "bind", "asyncId", "triggerAsyncId", "emitDestroy"]) {
+      expect(ours, member).toContain(member);
+    }
+    expect(typeof asyncHooks.AsyncResource.bind).toBe("function");
+  });
+});

--- a/packages/jco-std/test/wasi/0.2.x/node/24.x.x/async-hooks/unsupported.ts
+++ b/packages/jco-std/test/wasi/0.2.x/node/24.x.x/async-hooks/unsupported.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "vitest";
+
+import * as asyncHooks from "../../../../../../src/wasi/0.2.x/node/24.x.x/async-hooks.js";
+import { AsyncLocalStorage } from "../../../../../../src/wasi/0.2.x/node/24.x.x/async-hooks/async-local-storage.js";
+import { AsyncResource } from "../../../../../../src/wasi/0.2.x/node/24.x.x/async-hooks/async-resource.js";
+
+const UNSUPPORTED = expect.objectContaining({ code: "ERR_JCO_UNSUPPORTED_NODE_API" });
+
+/**
+ * The async boundary is refused at the call site rather than yielding an empty store later.
+ *
+ * That is the whole reason this module is written by hand instead of reusing unenv's, which returns
+ * `undefined` after an await and leaves the caller to discover it somewhere else.
+ */
+describe("asynchronous use is refused, not silently wrong", () => {
+  test("run rejects a callback that returns a promise", () => {
+    const als = new AsyncLocalStorage();
+    expect(() => als.run({ v: 1 }, () => Promise.resolve())).toThrow(UNSUPPORTED);
+    expect(() => als.run({ v: 1 }, async () => undefined)).toThrowError(/await/);
+  });
+
+  test("exit and withScope reject the same way", () => {
+    const als = new AsyncLocalStorage();
+    expect(() => als.exit(async () => undefined)).toThrow(UNSUPPORTED);
+    expect(() => als.withScope(async () => undefined)).toThrow(UNSUPPORTED);
+  });
+
+  test("a snapshot callback returning a promise is refused", () => {
+    const run = AsyncLocalStorage.snapshot();
+    expect(() => run(async () => undefined)).toThrow(UNSUPPORTED);
+  });
+
+  test("the error explains why rather than just refusing", () => {
+    const als = new AsyncLocalStorage();
+    try {
+      als.run({ v: 1 }, async () => undefined);
+      expect.unreachable("expected a refusal");
+    } catch (error) {
+      expect(String(error)).toMatch(/PerformPromiseThen/);
+      expect(String(error)).toMatch(/AsyncContext/);
+    }
+  });
+
+  test("the synchronous scope is still restored after a refusal", () => {
+    const als = new AsyncLocalStorage();
+    expect(() => als.run({ v: 1 }, async () => undefined)).toThrow();
+    expect(als.getStore()).toBeUndefined();
+  });
+});
+
+describe("APIs describing the async resource graph", () => {
+  test.each(["createHook", "executionAsyncId", "triggerAsyncId", "executionAsyncResource"])(
+    "%s throws an explicit unsupported error",
+    (name) => {
+      const fn = (asyncHooks as unknown as Record<string, () => unknown>)[name];
+      expect(fn).toThrow(UNSUPPORTED);
+    },
+  );
+
+  test("emitDestroy throws rather than silently doing nothing", () => {
+    expect(() => new AsyncResource("thing").emitDestroy()).toThrow(UNSUPPORTED);
+  });
+
+  test("asyncWrapProviders is an empty frozen table", () => {
+    expect(Object.isFrozen(asyncHooks.asyncWrapProviders)).toBe(true);
+    expect(Object.keys(asyncHooks.asyncWrapProviders)).toEqual([]);
+  });
+});

--- a/packages/jco/src/node-builtins.ts
+++ b/packages/jco/src/node-builtins.ts
@@ -19,6 +19,7 @@ const ASSERT_SPECIFIERS = new Set(["node:assert", "node:assert/strict"]);
 const CHILD_PROCESS_SPECIFIER = "node:child_process";
 const CLUSTER_SPECIFIER = "node:cluster";
 const CONSOLE_SPECIFIER = "node:console";
+const ASYNC_HOOKS_SPECIFIER = "node:async_hooks";
 const AUDITED_UNENV_SPECIFIERS = new Set(["node:buffer", "node:querystring"]);
 const VIRTUAL_PREFIX = "\0jco-node-builtin:";
 const UNENV_BUFFER_CORE = `${VIRTUAL_PREFIX}unenv-buffer-core`;
@@ -161,10 +162,34 @@ export interface NodeBuiltinOptions {
     clusterModule?: string;
     /** Path to jco-std's versioned `node:console` module (overridable for tests) */
     consoleModule?: string;
+    /** Path to jco-std's versioned `node:async_hooks` module (overridable for tests) */
+    asyncHooksModule?: string;
     /** Reports WIT imports required by builtins found while bundling. */
     onWitRequirement?: (requirement: NodeWitRequirement) => void;
     /** unenv aliases to resolve audited builtins against (overridable for tests) */
     unenvAliases?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Source of the `node:async_hooks` adapter.
+ *
+ * Capability-free: synchronous context tracking with no host involvement, so it resolves for a
+ * world with no imports at all.
+ */
+function asyncHooksAdapter(asyncHooksModule: string): string {
+    return `
+import asyncHooks from ${JSON.stringify(asyncHooksModule)};
+export default asyncHooks;
+export {
+    AsyncLocalStorage,
+    AsyncResource,
+    asyncWrapProviders,
+    createHook,
+    executionAsyncId,
+    executionAsyncResource,
+    triggerAsyncId,
+} from ${JSON.stringify(asyncHooksModule)};
+`;
 }
 
 /**
@@ -376,6 +401,9 @@ export function nodeBuiltinPlugin(worldMetadata: WorldMetadata, options: NodeBui
     const assertModule = () =>
         options.assertModule ??
         fileURLToPath(import.meta.resolve("@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/assert"));
+    const asyncHooksModule = () =>
+        options.asyncHooksModule ??
+        fileURLToPath(import.meta.resolve("@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/async-hooks"));
     const clusterModule = () =>
         options.clusterModule ??
         fileURLToPath(import.meta.resolve("@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/cluster"));
@@ -392,6 +420,10 @@ export function nodeBuiltinPlugin(worldMetadata: WorldMetadata, options: NodeBui
                 return id;
             }
             if (ASSERT_SPECIFIERS.has(id)) {
+                return `${VIRTUAL_PREFIX}${id}`;
+            }
+            if (id === ASYNC_HOOKS_SPECIFIER) {
+                // No onWitRequirement: this needs no host capability.
                 return `${VIRTUAL_PREFIX}${id}`;
             }
             if (id === CLUSTER_SPECIFIER) {
@@ -426,6 +458,9 @@ export function nodeBuiltinPlugin(worldMetadata: WorldMetadata, options: NodeBui
             }
             if (ASSERT_SPECIFIERS.has(value)) {
                 return assertAdapter(value, assertModule());
+            }
+            if (value === ASYNC_HOOKS_SPECIFIER) {
+                return asyncHooksAdapter(asyncHooksModule());
             }
             if (value === CLUSTER_SPECIFIER) {
                 return clusterAdapter(clusterModule());

--- a/packages/jco/test/node/builtins.js
+++ b/packages/jco/test/node/builtins.js
@@ -79,6 +79,36 @@ describe("Node builtin adapters", () => {
         expect(source).toContain("spawnSync");
     });
 
+    test("generates a capability-free adapter for node:async_hooks", () => {
+        const plugin = nodeBuiltinPlugin(
+            { imports: [], exports: [] },
+            { asyncHooksModule: "/jco/node/async-hooks.js" },
+        );
+        const id = plugin.resolveId("node:async_hooks");
+        expect(id).toBe("\0jco-node-builtin:node:async_hooks");
+        const source = plugin.load(id);
+        expect(source).toContain('from "/jco/node/async-hooks.js"');
+        expect(source).toContain("AsyncLocalStorage");
+    });
+
+    test("node:async_hooks requires no WIT capability", () => {
+        const onWitRequirement = vi.fn();
+        const plugin = nodeBuiltinPlugin(
+            { imports: [], exports: [] },
+            { asyncHooksModule: "/jco/node/async-hooks.js", onWitRequirement },
+        );
+        plugin.resolveId("node:async_hooks");
+        expect(onWitRequirement).not.toHaveBeenCalled();
+    });
+
+    test("does not intercept the bare async_hooks specifier", () => {
+        const plugin = nodeBuiltinPlugin(
+            { imports: [], exports: [] },
+            { asyncHooksModule: "/jco/node/async-hooks.js" },
+        );
+        expect(plugin.resolveId("async_hooks")).toBeNull();
+    });
+
     test("generates an adapter for node:cluster", () => {
         const plugin = nodeBuiltinPlugin({ imports: [], exports: [] }, { clusterModule: "/jco/node/cluster.js" });
         const id = plugin.resolveId("node:cluster");


### PR DESCRIPTION
Right now since we can't fully support async_hooks we add an error other than sync usage.

There's not much point to that, but until componentize-js supports async, it probably doesn't make sense to try to create an implementation (and may well be impossible).