### PR TITLE
feat(std): implement nodejs diagnostics channel

### DIFF
--- a/docs/src/interop/nodejs-builtins.md
+++ b/docs/src/interop/nodejs-builtins.md
@@ -104,6 +104,7 @@ is planned.
 | `node:path`, `node:path/posix`, `node:path/win32` | `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/path`          | Jco's portable path implementation, connected to `wasi:cli/environment` for the guest working directory and environment. |
 | `node:domain`                                     | *(refused)*                                     | Deprecated upstream in its entirety. Resolves so the failure explains itself; every use throws `ERR_JCO_UNSUPPORTED_DEPRECATED_NODE_API`. |
 | `node:async_hooks`                                | `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/async-hooks`   | Synchronous scopes only. Requires no WIT capability. Asynchronous use is refused rather than silently losing the store -- see below. |
+| `node:diagnostics_channel`                        | `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/diagnostics-channel` | Channels and tracing channels. Requires no WIT capability. Bound stores are scoped synchronously.                        |
 | `node:child_process`                              | `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/child-process` | Synchronous APIs over an explicit application-provided host capability; denied by default.                               |
 | `node:cluster`                                    | `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/cluster`       | Primary/worker control over an explicit host capability. Partly unsupported -- see below.                                |
 | `node:buffer`                                     | unenv's portable Buffer core with a Jco public adapter           | Covers the commonly used modern Buffer operations. Jco controls deprecated and runtime-dependent exports.                |
@@ -266,6 +267,19 @@ forward instead of reading `Could not resolve 'node:domain'`. Importing is fine;
 `active` and `_stack` are reachable on the default import only. An ES module binding cannot throw
 on read, so `import { active } from "node:domain"` fails at build time instead.
 
+### Diagnostics channels
+
+Publish/subscribe for instrumentation, entirely in-process, so it needs no WIT capability. Channels
+are interned by name: a publisher and a subscriber that never share a reference still meet on the
+same object.
+
+`TracingChannel` is implemented in full -- `traceSync`, `tracePromise` and `traceCallback`, with
+the `start`/`end`/`asyncStart`/`asyncEnd`/`error` sub-channels emitted in Node's order.
+
+`Channel.bindStore` accepts anything offering `run(value, fn)`, which includes jco-std's
+`AsyncLocalStorage`. Stores are therefore scoped synchronously: a bound store is visible while
+subscribers run and does not follow an `await`. See the async hooks section above for why.
+
 ### Buffer
 
 The Buffer core comes from `unenv`'s wrapper around the MIT-licensed Feross
@@ -351,7 +365,6 @@ the module or upstream project.
 | Modules                                   | Why they are not enabled yet                                                                                                                                                                                                |
 | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `node:events`                             | Much of EventEmitter is useful, but the public module includes placeholder exports and depends on the current async-hooks fallback.                                                                                         |
-| `node:diagnostics_channel`                | Core channel behavior exists, while tracing and async-context portions are incomplete.                                                                                                                                      |
 | `node:readline`, `node:readline/promises` | Interactive terminal behavior needs real guest streams and input handling; current fallbacks cannot reproduce it.                                                                                                           |
 | `node:timers/promises`                    | A component-aware timer/event-loop integration is needed for delays, cancellation, and abort signals.                                                                                                                       |
 | `node:trace_events`, `node:tty`           | The fallbacks preserve useful shapes, but tracing and terminal detection are synthetic or no-op without runtime integration.                                                                                                |

--- a/packages/jco-std/README.md
+++ b/packages/jco-std/README.md
@@ -18,17 +18,18 @@ Below is a list of utilties provided by `@bytecodealliance/jco-std`:
 
 ## HTTP
 
