### PR TITLE
fix(bindgen): WAST validate-no-async-abi-for-synt-type test

### DIFF
--- a/packages/jco-transpile/test/fixtures/wast/component-model/async/validate-no-async-abi-for-sync-type.wast
+++ b/packages/jco-transpile/test/fixtures/wast/component-model/async/validate-no-async-abi-for-sync-type.wast
@@ -1,0 +1,27 @@
+(assert_invalid
+  (component
+    (core module $M
+      (func (export "f"))
+    )
+    (core instance $i (instantiate $M))
+    (func (export "f") (canon lift (core func $i "f") async))
+  )
+  "the `async` canonical option requires an async function type")
+
+(assert_invalid
+  (component
+    (core module $M
+      (func (export "f") (param i32) (result i32) unreachable)
+      (func (export "f_cb") (param i32 i32 i32) (result i32) unreachable)
+    )
+    (core instance $i (instantiate $M))
+    (func (export "f") (canon lift (core func $i "f") async (callback (core func $i "f_cb"))))
+  )
+  "the `async` canonical option requires an async function type")
+
+(assert_invalid
+  (component
+    (import "f" (func $f))
+    (core func $f' (canon lower (func $f) async))
+  )
+  "the `async` canonical option requires an async function type")

--- a/packages/jco-transpile/test/p3/ported/component-model/wast.ts
+++ b/packages/jco-transpile/test/p3/ported/component-model/wast.ts
@@ -57,6 +57,7 @@ const WAST_TESTS: readonly WastTest[] = [
     { relPath: 'async/cross-abi-calls.wast' },
     { relPath: 'async/trap-on-reenter.wast' },
     { relPath: 'async/validate-no-stream-char.wast' },
+    { relPath: 'async/validate-no-async-abi-for-sync-type.wast' },
 
     // Skipped tests
     // TODO: Revisit this fixture once stackful async support is implemented.


### PR DESCRIPTION
This test actually doesn't require any changes except simply updating the test to no longer be skipped 🎉

(once we unwind this huge list of dependent PRs of course!) 