### PR TITLE
feat(preview2-shim): support follow symlink for node get-full-path

### DIFF
--- a/packages/preview2-shim/src/nodejs/filesystem.ts
+++ b/packages/preview2-shim/src/nodejs/filesystem.ts
@@ -303,7 +303,7 @@ class Descriptor implements IDescriptor {
     }
 
     createDirectoryAt(path) {
-        const fullPath = this.#getFullPath(path, undefined);
+        const fullPath = this.#getFullPath(path);
         try {
             mkdirSync(fullPath);
         } catch (e) {
@@ -333,7 +333,7 @@ class Descriptor implements IDescriptor {
     }
 
     statAt(pathFlags, path) {
-        const fullPath = this.#getFullPath(path, false);
+        const fullPath = this.#getFullPath(path);
         let stats;
         try {
             stats = (pathFlags.symlinkFollow ? statSync : lstatSync)(fullPath, {
@@ -354,7 +354,7 @@ class Descriptor implements IDescriptor {
     }
 
     setTimesAt(pathFlags, path, dataAccessTimestamp, dataModificationTimestamp) {
-        const fullPath = this.#getFullPath(path, false);
+        const fullPath = this.#getFullPath(path);
         let stats;
         if (
             dataAccessTimestamp.tag === "no-change" ||
@@ -383,14 +383,32 @@ class Descriptor implements IDescriptor {
     }
 
     linkAt(oldPathFlags, oldPath, newDescriptor, newPath) {
-        const oldFullPath = this.#getFullPath(oldPath, oldPathFlags.symlinkFollow);
-        const newFullPath = newDescriptor.#getFullPath(newPath, false);
+        const oldFullPath = this.#getFullPath(oldPath);
+        const newFullPath = newDescriptor.#getFullPath(newPath);
         // Windows doesn't automatically fail on trailing slashes
         if (isWindows && newFullPath.endsWith("/")) {
             throw "no-entry";
         }
         try {
-            linkSync(oldFullPath, newFullPath);
+            // Unlike open/stat, Node's link does not follow the final symlink.
+            // Resolve only this operation's source, propagating resolution errors
+            // instead of silently hard-linking a dangling or cyclic symlink.
+            let source = oldFullPath;
+            if (oldPathFlags.symlinkFollow) {
+                source = realpathSync(source);
+                // realpath strips trailing slashes; keep the caller's directory
+                // requirement so a regular-file source ending in '/' still fails.
+                if (oldFullPath.endsWith("/")) {
+                    // Windows may ignore a trailing slash even in linkSync.
+                    if (!statSync(source).isDirectory()) {
+                        throw "not-directory";
+                    }
+                    if (!source.endsWith("/")) {
+                        source += "/";
+                    }
+                }
+            }
+            linkSync(source, newFullPath);
         } catch (e) {
             throw convertFsError(e);
         }
@@ -400,7 +418,7 @@ class Descriptor implements IDescriptor {
         if (preopenEntries.length === 0) {
             throw "access";
         }
-        const fullPath = this.#getFullPath(path, pathFlags.symlinkFollow);
+        const fullPath = this.#getFullPath(path);
         let fsOpenFlags = 0x0;
         if (openFlags.create) {
             fsOpenFlags |= constants.O_CREAT;
@@ -481,7 +499,7 @@ class Descriptor implements IDescriptor {
     }
 
     readlinkAt(path) {
-        const fullPath = this.#getFullPath(path, false);
+        const fullPath = this.#getFullPath(path);
         try {
             return readlinkSync(fullPath);
         } catch (e) {
@@ -490,7 +508,7 @@ class Descriptor implements IDescriptor {
     }
 
     removeDirectoryAt(path) {
-        const fullPath = this.#getFullPath(path, false);
+        const fullPath = this.#getFullPath(path);
         try {
             rmdirSync(fullPath);
         } catch (e: any) {
@@ -502,8 +520,8 @@ class Descriptor implements IDescriptor {
     }
 
     renameAt(oldPath, newDescriptor, newPath) {
-        const oldFullPath = this.#getFullPath(oldPath, false);
-        const newFullPath = newDescriptor.#getFullPath(newPath, false);
+        const oldFullPath = this.#getFullPath(oldPath);
+        const newFullPath = newDescriptor.#getFullPath(newPath);
         try {
             renameSync(oldFullPath, newFullPath);
         } catch (e: any) {
@@ -515,7 +533,7 @@ class Descriptor implements IDescriptor {
     }
 
     symlinkAt(target, path) {
-        const fullPath = this.#getFullPath(path, false);
+        const fullPath = this.#getFullPath(path);
         if (target.startsWith("/")) {
             throw "not-permitted";
         }
@@ -543,7 +561,7 @@ class Descriptor implements IDescriptor {
     }
 
     unlinkFileAt(path) {
-        const fullPath = this.#getFullPath(path, false);
+        const fullPath = this.#getFullPath(path);
         try {
             if (fullPath.endsWith("/")) {
                 let isDir = false;
@@ -585,7 +603,7 @@ class Descriptor implements IDescriptor {
     }
 
     metadataHashAt(pathFlags, path) {
-        const fullPath = this.#getFullPath(path, false);
+        const fullPath = this.#getFullPath(path);
         try {
             const stats = (pathFlags.symlinkFollow ? statSync : lstatSync)(fullPath, {
                 bigint: true,
@@ -596,7 +614,8 @@ class Descriptor implements IDescriptor {
         }
     }
 
-    #getFullPath(subpath, followSymlinks) {
+    // Join paths lexically; each operation supplies its own symlink semantics.
+    #getFullPath(subpath) {
         let descriptor = this;
         if (subpath.indexOf("\\") !== -1) {
             subpath = subpath.replace(/\\/g, "/");
@@ -652,25 +671,11 @@ class Descriptor implements IDescriptor {
 
         subpath = segments.join("");
 
-        const fullPath = descriptor.#hostPreopen
+        return descriptor.#hostPreopen
             ? descriptor.#hostPreopen +
-              (descriptor.#hostPreopen.endsWith("/") ? "" : subpath.length > 0 ? "/" : "") +
-              subpath
+                  (descriptor.#hostPreopen.endsWith("/") ? "" : subpath.length > 0 ? "/" : "") +
+                  subpath
             : descriptor.#fullPath + (subpath.length > 0 ? "/" : "") + subpath;
-
-        if (!followSymlinks) {
-            return fullPath;
-        }
-        // Resolve any symlinks (including in intermediate path segments) so callers
-        // that request symlink-follow semantics operate on the real target rather
-        // than the syntactically-joined path. Fall back to the unresolved path if
-        // it doesn't exist yet (e.g. `open-at` with `create`) or otherwise can't be
-        // resolved - the underlying syscall reports the real error in that case.
-        try {
-            return realpathSync(fullPath);
-        } catch {
-            return fullPath;
-        }
     }
 }
 const descriptorCreatePreopen = Descriptor._createPreopen;

--- a/packages/preview2-shim/src/nodejs/filesystem.ts
+++ b/packages/preview2-shim/src/nodejs/filesystem.ts
@@ -36,6 +36,7 @@ import {
     mkdirSync,
     opendirSync,
     readlinkSync,
+    realpathSync,
     renameSync,
     rmdirSync,
     statSync,
@@ -595,8 +596,7 @@ class Descriptor implements IDescriptor {
         }
     }
 
-    // TODO: support followSymlinks
-    #getFullPath(subpath, _followSymlinks) {
+    #getFullPath(subpath, followSymlinks) {
         let descriptor = this;
         if (subpath.indexOf("\\") !== -1) {
             subpath = subpath.replace(/\\/g, "/");
@@ -652,14 +652,25 @@ class Descriptor implements IDescriptor {
 
         subpath = segments.join("");
 
-        if (descriptor.#hostPreopen) {
-            return (
-                descriptor.#hostPreopen +
-                (descriptor.#hostPreopen.endsWith("/") ? "" : subpath.length > 0 ? "/" : "") +
-                subpath
-            );
+        const fullPath = descriptor.#hostPreopen
+            ? descriptor.#hostPreopen +
+              (descriptor.#hostPreopen.endsWith("/") ? "" : subpath.length > 0 ? "/" : "") +
+              subpath
+            : descriptor.#fullPath + (subpath.length > 0 ? "/" : "") + subpath;
+
+        if (!followSymlinks) {
+            return fullPath;
         }
-        return descriptor.#fullPath + (subpath.length > 0 ? "/" : "") + subpath;
+        // Resolve any symlinks (including in intermediate path segments) so callers
+        // that request symlink-follow semantics operate on the real target rather
+        // than the syntactically-joined path. Fall back to the unresolved path if
+        // it doesn't exist yet (e.g. `open-at` with `create`) or otherwise can't be
+        // resolved - the underlying syscall reports the real error in that case.
+        try {
+            return realpathSync(fullPath);
+        } catch {
+            return fullPath;
+        }
     }
 }
 const descriptorCreatePreopen = Descriptor._createPreopen;

--- a/packages/preview2-shim/test/node-filesystem-symlinks.ts
+++ b/packages/preview2-shim/test/node-filesystem-symlinks.ts
@@ -1,0 +1,204 @@
+import { throws } from "node:assert";
+import {
+    existsSync,
+    linkSync,
+    lstatSync,
+    mkdirSync,
+    mkdtempSync,
+    readFileSync,
+    rmSync,
+    statSync,
+    symlinkSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { WASIShim } from "@bytecodealliance/preview2-shim/instantiation";
+import { afterEach, assert, beforeEach, suite, test } from "vitest";
+
+import type {
+    Descriptor,
+    OpenFlags,
+    PathFlags,
+} from "../types/interfaces/wasi-filesystem-types.js";
+
+suite("Node filesystem symlink paths", () => {
+    let testDir: string;
+    let root: Descriptor;
+    let opened: Descriptor[];
+
+    beforeEach(() => {
+        testDir = mkdtempSync(join(tmpdir(), "jco-symlink-paths-"));
+        opened = [];
+        writeFileSync(join(testDir, "target.txt"), "target contents");
+        const shim = new WASIShim({ sandbox: { preopens: { "/test": testDir } } });
+        [root] = shim.getImportObject()["wasi:filesystem/preopens"].getDirectories()[0];
+    });
+
+    afterEach(() => {
+        for (const descriptor of opened.reverse()) {
+            (descriptor as unknown as Disposable)[Symbol.dispose]();
+        }
+        rmSync(testDir, { recursive: true, force: true });
+    });
+
+    function open(path: string, pathFlags: PathFlags, openFlags: OpenFlags = {}) {
+        const descriptor = root.openAt(pathFlags, path, openFlags, { read: true });
+        opened.push(descriptor);
+        return descriptor;
+    }
+
+    for (const kind of ["relative", "absolute", "chain", "intermediate"] as const) {
+        test(`linkAt resolves ${kind} symlinks to the target inode`, () => {
+            let source = "link.txt";
+            if (kind === "intermediate") {
+                mkdirSync(join(testDir, "nested"));
+                symlinkSync("../target.txt", join(testDir, "nested", "link.txt"));
+                symlinkSync("nested", join(testDir, "alias"), "dir");
+                source = "alias/link.txt";
+            } else {
+                symlinkSync(
+                    kind === "absolute" ? join(testDir, "target.txt") : "target.txt",
+                    join(testDir, "link.txt"),
+                );
+                if (kind === "chain") {
+                    symlinkSync("link.txt", join(testDir, "chain.txt"));
+                    source = "chain.txt";
+                }
+            }
+
+            root.linkAt({ symlinkFollow: true }, source, root, "linked.txt");
+            const linked = lstatSync(join(testDir, "linked.txt"));
+            const target = statSync(join(testDir, "target.txt"));
+            assert.strictEqual(linked.isFile(), true);
+            assert.strictEqual(linked.dev, target.dev);
+            assert.strictEqual(linked.ino, target.ino);
+            assert.strictEqual(
+                readFileSync(join(testDir, "linked.txt"), "utf8"),
+                "target contents",
+            );
+        });
+    }
+
+    for (const target of ["target.txt", "missing.txt", "link.txt"]) {
+        test(`linkAt without follow preserves native link behavior for ${target}`, () => {
+            symlinkSync(target, join(testDir, "link.txt"));
+            linkSync(join(testDir, "link.txt"), join(testDir, "native.txt"));
+            root.linkAt({ symlinkFollow: false }, "link.txt", root, "linked.txt");
+            root.linkAt({}, "link.txt", root, "default.txt");
+            const linked = lstatSync(join(testDir, "linked.txt"));
+            const native = lstatSync(join(testDir, "native.txt"));
+            assert.strictEqual(linked.isSymbolicLink(), native.isSymbolicLink());
+            assert.strictEqual(linked.ino, native.ino);
+            assert.strictEqual(lstatSync(join(testDir, "default.txt")).ino, native.ino);
+        });
+    }
+
+    for (const [target, expected] of [
+        ["missing.txt", "no-entry"],
+        ["link.txt", "loop"],
+    ]) {
+        test(`linkAt with follow reports ${expected} instead of linking the symlink`, () => {
+            symlinkSync(target, join(testDir, "link.txt"));
+            throws(
+                () => root.linkAt({ symlinkFollow: true }, "link.txt", root, "linked.txt"),
+                (error) => error === expected,
+            );
+            throws(() => lstatSync(join(testDir, "linked.txt")), { code: "ENOENT" });
+        });
+    }
+
+    test("linkAt with follow rejects a missing source", () => {
+        throws(
+            () => root.linkAt({ symlinkFollow: true }, "missing.txt", root, "linked.txt"),
+            (error) => error === "no-entry",
+        );
+        assert.strictEqual(existsSync(join(testDir, "linked.txt")), false);
+    });
+
+    test("linkAt with follow does not overwrite an existing destination", () => {
+        symlinkSync("target.txt", join(testDir, "link.txt"));
+        writeFileSync(join(testDir, "existing.txt"), "keep me");
+        throws(
+            () => root.linkAt({ symlinkFollow: true }, "link.txt", root, "existing.txt"),
+            (error) => error === "exist",
+        );
+        assert.strictEqual(readFileSync(join(testDir, "existing.txt"), "utf8"), "keep me");
+    });
+
+    for (const path of ["target.txt/", "link.txt/"]) {
+        test(`openAt with follow rejects a trailing slash on ${path}`, () => {
+            symlinkSync("target.txt", join(testDir, "link.txt"));
+            throws(
+                () => open(path, { symlinkFollow: true }),
+                (error) => error === "not-directory",
+            );
+        });
+
+        test(`linkAt with follow rejects a trailing slash on ${path}`, () => {
+            symlinkSync("target.txt", join(testDir, "link.txt"));
+            throws(
+                () => root.linkAt({ symlinkFollow: true }, path, root, "linked.txt"),
+                (error) => error === "not-directory",
+            );
+            assert.strictEqual(existsSync(join(testDir, "linked.txt")), false);
+        });
+    }
+
+    test("openAt with follow still opens valid symlinks", () => {
+        symlinkSync("target.txt", join(testDir, "link.txt"));
+        const file = open("link.txt", { symlinkFollow: true });
+        assert.strictEqual(new TextDecoder().decode(file.read(64n, 0n)[0]), "target contents");
+    });
+
+    test("openAt without follow rejects a final symlink", () => {
+        symlinkSync("target.txt", join(testDir, "link.txt"));
+        throws(
+            () => open("link.txt", {}),
+            (error) => error === "loop",
+        );
+    });
+
+    for (const symlinkFollow of [false, true]) {
+        test(`openAt follows intermediate symlinks with final follow=${symlinkFollow}`, () => {
+            mkdirSync(join(testDir, "nested"));
+            writeFileSync(join(testDir, "nested", "child.txt"), "child contents");
+            symlinkSync("nested", join(testDir, "alias"), "dir");
+            const file = open("alias/child.txt", { symlinkFollow });
+            assert.strictEqual(new TextDecoder().decode(file.read(64n, 0n)[0]), "child contents");
+        });
+    }
+
+    test("openAt with follow still accepts directory paths with a trailing slash", () => {
+        mkdirSync(join(testDir, "nested"));
+        symlinkSync("nested", join(testDir, "alias"), "dir");
+        assert.strictEqual(
+            open("alias/", { symlinkFollow: true }, { directory: true }).getType(),
+            "directory",
+        );
+    });
+
+    test("openAt with follow can create a dangling symlink's target", () => {
+        symlinkSync("created.txt", join(testDir, "link.txt"));
+        const file = open("link.txt", { symlinkFollow: true }, { create: true });
+        assert.strictEqual(file.getType(), "regular-file");
+        assert.strictEqual(lstatSync(join(testDir, "link.txt")).isSymbolicLink(), true);
+        assert.strictEqual(statSync(join(testDir, "created.txt")).isFile(), true);
+    });
+
+    test("openAt with follow can create a new file", () => {
+        const file = open("created.txt", { symlinkFollow: true }, { create: true });
+        assert.strictEqual(file.getType(), "regular-file");
+        assert.strictEqual(statSync(join(testDir, "created.txt")).isFile(), true);
+    });
+
+    test("openAt with exclusive create rejects an existing symlink", () => {
+        symlinkSync("target.txt", join(testDir, "link.txt"));
+        throws(
+            () => open("link.txt", { symlinkFollow: true }, { create: true, exclusive: true }),
+            (error) => error === "exist",
+        );
+        assert.strictEqual(readFileSync(join(testDir, "target.txt"), "utf8"), "target contents");
+    });
+});

--- a/packages/preview2-shim/test/node.ts
+++ b/packages/preview2-shim/test/node.ts
@@ -1257,9 +1257,8 @@ suite("Sandboxing", () => {
     test(
         "linkAt honors path-flags.symlink-follow for the old path",
         testWithGCWrap(async () => {
-            const { mkdtempSync, writeFileSync, symlinkSync, lstatSync, rmSync } = await import(
-                "node:fs"
-            );
+            const { mkdtempSync, writeFileSync, symlinkSync, lstatSync, rmSync } =
+                await import("node:fs");
             const { tmpdir } = await import("node:os");
             const { join } = await import("node:path");
             const { WASIShim } = await import("@bytecodealliance/preview2-shim/instantiation");
@@ -1278,7 +1277,12 @@ suite("Sandboxing", () => {
                 // by this change, and implementation-defined by POSIX for symlinks).
                 // The fix under test is that `symlinkFollow: true` now resolves the old
                 // path's symlink chain before linking, instead of ignoring the flag.
-                rootDescriptor.linkAt({ symlinkFollow: true }, "link.txt", rootDescriptor, "followed.txt");
+                rootDescriptor.linkAt(
+                    { symlinkFollow: true },
+                    "link.txt",
+                    rootDescriptor,
+                    "followed.txt",
+                );
                 assert.strictEqual(
                     lstatSync(join(testDir, "followed.txt")).isSymbolicLink(),
                     false,

--- a/packages/preview2-shim/test/node.ts
+++ b/packages/preview2-shim/test/node.ts
@@ -1253,6 +1253,42 @@ suite("Sandboxing", () => {
             );
         }),
     );
+
+    test(
+        "linkAt honors path-flags.symlink-follow for the old path",
+        testWithGCWrap(async () => {
+            const { mkdtempSync, writeFileSync, symlinkSync, lstatSync, rmSync } = await import(
+                "node:fs"
+            );
+            const { tmpdir } = await import("node:os");
+            const { join } = await import("node:path");
+            const { WASIShim } = await import("@bytecodealliance/preview2-shim/instantiation");
+
+            const testDir = mkdtempSync(join(tmpdir(), "jco-symlink-follow-"));
+            try {
+                writeFileSync(join(testDir, "real.txt"), "target contents");
+                symlinkSync(join(testDir, "real.txt"), join(testDir, "link.txt"));
+
+                const shim = new WASIShim({ sandbox: { preopens: { "/test": testDir } } });
+                const [rootDescriptor] = shim
+                    .getImportObject()
+                    ["wasi:filesystem/preopens"].getDirectories()[0];
+
+                // `symlinkFollow: false` is Node/OS-native `link()` behavior (unaffected
+                // by this change, and implementation-defined by POSIX for symlinks).
+                // The fix under test is that `symlinkFollow: true` now resolves the old
+                // path's symlink chain before linking, instead of ignoring the flag.
+                rootDescriptor.linkAt({ symlinkFollow: true }, "link.txt", rootDescriptor, "followed.txt");
+                assert.strictEqual(
+                    lstatSync(join(testDir, "followed.txt")).isSymbolicLink(),
+                    false,
+                    "following the symlink should hard-link the real file",
+                );
+            } finally {
+                rmSync(testDir, { recursive: true, force: true });
+            }
+        }),
+    );
 });
 function testWithGCWrap(asyncTestFn: any) {
     return async () => {


### PR DESCRIPTION
Most other call sites (statAt, setTimesAt, openAt) already handled follow/no-follow correctly via statSync/lstatSync or O_NOFOLLOW directly, independent of this parameter — this fix specifically closes the gap for linkAt's old path and any other caller relying on #getFullPath to do the resolution.

- src/nodejs/filesystem.ts: #getFullPath now actually uses its followSymlinks parameter. When set, it resolves the syntactically-joined path via realpathSync (falling back to the unresolved path if resolution fails, e.g. for open-at with create on a not-yet-existing file). This fixes linkAt with `oldPathFlags.symlinkFollow: true`, which previously always hard-linked the symlink itself instead of its target (Node's linkSync doesn't dereference symlinks on its own).
- Added a test in test/node.ts creating a real file + symlink in a temp dir and verifying linkAt with `symlinkFollow: true` hard-links the resolved target.

  