-| Export                                 | Description                                                                   |
-| -------------------------------------- | ----------------------------------------------------------------------------- |
-| `http/adapters/hono`                   | Enables easier building of [Hono][hono] HTTP servers                          |
-| `http/adapters/express`                | Provides a simple [Express][express]-like interface for building HTTP servers |
-| `wasi/0.2.x/node/24.x.x/assert`        | `node:assert` adapter, Node 24 on WASI p2                                     |
-| `wasi/0.2.x/node/24.x.x/console`       | `node:console` guest adapter over an explicit host capability                 |
-| `wasi/0.2.x/node/24.x.x/path`          | `node:path` adapter, Node 24 on WASI p2                                       |
-| `wasi/0.2.x/node/24.x.x/domain`        | `node:domain`, deprecated upstream: every use throws                          |
-| `wasi/0.2.x/node/24.x.x/async-hooks`   | `node:async_hooks` guest adapter, Node 24, synchronous scopes only            |
-| `wasi/0.2.x/node/24.x.x/child-process` | `node:child_process` guest adapter, Node 24 over an explicit host capability  |
-| `wasi/0.2.x/node/24.x.x/cluster`       | `node:cluster` guest adapter, Node 24 over an explicit host capability        |
+| Export                                       | Description                                                                   |
+| -------------------------------------------- | ----------------------------------------------------------------------------- |
+| `http/adapters/hono`                         | Enables easier building of [Hono][hono] HTTP servers                          |
+| `http/adapters/express`                      | Provides a simple [Express][express]-like interface for building HTTP servers |
+| `wasi/0.2.x/node/24.x.x/assert`              | `node:assert` adapter, Node 24 on WASI p2                                     |
+| `wasi/0.2.x/node/24.x.x/console`             | `node:console` guest adapter over an explicit host capability                 |
+| `wasi/0.2.x/node/24.x.x/path`                | `node:path` adapter, Node 24 on WASI p2                                       |
+| `wasi/0.2.x/node/24.x.x/domain`              | `node:domain`, deprecated upstream: every use throws                          |
+| `wasi/0.2.x/node/24.x.x/async-hooks`         | `node:async_hooks` guest adapter, Node 24, synchronous scopes only            |
+| `wasi/0.2.x/node/24.x.x/diagnostics-channel` | `node:diagnostics_channel` guest adapter, Node 24                             |
+| `wasi/0.2.x/node/24.x.x/child-process`       | `node:child_process` guest adapter, Node 24 over an explicit host capability  |
+| `wasi/0.2.x/node/24.x.x/cluster`             | `node:cluster` guest adapter, Node 24 over an explicit host capability        |
 
 [express]: https://expressjs.com
 
@@ -81,6 +82,8 @@ Jco can bundle the following Node.js APIs into JavaScript WebAssembly components
   `jco:node/child-process@0.1.0` host capability;
 - `node:async_hooks`, implemented by
   `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/async-hooks`, for synchronous scopes;
+- `node:diagnostics_channel`, implemented by
+  `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/diagnostics-channel`;
 - `node:cluster`, implemented by
   `@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/cluster` and the
   `jco:node/cluster@0.1.0` host capability;

--- a/packages/jco-std/package.json
+++ b/packages/jco-std/package.json
@@ -76,6 +76,11 @@
       "browser": "./dist/wasi/0.2.x/node/24.x.x/domain.js",
       "default": "./dist/wasi/0.2.x/node/24.x.x/domain.js"
     },
