### PR TITLE
fix(bindgen): fix stream cancel-after-zero-read bug

### DIFF
--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -1587,6 +1587,30 @@ mod tests {
     }
 
     #[test]
+    fn stream_operations_only_suspend_for_sync_canonical_calls() {
+        for op in [
+            AsyncStreamIntrinsic::StreamRead,
+            AsyncStreamIntrinsic::StreamWrite,
+        ] {
+            let source = render_intrinsic_body(Intrinsic::AsyncStream(op));
+
+            assert!(source.contains(&format!("function {}(", op.name())));
+            assert!(!source.contains(&format!("async function {}(", op.name())));
+        }
+
+        for end in [
+            AsyncStreamIntrinsic::StreamReadableEndClass,
+            AsyncStreamIntrinsic::StreamWritableEndClass,
+        ] {
+            let source = render_intrinsic_body(Intrinsic::AsyncStream(end));
+            assert!(source.contains("copy(args) {"));
+            assert!(!source.contains("async copy(args) {"));
+            assert!(source.contains("if (isAsync) {"));
+            assert!(source.contains("return task.suspendUntil({"));
+        }
+    }
+
+    #[test]
     fn future_ends_track_own_and_peer_drop_state_separately() {
         let mut intrinsics = BTreeSet::from([Intrinsic::AsyncFuture(
             AsyncFutureIntrinsic::InternalFutureClass,

--- a/crates/js-component-bindgen/src/intrinsics/mod.rs
+++ b/crates/js-component-bindgen/src/intrinsics/mod.rs
@@ -1562,6 +1562,16 @@ mod tests {
     }
 
     #[test]
+    fn stream_new_allocates_the_readable_end_first() {
+        let source =
+            render_intrinsic_body(Intrinsic::AsyncStream(AsyncStreamIntrinsic::CreateStream));
+        let read = source.find("const readEnd = stream.readEnd();").unwrap();
+        let write = source.find("const writeEnd = stream.writeEnd();").unwrap();
+
+        assert!(read < write);
+    }
+
+    #[test]
     fn future_operations_only_suspend_for_sync_canonical_calls() {
         for op in [
             AsyncFutureIntrinsic::FutureRead,

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -374,16 +374,6 @@ impl AsyncStreamIntrinsic {
                         }});
                         stream.setGlobalStreamMapRep({global_stream_map}.insert(stream));
 
-                        const writeEnd = stream.writeEnd();
-                        writeEnd.setWaitableIdx(cstate.handles.insert(writeEnd));
-                        writeEnd.setHandle(localStreamTable.insert(writeEnd));
-                        if (writeEnd.streamTableIdx() !== tableIdx) {{ throw new Error("unexpectedly mismatched stream table"); }}
-
-                        const writeEndWaitableIdx = writeEnd.waitableIdx();
-                        const writeEndHandle = writeEnd.handle();
-                        writeWaitable.setTarget(`waitable for stream write end (waitable [${{writeEndWaitableIdx}}])`);
-                        writeEnd.setTarget(`stream write end (waitable [${{writeEndWaitableIdx}}])`);
-
                         const readEnd = stream.readEnd();
                         readEnd.setWaitableIdx(cstate.handles.insert(readEnd));
                         readEnd.setHandle(localStreamTable.insert(readEnd));
@@ -393,6 +383,16 @@ impl AsyncStreamIntrinsic {
                         const readEndHandle = readEnd.handle();
                         readWaitable.setTarget(`waitable for read end (waitable [${{readEndWaitableIdx}}])`);
                         readEnd.setTarget(`stream read end (waitable [${{readEndWaitableIdx}}])`);
+
+                        const writeEnd = stream.writeEnd();
+                        writeEnd.setWaitableIdx(cstate.handles.insert(writeEnd));
+                        writeEnd.setHandle(localStreamTable.insert(writeEnd));
+                        if (writeEnd.streamTableIdx() !== tableIdx) {{ throw new Error("unexpectedly mismatched stream table"); }}
+
+                        const writeEndWaitableIdx = writeEnd.waitableIdx();
+                        const writeEndHandle = writeEnd.handle();
+                        writeWaitable.setTarget(`waitable for stream write end (waitable [${{writeEndWaitableIdx}}])`);
+                        writeEnd.setTarget(`stream write end (waitable [${{writeEndWaitableIdx}}])`);
 
                         return {{
                             writeEnd,

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -789,7 +789,8 @@ impl AsyncStreamIntrinsic {
                             // after progress queued a COMPLETED event but before the guest
                             // consumed it; preserve the count and report the cancellation.
                             if (result === {stream_end_class}.CopyResult.COMPLETED
-                                && streamEnd.getCopyState() === {stream_end_class}.CopyState.CANCELLING_COPY) {{
+                                && streamEnd.getCopyState() === {stream_end_class}.CopyState.CANCELLING_COPY
+                                && !streamEnd.hasHostInject()) {{
                                 result = {stream_end_class}.CopyResult.CANCELLED;
                             }}
 
@@ -855,6 +856,17 @@ impl AsyncStreamIntrinsic {
                                 }}
 
                                 if (!this.#pendingBufferMeta.buffer) {{
+                                    // A just-in-time host-injected write found no reader buffer: the
+                                    // target read was cancelled. Return the undelivered items to the
+                                    // source (redelivered by a later read) instead of stranding
+                                    // (which blocks on a future read -- can deadlock a stream whose
+                                    // write waits on its reader -- or is dropped at stream end).
+                                    if (this.#sourceRebufferFn && buffer.isHostOwned()) {{
+                                        const remaining = buffer.remaining();
+                                        if (remaining > 0) {{ this.#sourceRebufferFn(buffer.read(remaining)); }}
+                                        onCopyDoneFn({stream_end_class}.CopyResult.COMPLETED);
+                                        return;
+                                    }}
                                     this.setPendingBufferMeta({{ componentIdx, buffer, onCopyFn, onCopyDoneFn }});
                                     return;
                                 }}
@@ -1534,6 +1546,7 @@ impl AsyncStreamIntrinsic {
                         #isHostOwned;
 
                         #result = null;
+                        #sourceRebufferFn = null;
 
                         #endOfStream = false;
                         #rejectedLength = null;
@@ -1580,6 +1593,8 @@ impl AsyncStreamIntrinsic {
                             this.#hostDropFn = f;
                         }}
                         setHostCancelFn(f) {{ this.#hostCancelFn = f; }}
+                        hasHostInject() {{ return !!this.#hostInjectFn; }}
+                        setSourceRebufferFn(f) {{ this.#sourceRebufferFn = f; }}
 
                         getElemMeta() {{ return {{...this.#elemMeta}}; }}
 
@@ -2503,6 +2518,7 @@ impl AsyncStreamIntrinsic {
                           const elemMeta = hostWriteEnd.getElemMeta();
 
                           const pendingValues = new {pending_value_queue_class}(readFn, elemMeta);
+                          hostWriteEnd.setSourceRebufferFn?.((items) => pendingValues.prepend(items));
 
                           return async function generatedStreamHostInject(args) {{
                               let {{ count }} = args;
@@ -2558,9 +2574,11 @@ impl AsyncStreamIntrinsic {
                                       if (readEnd.hasPendingEvent() || !hasPendingReadBuffer()) {{ return doNothingFn; }}
                                   }}
                                   if (pendingValues.length > 0) {{
-                                      const readyValues = [];
-                                      pendingValues.drainInto(readyValues, 1);
-                                      await writeValues(readyValues);
+                                      // Readiness signal for a zero-length read: complete it with zero
+                                      // items rather than draining/buffering one (which the wasmtime
+                                      // host contract warns can be lost, and which stores a pending
+                                      // write that corrupts the next read's rendezvous).
+                                      readEnd.resetAndNotifyPending(readEnd.constructor.CopyResult.COMPLETED);
                                   }} else if (pendingValues.done) {{
                                       hostWriteEnd.getPendingEvent();
                                       hostWriteEnd.drop();

--- a/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
+++ b/crates/js-component-bindgen/src/intrinsics/p3/async_stream.rs
@@ -1012,7 +1012,7 @@ impl AsyncStreamIntrinsic {
                 // read on an external stream class)
                 let copy_impl = format!(
                     r#"
-                         async copy(args) {{
+                         copy(args) {{
                              const {{
                                  isAsync,
                                  memory,
@@ -1088,7 +1088,38 @@ impl AsyncStreamIntrinsic {
                                  injectedWritePromise = this.#hostInjectFn({{ count }});
                              }}
 
-                             // If sync, wait forever but allow task to do other things
+                             const finishCopy = () => {{
+                                 const event = this.getPendingEvent();
+                                 if (!event) {{ throw new Error("unexpectedly missing pending event"); }}
+                                 if (event.code === undefined || event.payload0 === undefined || event.payload1 === undefined) {{
+                                     throw new Error("unexpectedly malformed event");
+                                 }}
+
+                                 const {{ code, payload0: index, payload1: payload }} = event;
+
+                                 const waitableIdx = this.getWaitable().idx();
+                                 if (code !== eventCode  || index !== waitableIdx || payload === {async_blocked_const}) {{
+                                     const errMsg = "invalid event code/event during stream operation";
+                                     {debug_log_fn}(errMsg, {{
+                                         event,
+                                         payload,
+                                         payloadIsBlockedConst: payload === {async_blocked_const},
+                                         code,
+                                         eventCode,
+                                         codeDoesNotMatchEventCode: code !== eventCode,
+                                         index,
+                                         internalEndIdx: waitableIdx,
+                                         indexDoesNotMatch: index !== waitableIdx,
+                                     }});
+                                     throw new Error(errMsg);
+                                 }}
+
+                                 if (event.rejectedLength !== undefined) {{
+                                     this.#rejectedLength = event.rejectedLength;
+                                 }}
+                                 return payload;
+                             }};
+
                              if (!this.hasPendingEvent()) {{
                                  if (isAsync) {{
                                      this.setCopyState({stream_end_class}.CopyState.ASYNC_COPYING);
@@ -1112,48 +1143,30 @@ impl AsyncStreamIntrinsic {
                                      if (!task) {{ throw new Error('missing task task from task meta'); }}
 
                                      const streamEnd = this;
-                                     await task.suspendUntil({{
+                                     return task.suspendUntil({{
                                          readyFn: () => streamEnd.hasPendingEvent(),
+                                     }}).then(() => {{
+                                         if (!injectedWritePromise) {{ return finishCopy(); }}
+                                         return injectedWritePromise.then(cleanupFn => {{
+                                             cleanupFn();
+                                             return finishCopy();
+                                         }});
                                      }});
                                  }}
                              }}
 
-                             // If the read completed immediately after injecting a host write,
-                             // it is safe to await injection cleanup before consuming the event.
-                             if (injectedWritePromise) {{
-                                 const cleanupFn = await injectedWritePromise;
+                             if (!injectedWritePromise) {{ return finishCopy(); }}
+                             if (isAsync) {{
+                                 injectedWritePromise.then(
+                                     cleanupFn => cleanupFn(),
+                                     err => this.setPendingEvent(() => {{ throw err; }}),
+                                 );
+                                 return finishCopy();
+                             }}
+                             return injectedWritePromise.then(cleanupFn => {{
                                  cleanupFn();
-                             }}
-
-                             const event = this.getPendingEvent();
-                             if (!event) {{ throw new Error("unexpectedly missing pending event"); }}
-                             if (event.code === undefined || event.payload0 === undefined || event.payload1 === undefined) {{
-                                 throw new Error("unexpectedly malformed event");
-                             }}
-
-                             const {{ code, payload0: index, payload1: payload }} = event;
-
-                             const waitableIdx = this.getWaitable().idx();
-                             if (code !== eventCode  || index !== waitableIdx || payload === {async_blocked_const}) {{
-                                 const errMsg = "invalid event code/event during stream operation";
-                                 {debug_log_fn}(errMsg, {{
-                                     event,
-                                     payload,
-                                     payloadIsBlockedConst: payload === {async_blocked_const},
-                                     code,
-                                     eventCode,
-                                     codeDoesNotMatchEventCode: code !== eventCode,
-                                     index,
-                                     internalEndIdx: waitableIdx,
-                                     indexDoesNotMatch: index !== waitableIdx,
-                                 }});
-                                 throw new Error(errMsg);
-                             }}
-
-                             if (event.rejectedLength !== undefined) {{
-                                 this.#rejectedLength = event.rejectedLength;
-                             }}
-                             return payload;
+                                 return finishCopy();
+                             }});
                          }}
                     "#
                 );
@@ -2154,7 +2167,7 @@ impl AsyncStreamIntrinsic {
                     render_args.require_intrinsic(Intrinsic::WebAssemblyRuntimeError);
 
                 output.push_str(&format!(r#"
-                    async function {stream_op_fn}(
+                    function {stream_op_fn}(
                         ctx,
                         streamEndWaitableIdx,
                         ptr,
@@ -2198,7 +2211,7 @@ impl AsyncStreamIntrinsic {
                             throw new Error(`stream end table idx [${{streamEnd.streamTableIdx()}}] != operation table idx [${{streamTableIdx}}]`);
                         }}
 
-                        const result = await streamEnd.copy({{
+                        return streamEnd.copy({{
                             isAsync,
                             memory: getMemoryFn?.(),
                             ptr,
@@ -2210,8 +2223,6 @@ impl AsyncStreamIntrinsic {
                             getReallocFn,
                             elemMeta,
                         }});
-
-                        return result;
                     }}
                 "#));
             }

--- a/crates/js-component-bindgen/src/transpile_bindgen.rs
+++ b/crates/js-component-bindgen/src/transpile_bindgen.rs
@@ -1582,13 +1582,12 @@ impl<'a> Instantiator<'a, '_> {
                     || options.async_
                     || self.types[*lower_ty].async_
             }
-            Trampoline::FutureRead { options, .. } | Trampoline::FutureWrite { options, .. } => {
-                !self.component.options[*options].async_
-            }
+            Trampoline::FutureRead { options, .. }
+            | Trampoline::FutureWrite { options, .. }
+            | Trampoline::StreamRead { options, .. }
+            | Trampoline::StreamWrite { options, .. } => !self.component.options[*options].async_,
             Trampoline::SubtaskCancel { .. }
             | Trampoline::WaitableSetWait { .. }
-            | Trampoline::StreamRead { .. }
-            | Trampoline::StreamWrite { .. }
             | Trampoline::StreamCancelRead { .. }
             | Trampoline::StreamCancelWrite { .. }
             | Trampoline::FutureCancelRead { .. }
@@ -2018,26 +2017,32 @@ impl<'a> Instantiator<'a, '_> {
                     );
                 }
 
-                uwriteln!(
-                    self.src.js,
-                    r#"const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_instance_id}, {stream_read_fn}.bind(
-                         null,
-                         {{
-                             componentIdx: {component_instance_id},
-                             memoryIdx: {memory_idx_js},
-                             getMemoryFn: {get_memory_fn_js},
-                             reallocIdx: {realloc_idx},
-                             getReallocFn: {get_realloc_fn_js},
-                             stringEncoding: {string_encoding},
-                             isAsync: {async_},
-                             streamTableIdx: {stream_table_idx},
-                             elemMeta: {elem_meta_js},
-                         }}
-                     )));
-                    "#,
-                    suspending_wrap_fn =
-                        self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn),
+                let ctx = format!(
+                    r#"{{
+                    componentIdx: {component_instance_id},
+                    memoryIdx: {memory_idx_js},
+                    getMemoryFn: {get_memory_fn_js},
+                    reallocIdx: {realloc_idx},
+                    getReallocFn: {get_realloc_fn_js},
+                    stringEncoding: {string_encoding},
+                    isAsync: {async_},
+                    streamTableIdx: {stream_table_idx},
+                    elemMeta: {elem_meta_js},
+                }}"#
                 );
+                if *async_ {
+                    uwriteln!(
+                        self.src.js,
+                        "const trampoline{i} = {stream_read_fn}.bind(null, {ctx});",
+                    );
+                } else {
+                    let suspending_wrap_fn =
+                        self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn);
+                    uwriteln!(
+                        self.src.js,
+                        "const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_instance_id}, {stream_read_fn}.bind(null, {ctx})));",
+                    );
+                }
             }
 
             Trampoline::StreamWrite {
@@ -2108,27 +2113,32 @@ impl<'a> Instantiator<'a, '_> {
                     );
                 }
 
-                uwriteln!(
-                    self.src.js,
-                    r#"
-                     const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_instance_id}, {stream_write_fn}.bind(
-                         null,
-                         {{
-                             componentIdx: {component_instance_id},
-                             memoryIdx: {memory_idx_js},
-                             getMemoryFn: {get_memory_fn_js},
-                             reallocIdx: {realloc_idx},
-                             getReallocFn: {get_realloc_fn_js},
-                             stringEncoding: {string_encoding},
-                             isAsync: {async_},
-                             streamTableIdx: {stream_table_idx},
-                             elemMeta: {elem_meta_js},
-                         }}
-                     )));
-                    "#,
-                    suspending_wrap_fn =
-                        self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn),
+                let ctx = format!(
+                    r#"{{
+                    componentIdx: {component_instance_id},
+                    memoryIdx: {memory_idx_js},
+                    getMemoryFn: {get_memory_fn_js},
+                    reallocIdx: {realloc_idx},
+                    getReallocFn: {get_realloc_fn_js},
+                    stringEncoding: {string_encoding},
+                    isAsync: {async_},
+                    streamTableIdx: {stream_table_idx},
+                    elemMeta: {elem_meta_js},
+                }}"#
                 );
+                if *async_ {
+                    uwriteln!(
+                        self.src.js,
+                        "const trampoline{i} = {stream_write_fn}.bind(null, {ctx});",
+                    );
+                } else {
+                    let suspending_wrap_fn =
+                        self.bindgen.intrinsic(Intrinsic::SuspendingImportWrapperFn);
+                    uwriteln!(
+                        self.src.js,
+                        "const trampoline{i} = new WebAssembly.Suspending({suspending_wrap_fn}({component_instance_id}, {stream_write_fn}.bind(null, {ctx})));",
+                    );
+                }
             }
 
             Trampoline::StreamCancelRead {

--- a/packages/jco-transpile/test/p3/deadlock-regressions.ts
+++ b/packages/jco-transpile/test/p3/deadlock-regressions.ts
@@ -163,6 +163,29 @@ suite('async scheduling regressions', () => {
         }
     });
 
+    // Regression guard for host-injected stream data lost across read cancellation
+    // (originally seen as a flaky `p3-sockets-tcp-streams` failure under real socket I/O).
+    //
+    // Failure scenario this reproduces:
+    //   - The guest reads a host-backed (lowered) stream in a loop: poll the read once
+    //     with a no-op waker and, if it is not immediately ready, CANCEL it -- then issue a
+    //     zero-length read to wait for host readiness before looping (see
+    //     `read_with_cancellation` in the `stream_concurrency` test component).
+    //   - Bug 1: the zero-length read used to DRAIN one item from the source and rendezvous
+    //     it with the zero-capacity read buffer, which stored it as a pending write in the
+    //     shared buffer slot -- corrupting the next real read's rendezvous.
+    //   - Bug 2: when a just-in-time host write then found no reader buffer (its target read
+    //     had been cancelled), its in-flight items were stranded and dropped when the stream
+    //     ended, instead of being returned to the source for redelivery.
+    //   - Net effect: the tail of the stream (exactly the in-flight chunk) was silently lost,
+    //     so the guest received fewer bytes than were sent.
+    //
+    // The loss only manifests when cancel completion wins the race against the in-flight
+    // write. In production that deferral is a `setTimeout(fn, 0)`, and real socket latency is
+    // what usually opens the window; a microtask-based host iterator alone does not. To make
+    // the race deterministic here we collapse zero-delay timers onto the microtask queue for
+    // the duration of the guest call (test-only; no production behavior changes) so cancel
+    // completion reliably precedes delivery. Without the fix this loses the final chunk.
     test('cancelled host stream reads preserve every value in order', async () => {
         const expected = Uint8Array.from({ length: 2 * 1024 * 1024 }, (_, index) => index & 0xff);
         let offset = 0;
@@ -201,12 +224,30 @@ suite('async scheduling regressions', () => {
             },
         });
 
+        // Force zero-delay `setTimeout` (used to defer stream cancel completion) onto the
+        // microtask queue so cancel completion deterministically races ahead of the in-flight
+        // host write -- the timing real socket I/O produces. Restored in `finally`.
+        const realSetTimeout = globalThis.setTimeout;
+        globalThis.setTimeout = (fn, delay, ...args) => {
+            if (!delay) {
+                queueMicrotask(() => fn(...args));
+                return 0;
+            }
+            return realSetTimeout(fn, delay, ...args);
+        };
+
         try {
-            assert.deepEqual(
-                await instance['jco:test-components/stream-concurrency-test'].readWithCancellation(stream),
-                expected,
+            const actual = await instance['jco:test-components/stream-concurrency-test'].readWithCancellation(stream);
+            // Explicit length check first: a regression drops the final in-flight chunk, so
+            // the clearest symptom is a short result rather than a mismatched byte.
+            assert.strictEqual(
+                actual.length,
+                expected.length,
+                `expected ${expected.length} bytes but received ${actual.length} (lost the in-flight tail)`,
             );
+            assert.deepEqual(actual, expected);
         } finally {
+            globalThis.setTimeout = realSetTimeout;
             await cleanup();
         }
     });

--- a/packages/jco-transpile/test/p3/ported/component-model/wast.ts
+++ b/packages/jco-transpile/test/p3/ported/component-model/wast.ts
@@ -23,7 +23,7 @@ const WAST_TESTS: readonly WastTest[] = [
     { relPath: 'async/sync-streams.wast', skip: true },
     { relPath: 'async/deadlock.wast', skip: true },
     { relPath: 'async/trap-if-block-and-sync.wast', skip: true },
-    { relPath: 'async/partial-stream-copies.wast', skip: true },
+    { relPath: 'async/partial-stream-copies.wast', skip: false },
     { relPath: 'async/trap-on-reenter.wast', skip: true },
     { relPath: 'async/sync-barges-in.wast', skip: true },
     { relPath: 'async/same-component-stream-future.wast', skip: true },


### PR DESCRIPTION
This PR fixes a stream issue that manifested as a flaky CI test w/ p3 TCP streams, which amounted to zero length reads erroneously taking values when they shouldn't have.