### PR TITLE
fix(preview2-shim): disposing a settled future incoming response aborts its still-streaming body

### DIFF
--- a/packages/preview2-shim/src/browser/http.ts
+++ b/packages/preview2-shim/src/browser/http.ts
@@ -873,6 +873,7 @@ class FutureIncomingResponse implements TypesNamespace.FutureIncomingResponse {
     #result: any = undefined;
     #promise: Promise<void> | null = null;
     #controller: AbortController | null = null;
+    #settled = false;
 
     subscribe(): Pollable {
         return pollableCreate(this.#promise!);
@@ -888,7 +889,15 @@ class FutureIncomingResponse implements TypesNamespace.FutureIncomingResponse {
     }
 
     [symbolDispose]() {
-        this.#controller?.abort();
+        // Only abort if the request never settled. If fetch already
+        // resolved (even with an ok response whose body is still being
+        // streamed elsewhere), aborting here kills the underlying
+        // connection and body stream out from under whoever is still
+        // reading it, surfacing as a bogus "BodyStreamBuffer was aborted"
+        // error on a request that actually succeeded.
+        if (!this.#settled) {
+            this.#controller?.abort();
+        }
         this.#controller = null;
         this.#promise = null;
     }
@@ -929,6 +938,7 @@ class FutureIncomingResponse implements TypesNamespace.FutureIncomingResponse {
                     if (timer) {
                         clearTimeout(timer);
                     }
+                    future.#settled = true;
                     future.#result = {
                         tag: "ok",
                         val: {
@@ -941,6 +951,7 @@ class FutureIncomingResponse implements TypesNamespace.FutureIncomingResponse {
                     if (timer) {
                         clearTimeout(timer);
                     }
+                    future.#settled = true;
                     future.#result = {
                         tag: "ok",
                         val: {

--- a/packages/preview2-shim/test/browser/http-future-e2e.ts
+++ b/packages/preview2-shim/test/browser/http-future-e2e.ts
@@ -1,0 +1,142 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { createServer } from "node:http";
+import { dirname } from "node:path";
+
+import { componentize, type ComponentizeOptions } from "@bytecodealliance/componentize-js";
+import { transpile } from "@bytecodealliance/jco";
+import { assert, test } from "vitest";
+
+import {
+    FIXTURES_WIT_DIR,
+    getTmpDir,
+    runBasicHarnessPageTest,
+    startTestServer,
+} from "../common.js";
+
+test("a component can drop its HTTP future before finishing a streamed body", async () => {
+    const outDir = await getTmpDir();
+    const { baseURL, browser, cleanup } = await startTestServer({
+        transpiledOutputDir: outDir,
+    });
+    const releaseBody = Promise.withResolvers<void>();
+    let streamStarted = false;
+    let releaseRequested = false;
+    const server = createServer((req, res) => {
+        res.setHeader("access-control-allow-origin", "*");
+        if (req.url === "/stream") {
+            streamStarted = true;
+            res.writeHead(200, { "content-type": "text/plain" });
+            res.write("before disposal; ");
+            // No timers: the final bytes do not exist on the wire until the
+            // component has explicitly dropped its future and requested them.
+            void releaseBody.promise.then(() => res.end("after disposal"));
+        } else if (req.url === "/release") {
+            releaseRequested = true;
+            releaseBody.resolve();
+            res.writeHead(204);
+            res.end();
+        } else {
+            res.writeHead(404);
+            res.end();
+        }
+    });
+
+    try {
+        await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+        const address = server.address();
+        assert.ok(address && typeof address !== "string");
+        if (!address || typeof address === "string") {
+            throw new Error("missing streaming server address");
+        }
+
+        const { component } = await componentize(
+            `
+import { Fields, OutgoingRequest, OutgoingBody } from "wasi:http/types@0.2.8";
+import { handle } from "wasi:http/outgoing-handler@0.2.8";
+
+const dispose = Symbol.dispose || Symbol.for("dispose");
+
+function fetchResponse(path) {
+    const req = new OutgoingRequest(new Fields());
+    req.setMethod({ tag: "get" });
+    req.setScheme({ tag: "HTTP" });
+    req.setAuthority("127.0.0.1:${address.port}");
+    req.setPathWithQuery(path);
+    OutgoingBody.finish(req.body(), undefined);
+    const future = handle(req, undefined);
+    const ready = future.subscribe();
+    ready.block();
+    ready[dispose]();
+    const result = future.get();
+    if (!result || result.tag !== "ok" || result.val.tag !== "ok") {
+        throw "request failed: " + JSON.stringify(result);
+    }
+    const response = result.val.val;
+    // Exercise the component's canonical resource-drop path, not a host-side
+    // prototype spy. Response headers are ready but the body is still live.
+    future[dispose]();
+    return response;
+}
+
+export const test = {
+    run() {
+        const response = fetchResponse("/stream");
+        if (response.status() !== 200) throw "expected 200";
+        const body = response.consume();
+        response[dispose]();
+        const stream = body.stream();
+
+        const released = fetchResponse("/release");
+        if (released.status() !== 204) throw "expected 204";
+        released[dispose]();
+
+        let text = "";
+        try {
+            for (;;) {
+                text += new TextDecoder().decode(stream.blockingRead(64n));
+            }
+        } catch (err) {
+            const error = err.payload || err;
+            if (error.tag !== "closed") throw "body read failed: " + JSON.stringify(error);
+        } finally {
+            stream[dispose]();
+            body[dispose]();
+        }
+        if (text !== "before disposal; after disposal") throw "incomplete body: " + text;
+        return text;
+    }
+}
+`,
+            { witPath: FIXTURES_WIT_DIR, worldName: "browser-http-fetch" } as ComponentizeOptions,
+        );
+        const { files } = await transpile(component, {
+            name: "component",
+            optimize: false,
+            asyncMode: "jspi",
+            asyncImports: [
+                "wasi:io/poll#[method]pollable.block",
+                "wasi:io/streams#[method]input-stream.blocking-read",
+            ],
+            asyncExports: ["tests:p2-shim/test#run"],
+            outDir,
+        });
+        for (const [path, contents] of Object.entries(files)) {
+            await mkdir(dirname(path), { recursive: true });
+            await writeFile(path, contents);
+        }
+        const { statusJSON } = await runBasicHarnessPageTest({
+            browser,
+            url: `${baseURL}/index.html#transpiled:component.js`,
+        });
+        assert.strictEqual(statusJSON.msg, "before disposal; after disposal");
+        assert.strictEqual(streamStarted, true);
+        assert.strictEqual(releaseRequested, true);
+    } finally {
+        releaseBody.resolve();
+        server.closeAllConnections();
+        await new Promise<void>((resolve, reject) => {
+            server.close((error) => (error ? reject(error) : resolve()));
+        });
+        await cleanup();
+    }
+}, 120_000);

--- a/packages/preview2-shim/test/browser/http-future-e2e.ts
+++ b/packages/preview2-shim/test/browser/http-future-e2e.ts
@@ -1,4 +1,4 @@
-import { mkdir, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { createServer } from "node:http";
 import { dirname } from "node:path";
 
@@ -49,64 +49,12 @@ test("a component can drop its HTTP future before finishing a streamed body", as
             throw new Error("missing streaming server address");
         }
 
+        const source = await readFile(
+            new URL("../fixtures/browser/http-future/component.js", import.meta.url),
+            "utf8",
+        );
         const { component } = await componentize(
-            `
-import { Fields, OutgoingRequest, OutgoingBody } from "wasi:http/types@0.2.8";
-import { handle } from "wasi:http/outgoing-handler@0.2.8";
-
-const dispose = Symbol.dispose || Symbol.for("dispose");
-
-function fetchResponse(path) {
-    const req = new OutgoingRequest(new Fields());
-    req.setMethod({ tag: "get" });
-    req.setScheme({ tag: "HTTP" });
-    req.setAuthority("127.0.0.1:${address.port}");
-    req.setPathWithQuery(path);
-    OutgoingBody.finish(req.body(), undefined);
-    const future = handle(req, undefined);
-    const ready = future.subscribe();
-    ready.block();
-    ready[dispose]();
-    const result = future.get();
-    if (!result || result.tag !== "ok" || result.val.tag !== "ok") {
-        throw "request failed: " + JSON.stringify(result);
-    }
-    const response = result.val.val;
-    // Exercise the component's canonical resource-drop path, not a host-side
-    // prototype spy. Response headers are ready but the body is still live.
-    future[dispose]();
-    return response;
-}
-
-export const test = {
-    run() {
-        const response = fetchResponse("/stream");
-        if (response.status() !== 200) throw "expected 200";
-        const body = response.consume();
-        response[dispose]();
-        const stream = body.stream();
-
-        const released = fetchResponse("/release");
-        if (released.status() !== 204) throw "expected 204";
-        released[dispose]();
-
-        let text = "";
-        try {
-            for (;;) {
-                text += new TextDecoder().decode(stream.blockingRead(64n));
-            }
-        } catch (err) {
-            const error = err.payload || err;
-            if (error.tag !== "closed") throw "body read failed: " + JSON.stringify(error);
-        } finally {
-            stream[dispose]();
-            body[dispose]();
-        }
-        if (text !== "before disposal; after disposal") throw "incomplete body: " + text;
-        return text;
-    }
-}
-`,
+            source.replace("{{SERVER_AUTHORITY}}", `127.0.0.1:${address.port}`),
             { witPath: FIXTURES_WIT_DIR, worldName: "browser-http-fetch" } as ComponentizeOptions,
         );
         const { files } = await transpile(component, {

--- a/packages/preview2-shim/test/browser/http-future.ts
+++ b/packages/preview2-shim/test/browser/http-future.ts
@@ -1,0 +1,202 @@
+import { rejects } from "node:assert";
+
+import { afterEach, assert, suite, test, vi } from "vitest";
+
+import { outgoingHandler, types } from "../../src/browser/http.js";
+
+function request() {
+    const req = new types.OutgoingRequest(new types.Fields());
+    req.setMethod({ tag: "get" });
+    req.setScheme({ tag: "HTTPS" });
+    req.setAuthority("example.com");
+    req.setPathWithQuery("/");
+    return req;
+}
+
+function dispose(resource: unknown) {
+    (resource as Disposable)[Symbol.dispose]();
+}
+
+suite("browser HTTP future disposal", () => {
+    afterEach(() => {
+        vi.restoreAllMocks();
+        vi.useRealTimers();
+    });
+
+    for (const consumeResult of [false, true]) {
+        test(`settled response survives disposal ${consumeResult ? "after" : "before"} get`, async () => {
+            vi.useFakeTimers();
+            let signal!: AbortSignal;
+            let body!: ReadableStreamDefaultController<Uint8Array>;
+            const abort = vi.fn();
+            vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+                signal = init!.signal!;
+                const stream = new ReadableStream<Uint8Array>({
+                    start(controller) {
+                        body = controller;
+                        controller.enqueue(new TextEncoder().encode("first "));
+                        signal.addEventListener("abort", () => {
+                            abort();
+                            controller.error(signal.reason);
+                        });
+                    },
+                });
+                return new Response(stream);
+            });
+            const options = new types.RequestOptions();
+            options.setFirstByteTimeout(10_000_000n);
+            const future = outgoingHandler.handle(request(), options);
+            const ready = future.subscribe();
+            await ready.block();
+            dispose(ready);
+
+            const result = consumeResult ? future.get() : undefined;
+            dispose(future);
+            dispose(future);
+            await vi.advanceTimersByTimeAsync(20);
+            assert.strictEqual(signal.aborted, false);
+            assert.strictEqual(abort.mock.calls.length, 0);
+            assert.strictEqual(vi.getTimerCount(), 0);
+
+            if (consumeResult) {
+                assert.ok(result?.tag === "ok" && result.val.tag === "ok");
+                if (result?.tag !== "ok" || result.val.tag !== "ok") {
+                    throw new Error("expected a successful response");
+                }
+                const response = result.val.val;
+                assert.strictEqual(response.status(), 200);
+                const incomingBody = response.consume();
+                const stream = incomingBody.stream();
+                assert.strictEqual(
+                    new TextDecoder().decode(await stream.blockingRead(64n)),
+                    "first ",
+                );
+                body.enqueue(new TextEncoder().encode("second"));
+                body.close();
+                assert.strictEqual(
+                    new TextDecoder().decode(await stream.blockingRead(64n)),
+                    "second",
+                );
+                await rejects(
+                    Promise.resolve().then(() => stream.blockingRead(64n)),
+                    (error: { tag: string }) => error.tag === "closed",
+                );
+                dispose(stream);
+                dispose(incomingBody);
+                dispose(response);
+            } else {
+                body.close();
+            }
+        });
+    }
+
+    test("get consumes a settled result once without cancelling it", async () => {
+        let signal!: AbortSignal;
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+            signal = init!.signal!;
+            return new Response(null, { status: 204 });
+        });
+        const future = outgoingHandler.handle(request(), undefined);
+        assert.strictEqual(future.get(), undefined);
+        const ready = future.subscribe();
+        await ready.block();
+        dispose(ready);
+        assert.strictEqual(future.get()?.tag, "ok");
+        assert.strictEqual(future.get()?.tag, "err");
+        dispose(future);
+        assert.strictEqual(signal.aborted, false);
+    });
+
+    test("disposing a pending fetch aborts it once", async () => {
+        let signal!: AbortSignal;
+        const abort = vi.fn();
+        vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+            signal = init!.signal!;
+            return new Promise((_resolve, reject) => {
+                signal.addEventListener("abort", () => {
+                    abort();
+                    reject(signal.reason);
+                });
+            });
+        });
+        const future = outgoingHandler.handle(request(), undefined);
+        await Promise.resolve();
+        assert.strictEqual(future.get(), undefined);
+        assert.strictEqual(signal.aborted, false);
+        dispose(future);
+        dispose(future);
+        assert.strictEqual(signal.aborted, true);
+        assert.strictEqual(abort.mock.calls.length, 1);
+        // Drain the rejection handler; dropping a future must not leak a rejection.
+        await Promise.resolve();
+    });
+
+    test("disposing before buffered request completion cancels the eventual fetch", async () => {
+        let signal!: AbortSignal;
+        const started = Promise.withResolvers<void>();
+        const fetch = vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+            signal = init!.signal!;
+            started.resolve();
+            signal.throwIfAborted();
+            throw new Error("a disposed request must not reach the network");
+        });
+        const req = request();
+        req.setMethod({ tag: "post" });
+        const body = req.body();
+        const future = outgoingHandler.handle(req, undefined);
+        dispose(future);
+        assert.strictEqual(fetch.mock.calls.length, 0);
+        types.OutgoingBody.finish(body, undefined);
+        await started.promise;
+        assert.strictEqual(fetch.mock.calls.length, 1);
+        assert.strictEqual(signal.aborted, true);
+    });
+
+    test("failed settlement clears the timeout and does not abort on disposal", async () => {
+        vi.useFakeTimers();
+        let signal!: AbortSignal;
+        vi.spyOn(globalThis, "fetch").mockImplementation(async (_url, init) => {
+            signal = init!.signal!;
+            throw new TypeError("network failed");
+        });
+        const options = new types.RequestOptions();
+        options.setFirstByteTimeout(10_000_000n);
+        const future = outgoingHandler.handle(request(), options);
+        const ready = future.subscribe();
+        await ready.block();
+        dispose(ready);
+        assert.deepStrictEqual(future.get(), {
+            tag: "ok",
+            val: { tag: "err", val: { tag: "internal-error", val: "network failed" } },
+        });
+        dispose(future);
+        await vi.advanceTimersByTimeAsync(20);
+        assert.strictEqual(signal.aborted, false);
+        assert.strictEqual(vi.getTimerCount(), 0);
+    });
+
+    test("a pending request still times out", async () => {
+        vi.useFakeTimers();
+        let signal!: AbortSignal;
+        vi.spyOn(globalThis, "fetch").mockImplementation((_url, init) => {
+            signal = init!.signal!;
+            return new Promise((_resolve, reject) => {
+                signal.addEventListener("abort", () => reject(signal.reason));
+            });
+        });
+        const options = new types.RequestOptions();
+        options.setFirstByteTimeout(10_000_000n);
+        const future = outgoingHandler.handle(request(), options);
+        const ready = future.subscribe();
+        await vi.advanceTimersByTimeAsync(10);
+        await ready.block();
+        dispose(ready);
+        assert.strictEqual(signal.aborted, true);
+        assert.deepStrictEqual(future.get(), {
+            tag: "ok",
+            val: { tag: "err", val: { tag: "connection-timeout" } },
+        });
+        dispose(future);
+        assert.strictEqual(vi.getTimerCount(), 0);
+    });
+});

--- a/packages/preview2-shim/test/fixtures/browser/http-future/component.js
+++ b/packages/preview2-shim/test/fixtures/browser/http-future/component.js
@@ -1,0 +1,64 @@
+import { Fields, OutgoingRequest, OutgoingBody } from "wasi:http/types@0.2.8";
+import { handle } from "wasi:http/outgoing-handler@0.2.8";
+
+const dispose = Symbol.dispose || Symbol.for("dispose");
+
+function fetchResponse(path) {
+    const req = new OutgoingRequest(new Fields());
+    req.setMethod({ tag: "get" });
+    req.setScheme({ tag: "HTTP" });
+    // The test supplies its ephemeral streaming server's address before componentizing.
+    req.setAuthority("{{SERVER_AUTHORITY}}");
+    req.setPathWithQuery(path);
+    OutgoingBody.finish(req.body(), undefined);
+    const future = handle(req, undefined);
+    const ready = future.subscribe();
+    ready.block();
+    ready[dispose]();
+    const result = future.get();
+    if (!result || result.tag !== "ok" || result.val.tag !== "ok") {
+        throw "request failed: " + JSON.stringify(result);
+    }
+    const response = result.val.val;
+    // Exercise the component's canonical resource-drop path, not a host-side
+    // prototype spy. Response headers are ready but the body is still live.
+    future[dispose]();
+    return response;
+}
+
+export const test = {
+    run() {
+        const response = fetchResponse("/stream");
+        if (response.status() !== 200) {
+            throw "expected 200";
+        }
+        const body = response.consume();
+        response[dispose]();
+        const stream = body.stream();
+
+        const released = fetchResponse("/release");
+        if (released.status() !== 204) {
+            throw "expected 204";
+        }
+        released[dispose]();
+
+        let text = "";
+        try {
+            for (;;) {
+                text += new TextDecoder().decode(stream.blockingRead(64n));
+            }
+        } catch (err) {
+            const error = err.payload || err;
+            if (error.tag !== "closed") {
+                throw "body read failed: " + JSON.stringify(error);
+            }
+        } finally {
+            stream[dispose]();
+            body[dispose]();
+        }
+        if (text !== "before disposal; after disposal") {
+            throw "incomplete body: " + text;
+        }
+        return text;
+    },
+};


### PR DESCRIPTION
Fixes #2044.

The browser IncomingBody's [Symbol.dispose] unconditionally called controller.abort(), even after the fetch had already resolved successfully and its response body was still being streamed elsewhere. Since the guest typically drops the future-incoming-response handle right after extracting the response - well before the body is fully read. This aborted the underlying connection out from under whoever was still reading it, surfacing as a bogus "BodyStreamBuffer was aborted" error on requests that actually succeeded (e.g. aws-cli's `s3 ls`, discovered while validating the would-block fix in #2043). Only abort if the request never settled.