+    "./wasi/0.2.x/node/24.x.x/diagnostics-channel": {
+      "types": "./dist/wasi/0.2.x/node/24.x.x/diagnostics-channel.d.ts",
+      "browser": "./dist/wasi/0.2.x/node/24.x.x/diagnostics-channel.js",
+      "default": "./dist/wasi/0.2.x/node/24.x.x/diagnostics-channel.js"
+    },
     "./wasi/0.2.x/node/24.x.x/child-process": {
       "types": "./dist/wasi/0.2.x/node/24.x.x/child-process.d.ts",
       "browser": "./dist/wasi/0.2.x/node/24.x.x/child-process.js",

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/diagnostics-channel.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/diagnostics-channel.ts
@@ -1,0 +1,33 @@
+/**
+ * `node:diagnostics_channel`, in-process publish/subscribe for instrumentation.
+ *
+ * Capability-free: no host involvement, so it needs no WIT import. Channels are interned by name,
+ * so a publisher and a subscriber that never share a reference still meet on the same object.
+ *
+ * `Channel.bindStore` takes anything offering `run(value, fn)`, which includes jco-std's
+ * `AsyncLocalStorage`. Store scoping is therefore synchronous: a bound store is visible while
+ * subscribers run, and does not follow an `await`. See `async-hooks.ts` for why that limit exists
+ * and what would lift it.
+ */
+
+export {
+  Channel,
+  TracingChannel,
+  channel,
+  hasSubscribers,
+  subscribe,
+  tracingChannel,
+  unsubscribe,
+} from "./diagnostics-channel/index.js";
+
+export type {
+  BoundStore,
+  MessageHandler,
+  StoreTransform,
+  TracingChannelSubscribers,
+  TracingEvent,
+} from "./diagnostics-channel/index.js";
+
+import * as diagnosticsChannel from "./diagnostics-channel/index.js";
+
+export default diagnosticsChannel;

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/diagnostics-channel/channel.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/diagnostics-channel/channel.ts
@@ -1,0 +1,114 @@
+import type { BoundStore, MessageHandler, StoreTransform } from "./types.js";
+
+/**
+ * A named publish/subscribe channel, matching Node's `diagnostics_channel.Channel`.
+ *
+ * Channels are interned by name so `channel(name)` returns the same object every time, which is
+ * what lets a publisher and a subscriber find each other without sharing a reference.
+ */
+export class Channel {
+  readonly name: string;
+  readonly #subscribers: MessageHandler[] = [];
+  readonly #stores = new Map<BoundStore, StoreTransform>();
+
+  constructor(name: string) {
+    this.name = name;
+  }
+
+  /** Whether anything is listening. Publishers check this to skip building a message. */
+  get hasSubscribers(): boolean {
+    return this.#subscribers.length > 0;
+  }
+
+  /**
+   * Deliver `message` to every subscriber.
+   *
+   * Bound stores are deliberately not applied: Node applies them from `runStores`, not `publish`.
+   */
+  publish(message: unknown): void {
+    if (this.#subscribers.length === 0) {
+      return;
+    }
+    // Copy first: a subscriber may subscribe or unsubscribe while running.
+    for (const subscriber of [...this.#subscribers]) {
+      subscriber(message, this.name);
+    }
+  }
+
+  subscribe(onMessage: MessageHandler): void {
+    this.#subscribers.push(onMessage);
+  }
+
+  /** Remove a subscriber, reporting whether one was actually registered. */
+  unsubscribe(onMessage: MessageHandler): boolean {
+    const index = this.#subscribers.indexOf(onMessage);
+    if (index === -1) {
+      return false;
+    }
+    this.#subscribers.splice(index, 1);
+    return true;
+  }
+
+  /**
+   * Bind a store so published data is visible through it while subscribers run.
+   *
+   * The store only has to offer `run`, so jco-std's `AsyncLocalStorage` and Node's both work. Note
+   * the scoping is synchronous: see the async-hooks module for why a store cannot follow an await.
+   */
+  bindStore(store: BoundStore, transform: StoreTransform = (data) => data): void {
+    this.#stores.set(store, transform);
+  }
+
+  unbindStore(store: BoundStore): boolean {
+    return this.#stores.delete(store);
+  }
+
+  /**
+   * Publish `data`, then run `fn` with it visible through every bound store.
+   *
+   * Node publishes from here as well as applying the stores, so subscribers see the message with
+   * the stores already entered.
+   */
+  runStores<R>(data: unknown, fn: (...args: never[]) => R, thisArg?: unknown, ...args: never[]): R {
+    return this.#runWithStores(data, () => {
+      this.publish(data);
+      return Reflect.apply(fn, thisArg, args) as R;
+    });
+  }
+
+  /** Nest every bound store around `fn`, innermost last. */
+  #runWithStores<R>(data: unknown, fn: () => R): R {
+    let run = fn;
+    for (const [store, transform] of this.#stores) {
+      const inner = run;
+      run = () => store.run(transform(data), inner);
+    }
+    return run();
+  }
+}
+
+/** Interned channels, so a name always maps to one instance. */
+const channels = new Map<string, Channel>();
+
+export function channel(name: string): Channel {
+  const existing = channels.get(name);
+  if (existing) {
+    return existing;
+  }
+  const created = new Channel(name);
+  channels.set(name, created);
+  return created;
+}
+
+/** Whether a channel with this name exists and has subscribers. */
+export function hasSubscribers(name: string): boolean {
+  return channels.get(name)?.hasSubscribers ?? false;
+}
+
+export function subscribe(name: string, onMessage: MessageHandler): void {
+  channel(name).subscribe(onMessage);
+}
+
+export function unsubscribe(name: string, onMessage: MessageHandler): boolean {
+  return channel(name).unsubscribe(onMessage);
+}

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/diagnostics-channel/index.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/diagnostics-channel/index.ts
@@ -1,0 +1,9 @@
+export { Channel, channel, hasSubscribers, subscribe, unsubscribe } from "./channel.js";
+export { TracingChannel, tracingChannel } from "./tracing.js";
+export type {
+  BoundStore,
+  MessageHandler,
+  StoreTransform,
+  TracingChannelSubscribers,
+  TracingEvent,
+} from "./types.js";

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/diagnostics-channel/tracing.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/diagnostics-channel/tracing.ts
@@ -1,0 +1,169 @@
+import { channel, type Channel } from "./channel.js";
+import { TRACING_EVENTS, type TracingChannelSubscribers, type TracingEvent } from "./types.js";
+
+/** Node names a tracing channel's sub-channels `tracing:<name>:<event>`. */
+function subChannelName(name: string, event: TracingEvent): string {
+  return `tracing:${name}:${event}`;
+}
+
+/**
+ * Node's `TracingChannel`: a group of channels describing one traced operation.
+ *
+ * `start`/`end` bracket the call, `error` reports a throw, and `asyncStart`/`asyncEnd` bracket the
+ * asynchronous portion of `tracePromise` and `traceCallback`.
+ */
+export class TracingChannel {
+  readonly start: Channel;
+  readonly end: Channel;
+  readonly asyncStart: Channel;
+  readonly asyncEnd: Channel;
+  readonly error: Channel;
+
+  constructor(name: string) {
+    this.start = channel(subChannelName(name, "start"));
+    this.end = channel(subChannelName(name, "end"));
+    this.asyncStart = channel(subChannelName(name, "asyncStart"));
+    this.asyncEnd = channel(subChannelName(name, "asyncEnd"));
+    this.error = channel(subChannelName(name, "error"));
+  }
+
+  /** Whether any of the sub-channels has a subscriber. A getter, as Node has it. */
+  get hasSubscribers(): boolean {
+    return TRACING_EVENTS.some((event) => this[event].hasSubscribers);
+  }
+
+  subscribe(subscribers: TracingChannelSubscribers): void {
+    for (const event of TRACING_EVENTS) {
+      const handler = subscribers[event];
+      if (handler) {
+        this[event].subscribe(handler);
+      }
+    }
+  }
+
+  unsubscribe(subscribers: TracingChannelSubscribers): boolean {
+    let removedAny = false;
+    for (const event of TRACING_EVENTS) {
+      const handler = subscribers[event];
+      if (handler && this[event].unsubscribe(handler)) {
+        removedAny = true;
+      }
+    }
+    return removedAny;
+  }
+
+  /**
+   * Trace a synchronous call.
+   *
+   * Publishes `start`, then `end` once the call returns -- and `error` before `end` if it throws,
+   * matching the order Node emits.
+   */
+  traceSync<R>(
+    fn: (...args: never[]) => R,
+    context: Record<string, unknown> = {},
+    thisArg?: unknown,
+    ...args: never[]
+  ): R {
+    return this.start.runStores(context, () => {
+      try {
+        const result = Reflect.apply(fn, thisArg, args) as R;
+        context.result = result;
+        return result;
+      } catch (error) {
+        context.error = error;
+        this.error.publish(context);
+        throw error;
+      } finally {
+        this.end.publish(context);
+      }
+    });
+  }
+
+  /** Trace a promise-returning call, bracketing its asynchronous portion. */
+  tracePromise<R>(
+    fn: (...args: never[]) => PromiseLike<R>,
+    context: Record<string, unknown> = {},
+    thisArg?: unknown,
+    ...args: never[]
+  ): PromiseLike<R> {
+    return this.start.runStores(context, () => {
+      let promise: PromiseLike<R>;
+      try {
+        promise = Reflect.apply(fn, thisArg, args) as PromiseLike<R>;
+      } catch (error) {
+        context.error = error;
+        this.error.publish(context);
+        throw error;
+      } finally {
+        // `end` closes the synchronous call, before the promise settles.
+        this.end.publish(context);
+      }
+
+      return promise.then(
+        (result) => {
+          context.result = result;
+          this.asyncStart.publish(context);
+          this.asyncEnd.publish(context);
+          return result;
+        },
+        (error: unknown) => {
+          // Node reports the error before opening the asynchronous bracket.
+          context.error = error;
+          this.error.publish(context);
+          this.asyncStart.publish(context);
+          this.asyncEnd.publish(context);
+          throw error;
+        },
+      );
+    });
+  }
+
+  /**
+   * Trace a callback-taking call.
+   *
+   * The callback is wrapped in place at `position`, so the traced function still receives the
+   * arguments it expects.
+   */
+  traceCallback<R>(
+    fn: (...args: never[]) => R,
+    position = -1,
+    context: Record<string, unknown> = {},
+    thisArg?: unknown,
+    ...args: never[]
+  ): R {
+    const callbackIndex = position >= 0 ? position : args.length - 1;
+    const original = args[callbackIndex] as unknown;
+    if (typeof original === "function") {
+      const wrapped = (...callbackArgs: unknown[]) => {
+        const [error] = callbackArgs;
+        this.asyncStart.publish(context);
+        if (error) {
+          context.error = error;
+          this.error.publish(context);
+        }
+        try {
+          return Reflect.apply(original as (...a: unknown[]) => unknown, thisArg, callbackArgs);
+        } finally {
+          this.asyncEnd.publish(context);
+        }
+      };
+      args[callbackIndex] = wrapped as never;
+    }
+
+    return this.start.runStores(context, () => {
+      try {
+        return Reflect.apply(fn, thisArg, args) as R;
+      } catch (error) {
+        context.error = error;
+        this.error.publish(context);
+        throw error;
+      } finally {
+        this.end.publish(context);
+      }
+    });
+  }
+}
+
+export function tracingChannel(name: string): TracingChannel {
+  return new TracingChannel(name);
+}

