### PR TITLE
feat(p2-shim): add missing socket error-code mapping

### DIFF
--- a/packages/preview2-shim/src/io/worker-sockets.ts
+++ b/packages/preview2-shim/src/io/worker-sockets.ts
@@ -24,7 +24,13 @@ import {
     ECONNABORTED,
     ECONNREFUSED,
     ECONNRESET,
+    EHOSTUNREACH,
     EINVAL,
+    EMFILE,
+    EMSGSIZE,
+    ENETDOWN,
+    ENETUNREACH,
+    ENFILE,
     ENOBUFS,
     ENOMEM,
     ENOTCONN,
@@ -146,18 +152,26 @@ export function convertSocketError(err) {
             return "concurrency-conflict";
         case "EWOULDBLOCK":
             return "would-block";
-        // TODO: return "new-socket-limit";
+        case "EMFILE":
+        case "ENFILE":
+            return "new-socket-limit";
         case "EADDRNOTAVAIL":
             return "address-not-bindable";
         case "EADDRINUSE":
             return "address-in-use";
-        // TODO: return "remote-unreachable";
+        case "EHOSTUNREACH":
+        case "EHOSTDOWN":
+        case "ENETUNREACH":
+        case "ENETDOWN":
+            return "remote-unreachable";
         case "ECONNREFUSED":
             return "connection-refused";
         case "ECONNRESET":
             return "connection-reset";
         case "ECONNABORTED":
             return "connection-aborted";
+        case "EMSGSIZE":
+            return "datagram-too-large";
         default:
             return "unknown";
     }
@@ -184,23 +198,30 @@ export function convertSocketErrorCode(code) {
             return "concurrency-conflict";
         case EWOULDBLOCK:
             return "would-block";
-        // TODO: return "new-socket-limit";
+        case EMFILE:
+        case ENFILE:
+            return "new-socket-limit";
         case 4090: // windows
         case EADDRNOTAVAIL:
             return "address-not-bindable";
         case 4091: // windows
         case EADDRINUSE:
             return "address-in-use";
-        // TODO: return "remote-unreachable";
+        case EHOSTUNREACH:
+        case ENETUNREACH:
+        case ENETDOWN:
+            return "remote-unreachable";
         case ECONNREFUSED:
             return "connection-refused";
         case ECONNRESET:
             return "connection-reset";
         case ECONNABORTED:
             return "connection-aborted";
-        // TODO: return "datagram-too-large";
-        // TODO: return "name-unresolvable";
-        // TODO: return "temporary-resolver-failure";
+        case EMSGSIZE:
+            return "datagram-too-large";
+        // name-unresolvable/temporary-resolver-failure are DNS lookup errors,
+        // which only surface here as string error codes (see
+        // socketResolveAddress above), never as a raw platform errno.
         default:
             // process._rawDebug('unknown error code', code);
             return "unknown";

--- a/packages/preview2-shim/test/socket-error-codes.ts
+++ b/packages/preview2-shim/test/socket-error-codes.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { EHOSTUNREACH, EMFILE, EMSGSIZE, ENETDOWN, ENETUNREACH, ENFILE } from "node:constants";
+
+import { suite, test } from "vitest";
+
+import { convertSocketError, convertSocketErrorCode } from "../src/io/worker-sockets.js";
+
+suite("socket error-code mapping", () => {
+    test.each([
+        ["EMFILE", "new-socket-limit"],
+        ["ENFILE", "new-socket-limit"],
+        ["EHOSTUNREACH", "remote-unreachable"],
+        ["EHOSTDOWN", "remote-unreachable"],
+        ["ENETUNREACH", "remote-unreachable"],
+        ["ENETDOWN", "remote-unreachable"],
+        ["EMSGSIZE", "datagram-too-large"],
+    ])("convertSocketError maps %s to %s", (code, expected) => {
+        assert.equal(convertSocketError({ code }), expected);
+    });
+
+    test.each([
+        [EMFILE, "new-socket-limit"],
+        [ENFILE, "new-socket-limit"],
+        [EHOSTUNREACH, "remote-unreachable"],
+        [ENETUNREACH, "remote-unreachable"],
+        [ENETDOWN, "remote-unreachable"],
+        [EMSGSIZE, "datagram-too-large"],
+    ])("convertSocketErrorCode maps %s to %s", (code, expected) => {
+        assert.equal(convertSocketErrorCode(code), expected);
+    });
+});


### PR DESCRIPTION
Finish the `catch`/`switch` arms mapping Node/browser socket errors to the correct `wasi:sockets/network#error-code` variants.

- packages/preview2-shim/src/io/worker-sockets.ts: filled in the previously-TODO'd error mappings in both convertSocketError (string-code path) and convertSocketErrorCode (numeric-code path) for new-socket-limit (EMFILE/ENFILE), remote-unreachable (EHOSTUNREACH/EHOSTDOWN/ENETUNREACH/ENETDOWN), and datagram-too-large (EMSGSIZE). Left name-unresolvable/temporary-resolver-failure out of convertSocketErrorCode with an explanatory comment — Node has no portable numeric errno for DNS resolution failures; those are already handled correctly via string .code values in socketResolveAddress.
- Added packages/preview2-shim/test/socket-error-codes.ts covering the new mappings for both functions.