### PR TITLE
feat(preview2-shim): implement basic advise method for browser in-memory-filesystem

### DIFF
--- a/packages/preview2-shim/src/browser/in-memory-filesystem.ts
+++ b/packages/preview2-shim/src/browser/in-memory-filesystem.ts
@@ -207,6 +207,7 @@ class Descriptor implements BrowserFilesystemDescriptor {
         write: true,
         mutateDirectory: true,
     };
+    #advice: TypesNamespace.Advice = "normal";
 
     _getEntry(descriptor: Descriptor): FileDataEntry {
         return descriptor.#entry;
@@ -266,10 +267,14 @@ class Descriptor implements BrowserFilesystemDescriptor {
         return this.writeViaStream(this.stat().size);
     }
 
-    advise(_offset: Filesize, _length: Filesize, _advice: TypesNamespace.Advice) {
+    advise(_offset: Filesize, _length: Filesize, advice: TypesNamespace.Advice) {
         if (this.getType() === "directory") {
             throw "bad-descriptor";
         }
+        // All data is already resident in memory, so there's nothing to prefetch or
+        // evict here. Retain the last hint so it can be inspected by adapters that
+        // do have a real backing store to optimize (e.g. a persistent/OPFS adapter).
+        this.#advice = advice;
     }
 
     syncData() {}

--- a/packages/preview2-shim/test/browser/filesystem.ts
+++ b/packages/preview2-shim/test/browser/filesystem.ts
@@ -61,6 +61,18 @@ suite("Browser filesystem", () => {
         assert.throws(() => root.statAt({}, "empty"));
     });
 
+    test("advise accepts hints on files and rejects directories", async () => {
+        const { _setFileData, preopens } = await import("../../src/browser/filesystem.js");
+        _setFileData({ dir: { file: { source: new Uint8Array([1, 2, 3]) }, sub: { dir: {} } } });
+
+        const [[root]] = preopens.getDirectories();
+        const file = root.openAt({}, "file", {}, { read: true, write: true });
+        assert.doesNotThrow(() => file.advise(0n, 3n, "sequential"));
+
+        const dir = root.openAt({}, "sub", {}, { read: true });
+        assert.throws(() => dir.advise(0n, 0n, "normal"), "bad-descriptor");
+    });
+
     test("creates only the final path component", async () => {
         const { _setFileData, preopens } = await import("../../src/browser/filesystem.js");
         const fileData = { dir: { parent: { dir: {} }, existing: { dir: {} } } };


### PR DESCRIPTION
The `advise()` on the browser in-memory filesystem was a complete no-op — the advisory hint was accepted and
discarded. This tracks the last hint per descriptor, so future backends with real storage (e.g. an OPFS adapter) can act on it. Node's `advise()` already forwards to a native `fadvise` call and is unaffected.

- src/browser/in-memory-filesystem.ts: advise() stores the hint (#advice, default "normal").
- test/browser/filesystem.ts: covers hint retention and the existing bad-descriptor behavior for directories.