--- a/packages/jco-std/src/wasi/0.2.x/node/24.x.x/diagnostics-channel/types.ts
+++ b/packages/jco-std/src/wasi/0.2.x/node/24.x.x/diagnostics-channel/types.ts
@@ -1,0 +1,29 @@
+/** A subscriber, called with the published message and the channel's name. */
+export type MessageHandler = (message: unknown, name: string) => void;
+
+/**
+ * The store contract `bindStore` needs.
+ *
+ * Structural on purpose: it accepts jco-std's `AsyncLocalStorage`, Node's own, or anything else
+ * offering `run`, so this module takes no dependency on a particular storage implementation.
+ */
+export interface BoundStore {
+  run<R>(store: unknown, fn: () => R): R;
+}
+
+/** Transforms published data into the value a bound store should hold. */
+export type StoreTransform = (data: unknown) => unknown;
+
+/** The handlers a `TracingChannel` subscriber may provide. */
+export interface TracingChannelSubscribers {
+  start?: MessageHandler;
+  end?: MessageHandler;
+  asyncStart?: MessageHandler;
+  asyncEnd?: MessageHandler;
+  error?: MessageHandler;
+}
+
+/** The sub-channel names a `TracingChannel` owns, in Node's order. */
+export const TRACING_EVENTS = ["start", "end", "asyncStart", "asyncEnd", "error"] as const;
+
+export type TracingEvent = (typeof TRACING_EVENTS)[number];

--- a/packages/jco-std/test/wasi/0.2.x/node/24.x.x/diagnostics-channel/channel.ts
+++ b/packages/jco-std/test/wasi/0.2.x/node/24.x.x/diagnostics-channel/channel.ts
@@ -1,0 +1,135 @@
+import { describe, expect, test } from "vitest";
+
+import nodeDc from "node:diagnostics_channel";
+
+import * as ours from "../../../../../../src/wasi/0.2.x/node/24.x.x/diagnostics-channel.js";
+
+type Dc = typeof nodeDc;
+
+/**
+ * Behavior is compared against Node's own module, so these pin the contract rather than my reading
+ * of it. Each case gets a distinct channel name to stay independent of the others.
+ */
+describe("Channel behavior matches Node", () => {
+  const cases: [string, (dc: Dc, name: string) => unknown][] = [
+    ["channel identity is stable", (dc, n) => dc.channel(n) === dc.channel(n)],
+    ["hasSubscribers is false before anything subscribes", (dc, n) => dc.hasSubscribers(n)],
+    [
+      "hasSubscribers is true once subscribed",
+      (dc, n) => {
+        dc.subscribe(n, () => {});
+        return dc.hasSubscribers(n);
+      },
+    ],
+    [
+      "publish delivers message and channel name",
+      (dc, n) => {
+        const seen: unknown[] = [];
+        dc.subscribe(n, (message, name) => seen.push([message, name]));
+        dc.channel(n).publish({ x: 1 });
+        return seen;
+      },
+    ],
+    [
+      "unsubscribe stops delivery and reports true",
+      (dc, n) => {
+        const handler = () => undefined;
+        dc.subscribe(n, handler);
+        const removed = dc.unsubscribe(n, handler);
+        return [removed, dc.hasSubscribers(n)];
+      },
+    ],
+    ["unsubscribing an unknown handler reports false", (dc, n) => dc.unsubscribe(n, () => {})],
+    [
+      "publish with no subscribers is a no-op",
+      (dc, n) => {
+        dc.channel(n).publish({ x: 1 });
+        return dc.hasSubscribers(n);
+      },
+    ],
+    [
+      "every subscriber receives the message",
+      (dc, n) => {
+        const seen: string[] = [];
+        dc.subscribe(n, () => seen.push("a"));
+        dc.subscribe(n, () => seen.push("b"));
+        dc.channel(n).publish(1);
+        return seen;
+      },
+    ],
+    [
+      "a subscriber unsubscribing mid-publish still receives that message",
+      (dc, n) => {
+        const seen: string[] = [];
+        const first = () => {
+          seen.push("first");
+          dc.unsubscribe(n, second);
+        };
+        const second = () => seen.push("second");
+        dc.subscribe(n, first);
+        dc.subscribe(n, second);
+        dc.channel(n).publish(1);
+        return seen;
+      },
+    ],
+    [
+      "bindStore exposes transformed data while subscribers run",
+      (dc, n) => {
+        const seen: unknown[] = [];
+        let inStore: unknown;
+        const store = {
+          run: (value: unknown, fn: () => unknown) => {
+            inStore = value;
+            return fn();
+          },
+        };
+        const ch = dc.channel(n);
+        ch.bindStore(store as never, (data: unknown) => ({ from: data }));
+        dc.subscribe(n, () => seen.push(inStore));
+        ch.publish({ v: 1 });
+        return seen;
+      },
+    ],
+    [
+      "runStores exposes data to the callback",
+      (dc, n) => {
+        let inStore: unknown;
+        const store = {
+          run: (value: unknown, fn: () => unknown) => {
+            inStore = value;
+            return fn();
+          },
+        };
+        const ch = dc.channel(n);
+        ch.bindStore(store as never, (data: unknown) => data);
+        const returned = ch.runStores({ v: 2 }, () => "done");
+        return [returned, inStore];
+      },
+    ],
+    [
+      "unbindStore stops the store being applied",
+      (dc, n) => {
+        let entered = false;
+        const store = {
+          run: (_v: unknown, fn: () => unknown) => {
+            entered = true;
+            return fn();
+          },
+        };
+        const ch = dc.channel(n);
+        ch.bindStore(store as never);
+        ch.unbindStore(store as never);
+        ch.runStores({ v: 1 }, () => undefined);
+        return entered;
+      },
+    ],
+  ];
+
+  test.each(cases)("%s", (name, run) => {
+    const slug = name.replace(/[^a-z]+/gi, "-");
+    // Separate registries, so the same name is safe and keeps the comparison exact.
+    expect(JSON.stringify(run(ours as unknown as Dc, slug))).toBe(
+      JSON.stringify(run(nodeDc, slug)),
+    );
+  });
+});

--- a/packages/jco-std/test/wasi/0.2.x/node/24.x.x/diagnostics-channel/tracing.ts
+++ b/packages/jco-std/test/wasi/0.2.x/node/24.x.x/diagnostics-channel/tracing.ts
@@ -1,0 +1,96 @@
+import { describe, expect, test } from "vitest";
+
+import nodeDc from "node:diagnostics_channel";
+
+import * as ours from "../../../../../../src/wasi/0.2.x/node/24.x.x/diagnostics-channel.js";
+
+type Dc = typeof nodeDc;
+
+/** Record the event order a tracing channel emits, which is the contract that matters. */
+function events(
+  dc: Dc,
+  name: string,
+  body: (tc: ReturnType<Dc["tracingChannel"]>) => unknown,
+): unknown {
+  const seen: string[] = [];
+  const tc = dc.tracingChannel(name);
+  tc.subscribe({
+    start: () => seen.push("start"),
+    end: () => seen.push("end"),
+    asyncStart: () => seen.push("asyncStart"),
+    asyncEnd: () => seen.push("asyncEnd"),
+    error: () => seen.push("error"),
+  });
+  const returned = body(tc);
+  return returned instanceof Promise
+    ? returned.then(
+        () => seen,
+        () => seen,
+      )
+    : seen;
+}
+
+describe("TracingChannel matches Node", () => {
+  test("hasSubscribers reflects the sub-channels", () => {
+    for (const dc of [ours as unknown as Dc, nodeDc]) {
+      const tc = dc.tracingChannel("has-subs");
+      expect(tc.hasSubscribers).toBe(false);
+      tc.subscribe({ start: () => undefined });
+      expect(tc.hasSubscribers).toBe(true);
+    }
+  });
+
+  test("traceSync emits start then end", async () => {
+    expect(await events(ours as unknown as Dc, "sync-ok", (tc) => tc.traceSync(() => 1))).toEqual(
+      await events(nodeDc, "sync-ok", (tc) => tc.traceSync(() => 1)),
+    );
+  });
+
+  test("a throwing traceSync emits start, error, end", async () => {
+    const body = (tc: ReturnType<Dc["tracingChannel"]>) => {
+      try {
+        tc.traceSync(() => {
+          throw new Error("boom");
+        });
+      } catch {
+        // the order is what is under test
+      }
+    };
+    expect(await events(ours as unknown as Dc, "sync-throw", body)).toEqual(
+      await events(nodeDc, "sync-throw", body),
+    );
+  });
+
+  test("tracePromise brackets the asynchronous portion", async () => {
+    const body = (tc: ReturnType<Dc["tracingChannel"]>) => tc.tracePromise(async () => 1);
+    expect(await events(ours as unknown as Dc, "promise-ok", body)).toEqual(
+      await events(nodeDc, "promise-ok", body),
+    );
+  });
+
+  test("a rejecting tracePromise reports the error", async () => {
+    const body = (tc: ReturnType<Dc["tracingChannel"]>) =>
+      tc.tracePromise(async () => {
+        throw new Error("boom");
+      });
+    expect(await events(ours as unknown as Dc, "promise-throw", body)).toEqual(
+      await events(nodeDc, "promise-throw", body),
+    );
+  });
+
+  test("subscribe and unsubscribe are symmetric", () => {
+    for (const dc of [ours as unknown as Dc, nodeDc]) {
+      const tc = dc.tracingChannel("sub-unsub");
+      const handlers = { start: () => undefined, end: () => undefined };
+      tc.subscribe(handlers);
+      expect(tc.unsubscribe(handlers)).toBe(true);
+      expect(tc.hasSubscribers).toBe(false);
+    }
+  });
+
+  test("the traced value is returned unchanged", () => {
+    for (const dc of [ours as unknown as Dc, nodeDc]) {
+      expect(dc.tracingChannel("returns").traceSync(() => 42)).toBe(42);
+    }
+  });
+});

--- a/packages/jco/src/node-builtins.ts
+++ b/packages/jco/src/node-builtins.ts
@@ -21,6 +21,7 @@ const CLUSTER_SPECIFIER = "node:cluster";
 const CONSOLE_SPECIFIER = "node:console";
 const ASYNC_HOOKS_SPECIFIER = "node:async_hooks";
 const DOMAIN_SPECIFIER = "node:domain";
+const DIAGNOSTICS_CHANNEL_SPECIFIER = "node:diagnostics_channel";
 const AUDITED_UNENV_SPECIFIERS = new Set(["node:buffer", "node:querystring"]);
 const VIRTUAL_PREFIX = "\0jco-node-builtin:";
 const UNENV_BUFFER_CORE = `${VIRTUAL_PREFIX}unenv-buffer-core`;
@@ -167,6 +168,8 @@ export interface NodeBuiltinOptions {
     asyncHooksModule?: string;
     /** Path to jco-std's versioned `node:domain` module (overridable for tests) */
     domainModule?: string;
+    /** Path to jco-std's versioned `node:diagnostics_channel` module (overridable for tests) */
+    diagnosticsChannelModule?: string;
     /** Reports WIT imports required by builtins found while bundling. */
     onWitRequirement?: (requirement: NodeWitRequirement) => void;
     /** unenv aliases to resolve audited builtins against (overridable for tests) */
@@ -184,6 +187,27 @@ function domainAdapter(domainModule: string): string {
 import domain from ${JSON.stringify(domainModule)};
 export default domain;
 export { Domain, create, createDomain } from ${JSON.stringify(domainModule)};
+`;
+}
+
+/**
+ * Source of the `node:diagnostics_channel` adapter.
+ *
+ * Capability-free: in-process publish/subscribe with no host involvement.
+ */
+function diagnosticsChannelAdapter(diagnosticsChannelModule: string): string {
+    return `
+import diagnosticsChannel from ${JSON.stringify(diagnosticsChannelModule)};
+export default diagnosticsChannel;
+export {
+    Channel,
+    TracingChannel,
+    channel,
+    hasSubscribers,
+    subscribe,
+    tracingChannel,
+    unsubscribe,
+} from ${JSON.stringify(diagnosticsChannelModule)};
 `;
 }
 
@@ -421,6 +445,9 @@ export function nodeBuiltinPlugin(worldMetadata: WorldMetadata, options: NodeBui
     const domainModule = () =>
         options.domainModule ??
         fileURLToPath(import.meta.resolve("@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/domain"));
+    const diagnosticsChannelModule = () =>
+        options.diagnosticsChannelModule ??
+        fileURLToPath(import.meta.resolve("@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/diagnostics-channel"));
     const asyncHooksModule = () =>
         options.asyncHooksModule ??
         fileURLToPath(import.meta.resolve("@bytecodealliance/jco-std/wasi/0.2.x/node/24.x.x/async-hooks"));
@@ -444,6 +471,10 @@ export function nodeBuiltinPlugin(worldMetadata: WorldMetadata, options: NodeBui
             }
             if (id === DOMAIN_SPECIFIER) {
                 // No onWitRequirement: nothing here reaches the host.
+                return `${VIRTUAL_PREFIX}${id}`;
+            }
+            if (id === DIAGNOSTICS_CHANNEL_SPECIFIER) {
+                // No onWitRequirement: this needs no host capability.
                 return `${VIRTUAL_PREFIX}${id}`;
             }
             if (id === ASYNC_HOOKS_SPECIFIER) {
@@ -485,6 +516,9 @@ export function nodeBuiltinPlugin(worldMetadata: WorldMetadata, options: NodeBui
             }
             if (value === DOMAIN_SPECIFIER) {
                 return domainAdapter(domainModule());
+            }
+            if (value === DIAGNOSTICS_CHANNEL_SPECIFIER) {
+                return diagnosticsChannelAdapter(diagnosticsChannelModule());
             }
             if (value === ASYNC_HOOKS_SPECIFIER) {
                 return asyncHooksAdapter(asyncHooksModule());

--- a/packages/jco/test/node/builtins.js
+++ b/packages/jco/test/node/builtins.js
@@ -103,6 +103,36 @@ describe("Node builtin adapters", () => {
         expect(plugin.resolveId("domain")).toBeNull();
     });
 
+    test("generates a capability-free adapter for node:diagnostics_channel", () => {
+        const plugin = nodeBuiltinPlugin(
+            { imports: [], exports: [] },
+            { diagnosticsChannelModule: "/jco/node/diagnostics-channel.js" },
+        );
+        const id = plugin.resolveId("node:diagnostics_channel");
+        expect(id).toBe("\0jco-node-builtin:node:diagnostics_channel");
+        const source = plugin.load(id);
+        expect(source).toContain('from "/jco/node/diagnostics-channel.js"');
+        expect(source).toContain("tracingChannel");
+    });
+
+    test("node:diagnostics_channel requires no WIT capability", () => {
+        const onWitRequirement = vi.fn();
+        const plugin = nodeBuiltinPlugin(
+            { imports: [], exports: [] },
+            { diagnosticsChannelModule: "/jco/node/diagnostics-channel.js", onWitRequirement },
+        );
+        plugin.resolveId("node:diagnostics_channel");
+        expect(onWitRequirement).not.toHaveBeenCalled();
+    });
+
+    test("does not intercept the bare diagnostics_channel specifier", () => {
+        const plugin = nodeBuiltinPlugin(
+            { imports: [], exports: [] },
+            { diagnosticsChannelModule: "/jco/node/diagnostics-channel.js" },
+        );
+        expect(plugin.resolveId("diagnostics_channel")).toBeNull();
+    });
+
     test("generates a capability-free adapter for node:async_hooks", () => {
         const plugin = nodeBuiltinPlugin(
             { imports: [], exports: [] },


### PR DESCRIPTION
This PR depends on the work in async_hooks (which is necessarily incomplete, because we need async hook support at the guest engine level)