### PR TITLE
feat(p2-shim): support symlink for browser in-memory filesystem

### DIFF
--- a/packages/preview2-shim/src/browser/in-memory-filesystem.ts
+++ b/packages/preview2-shim/src/browser/in-memory-filesystem.ts
@@ -20,6 +20,8 @@ export interface FileDataEntry {
     dir?: Record<string, FileDataEntry>;
     // File contents (present for files)
     source?: Uint8Array | string;
+    // Symlink target, stored verbatim as passed to `symlink-at` (present for symlinks)
+    symlink?: string;
 }
 
 /**
@@ -58,37 +60,76 @@ function coerceToSafeIntegerNumber(obj: number | bigint): number {
     return n;
 }
 
-function getChildEntry(parentEntry: FileDataEntry, subpath: string): FileDataEntry {
-    if (subpath === "." && rootEntries.has(parentEntry)) {
+// Linux's SYMLOOP_MAX; used to bound recursive symlink resolution so a cyclic
+// chain raises the WASI `loop` error instead of overflowing the call stack.
+const MAX_SYMLINK_DEPTH = 40;
+
+/**
+ * Resolve `subpath` from `dir`, following symlinks encountered along the way.
+ * Intermediate path segments always follow symlinks (matching POSIX path
+ * resolution); the final segment only does so when `followFinal` is set.
+ * Symlink targets are resolved relative to the directory that contains the
+ * symlink - this filesystem has no notion of a host-absolute root (a leading
+ * "/" is just an empty path segment, same as everywhere else in this file),
+ * so a target starting with "/" simply resolves from that same directory.
+ */
+function resolveEntry(
+    dir: FileDataEntry,
+    subpath: string,
+    followFinal: boolean,
+    depth: number,
+): FileDataEntry {
+    if (depth > MAX_SYMLINK_DEPTH) {
+        throw "loop";
+    }
+    if (subpath === "." && rootEntries.has(dir)) {
         subpath = _getCwd();
         if (subpath.startsWith("/") && subpath !== "/") {
             subpath = subpath.slice(1);
         }
     }
-    let entry: FileDataEntry | undefined = parentEntry;
+    let entry: FileDataEntry = dir;
     let segmentIdx: number;
     do {
-        if (!entry?.dir) {
+        if (!entry.dir) {
             throw "not-directory";
         }
         segmentIdx = subpath.indexOf("/");
         const segment = segmentIdx === -1 ? subpath : subpath.slice(0, segmentIdx);
+        const rest = subpath.slice(segmentIdx + 1);
         if (segment === "..") {
             throw "no-entry";
         }
-        if (segment === "." || segment === "") {
-        } else {
-            entry = entry.dir[segment];
-            if (!entry) {
+        if (segment !== "." && segment !== "") {
+            const child = entry.dir[segment];
+            if (!child) {
                 throw "no-entry";
             }
+            const isFinalSegment = segmentIdx === -1;
+            if (child.symlink !== undefined && (!isFinalSegment || followFinal)) {
+                return resolveEntry(
+                    entry,
+                    child.symlink + (isFinalSegment ? "" : "/" + rest),
+                    followFinal,
+                    depth + 1,
+                );
+            }
+            entry = child;
         }
-        subpath = subpath.slice(segmentIdx + 1);
+        subpath = rest;
     } while (segmentIdx !== -1);
-    if (!entry) {
-        throw "no-entry";
-    }
     return entry;
+}
+
+function getChildEntry(
+    parentEntry: FileDataEntry,
+    subpath: string,
+    // No default: `pathFlags.symlinkFollow` is `undefined` when unset, and a
+    // default parameter substitutes on `undefined` regardless of whether it's
+    // literal or a forwarded value - callers must pass an explicit boolean.
+    followFinal: boolean | undefined,
+): FileDataEntry {
+    return resolveEntry(parentEntry, subpath, !!followFinal, 0);
 }
 
 function getParentEntry(root: FileDataEntry, path: string): [FileDataEntry, string] {
@@ -99,9 +140,12 @@ function getParentEntry(root: FileDataEntry, path: string): [FileDataEntry, stri
     const name = segments.pop()!;
     let parent = root;
     for (const segment of segments) {
-        const child = parent.dir?.[segment];
+        let child = parent.dir?.[segment];
         if (!child) {
             throw "no-entry";
+        }
+        if (child.symlink !== undefined) {
+            child = resolveEntry(parent, child.symlink, true, 0);
         }
         if (!child.dir) {
             throw "not-directory";
@@ -119,6 +163,23 @@ function getSource(fileEntry: FileDataEntry): Uint8Array {
         fileEntry.source = new TextEncoder().encode(fileEntry.source);
     }
     return fileEntry.source!;
+}
+
+function describeEntry(entry: FileDataEntry): {
+    type: TypesNamespace.DescriptorType;
+    size: Filesize;
+} {
+    if (entry.symlink !== undefined) {
+        // Matches POSIX lstat: a symlink's size is the byte length of its target.
+        return {
+            type: "symbolic-link",
+            size: BigInt(new TextEncoder().encode(entry.symlink).byteLength),
+        };
+    }
+    if (entry.dir) {
+        return { type: "directory", size: 0n };
+    }
+    return { type: "regular-file", size: BigInt(getSource(entry).byteLength) };
 }
 
 function containsEntry(root: FileDataEntry, target: FileDataEntry): boolean {
@@ -190,7 +251,7 @@ class DirectoryEntryStream implements BrowserDirectoryEntryStream {
         this.idx += 1;
         return {
             name,
-            type: entry.dir ? "directory" : "regular-file",
+            type: describeEntry(entry).type,
         } as TypesNamespace.DirectoryEntry;
     }
 }
@@ -287,6 +348,9 @@ class Descriptor implements BrowserFilesystemDescriptor {
         if (this.#stream) {
             return "fifo";
         }
+        if (this.#entry.symlink !== undefined) {
+            return "symbolic-link";
+        }
         if (this.#entry.dir) {
             return "directory";
         }
@@ -359,7 +423,9 @@ class Descriptor implements BrowserFilesystemDescriptor {
 
     createDirectoryAt(path: string) {
         try {
-            getChildEntry(this.#entry, path);
+            // Existence is checked against the literal entry (mkdir never follows
+            // the final path component, even if it's a symlink).
+            getChildEntry(this.#entry, path, false);
             throw "exist";
         } catch (error) {
             if (error !== "no-entry") {
@@ -372,15 +438,7 @@ class Descriptor implements BrowserFilesystemDescriptor {
     }
 
     stat() {
-        let type: TypesNamespace.DescriptorType = "unknown";
-        let size = 0n;
-        if (this.#entry.source) {
-            type = "regular-file";
-            const source = getSource(this.#entry);
-            size = BigInt(source.byteLength);
-        } else if (this.#entry.dir) {
-            type = "directory";
-        }
+        const { type, size } = describeEntry(this.#entry);
         return {
             type,
             linkCount: metadata(this.#entry).linkCount,
@@ -391,17 +449,9 @@ class Descriptor implements BrowserFilesystemDescriptor {
         };
     }
 
-    statAt(_pathFlags: PathFlags, path: string) {
-        const entry = getChildEntry(this.#entry, path);
-        let type: TypesNamespace.DescriptorType = "unknown";
-        let size = 0n;
-        if (entry.source) {
-            type = "regular-file";
-            const source = getSource(entry);
-            size = BigInt(source.byteLength);
-        } else if (entry.dir) {
-            type = "directory";
-        }
+    statAt(pathFlags: PathFlags, path: string) {
+        const entry = getChildEntry(this.#entry, path, pathFlags.symlinkFollow);
+        const { type, size } = describeEntry(entry);
         return {
             type,
             linkCount: metadata(entry).linkCount,
@@ -412,8 +462,8 @@ class Descriptor implements BrowserFilesystemDescriptor {
         };
     }
 
-    setTimesAt(_pathFlags: PathFlags, path: string, _atime: any, mtime: any) {
-        const entry = getChildEntry(this.#entry, path);
+    setTimesAt(pathFlags: PathFlags, path: string, _atime: any, mtime: any) {
+        const entry = getChildEntry(this.#entry, path, pathFlags.symlinkFollow);
         if (mtime?.tag !== "no-change") {
             // Metadata is currently descriptor-local; touching the entry makes
             // the mutation visible through metadata hashes on newly opened handles.
@@ -423,12 +473,14 @@ class Descriptor implements BrowserFilesystemDescriptor {
     }
 
     linkAt(
-        _pathFlags: PathFlags,
+        oldPathFlags: PathFlags,
         oldPath: string,
         newDescriptor: BrowserFilesystemDescriptor,
         newPath: string,
     ) {
-        const entry = getChildEntry(this.#entry, oldPath);
+        // Unlike open/stat, link never follows the final symlink unless the
+        // caller explicitly asked for it via `symlink-follow`.
+        const entry = getChildEntry(this.#entry, oldPath, oldPathFlags.symlinkFollow);
         if (entry.dir) {
             throw "not-permitted";
         }
@@ -445,14 +497,14 @@ class Descriptor implements BrowserFilesystemDescriptor {
     }
 
     openAt(
-        _pathFlags: PathFlags,
+        pathFlags: PathFlags,
         path: string,
         openFlags: OpenFlags,
         _flags: TypesNamespace.DescriptorFlags,
     ) {
         let childEntry: FileDataEntry;
         try {
-            childEntry = getChildEntry(this.#entry, path);
+            childEntry = getChildEntry(this.#entry, path, pathFlags.symlinkFollow);
             if (openFlags.create && openFlags.exclusive) {
                 throw "exist";
             }
@@ -465,6 +517,11 @@ class Descriptor implements BrowserFilesystemDescriptor {
                 ? { dir: {} }
                 : { source: new Uint8Array() };
             touch(parent);
+        }
+        if (childEntry.symlink !== undefined) {
+            // `symlink-follow` was unset and the final path component is a
+            // symlink - matches opening with O_NOFOLLOW against a symlink.
+            throw "loop";
         }
         if (openFlags.directory && !childEntry.dir) {
             throw "not-directory";
@@ -479,8 +536,14 @@ class Descriptor implements BrowserFilesystemDescriptor {
         return descriptorCreate(childEntry);
     }
 
-    readlinkAt(_path: string): string {
-        throw "unsupported";
+    readlinkAt(path: string): string {
+        // The literal entry, never resolved - readlink always reports the
+        // immediate target, not what it ultimately points to.
+        const entry = getChildEntry(this.#entry, path, false);
+        if (entry.symlink === undefined) {
+            throw "invalid";
+        }
+        return entry.symlink;
     }
 
     removeDirectoryAt(path: string) {
@@ -537,8 +600,18 @@ class Descriptor implements BrowserFilesystemDescriptor {
         }
     }
 
-    symlinkAt() {
-        throw "unsupported";
+    symlinkAt(oldPath: string, newPath: string) {
+        // Matches the Node backend: guest-visible symlink targets are always
+        // relative, since this sandboxed filesystem has no host-absolute root.
+        if (oldPath.startsWith("/")) {
+            throw "not-permitted";
+        }
+        const [parent, name] = getParentEntry(this.#entry, newPath);
+        if (parent.dir![name]) {
+            throw "exist";
+        }
+        parent.dir![name] = { symlink: oldPath };
+        touch(parent);
     }
 
     unlinkFileAt(path: string) {
@@ -564,8 +637,8 @@ class Descriptor implements BrowserFilesystemDescriptor {
         return { upper: value.id, lower: value.version };
     }
 
-    metadataHashAt(_pathFlags: any, path: string) {
-        const value = metadata(getChildEntry(this.#entry, path));
+    metadataHashAt(pathFlags: PathFlags, path: string) {
+        const value = metadata(getChildEntry(this.#entry, path, pathFlags.symlinkFollow));
         return { upper: value.id, lower: value.version };
     }
 }

--- a/packages/preview2-shim/src/browser/in-memory-filesystem.ts
+++ b/packages/preview2-shim/src/browser/in-memory-filesystem.ts
@@ -26,7 +26,7 @@ export interface FileDataEntry {
 
 /**
  * Root file data structure representing a filesystem tree.
- * Each entry is either a directory (has `dir` property) or a file (has `source` property).
+ * Each entry is a directory (`dir`), a file (`source`), or a symbolic link (`symlink`).
  * @example
  * // A simple filesystem with one directory containing one file:
  * const fileData = {
@@ -60,98 +60,99 @@ function coerceToSafeIntegerNumber(obj: number | bigint): number {
     return n;
 }
 
-// Linux's SYMLOOP_MAX; used to bound recursive symlink resolution so a cyclic
-// chain raises the WASI `loop` error instead of overflowing the call stack.
+// Bound the total number of symlinks followed during a single path resolution.
 const MAX_SYMLINK_DEPTH = 40;
 
+interface ResolvedEntry {
+    entry: FileDataEntry | undefined;
+    parent: FileDataEntry;
+    name: string;
+}
+
 /**
- * Resolve `subpath` from `dir`, following symlinks encountered along the way.
- * Intermediate path segments always follow symlinks (matching POSIX path
- * resolution); the final segment only does so when `followFinal` is set.
- * Symlink targets are resolved relative to the directory that contains the
- * symlink - this filesystem has no notion of a host-absolute root (a leading
- * "/" is just an empty path segment, same as everywhere else in this file),
- * so a target starting with "/" simply resolves from that same directory.
+ * Resolve from the descriptor's base directory, retaining the directory stack
+ * across symlink expansions so `..` cannot escape that capability. Intermediate
+ * symlinks always follow; the final segment follows only when requested.
+ * Creation may return a missing final entry, together with its resolved parent.
  */
 function resolveEntry(
-    dir: FileDataEntry,
-    subpath: string,
+    root: FileDataEntry,
+    path: string,
     followFinal: boolean,
-    depth: number,
-): FileDataEntry {
-    if (depth > MAX_SYMLINK_DEPTH) {
-        throw "loop";
-    }
-    if (subpath === "." && rootEntries.has(dir)) {
-        subpath = _getCwd();
-        if (subpath.startsWith("/") && subpath !== "/") {
-            subpath = subpath.slice(1);
-        }
-    }
-    let entry: FileDataEntry = dir;
-    let segmentIdx: number;
-    do {
-        if (!entry.dir) {
+    allowMissingFinal = false,
+): ResolvedEntry {
+    const directories = [root];
+    const pending = path.split("/").reverse();
+    let followed = 0;
+    while (pending.length) {
+        const parent = directories[directories.length - 1];
+        if (!parent.dir) {
             throw "not-directory";
         }
-        segmentIdx = subpath.indexOf("/");
-        const segment = segmentIdx === -1 ? subpath : subpath.slice(0, segmentIdx);
-        const rest = subpath.slice(segmentIdx + 1);
-        if (segment === "..") {
+        const name = pending.pop()!;
+        if (name === "" || name === ".") {
+            continue;
+        }
+        if (name === "..") {
+            if (directories.length === 1) {
+                throw "not-permitted";
+            }
+            directories.pop();
+            continue;
+        }
+        const entry = parent.dir[name];
+        const isFinal = pending.length === 0;
+        if (!entry) {
+            if (isFinal && allowMissingFinal) {
+                return { entry: undefined, parent, name };
+            }
             throw "no-entry";
         }
-        if (segment !== "." && segment !== "") {
-            const child = entry.dir[segment];
-            if (!child) {
-                throw "no-entry";
+        if (entry.symlink !== undefined && (!isFinal || followFinal)) {
+            if (++followed > MAX_SYMLINK_DEPTH) {
+                throw "loop";
             }
-            const isFinalSegment = segmentIdx === -1;
-            if (child.symlink !== undefined && (!isFinalSegment || followFinal)) {
-                return resolveEntry(
-                    entry,
-                    child.symlink + (isFinalSegment ? "" : "/" + rest),
-                    followFinal,
-                    depth + 1,
-                );
+            if (entry.symlink.startsWith("/")) {
+                throw "not-permitted";
             }
-            entry = child;
+            for (const segment of entry.symlink.split("/").reverse()) {
+                pending.push(segment);
+            }
+            continue;
         }
-        subpath = rest;
-    } while (segmentIdx !== -1);
-    return entry;
+        if (isFinal) {
+            return { entry, parent, name };
+        }
+        directories.push(entry);
+    }
+    const entry = directories[directories.length - 1];
+    return { entry, parent: entry, name: "" };
+}
+
+// Preserve the legacy root lookup of `.` without applying CWD substitution to
+// symlink targets or to the parent paths used by mutations.
+function lookupPath(root: FileDataEntry, path: string): string {
+    if (path === "." && rootEntries.has(root)) {
+        return _getCwd();
+    }
+    return path;
 }
 
 function getChildEntry(
     parentEntry: FileDataEntry,
     subpath: string,
-    // No default: `pathFlags.symlinkFollow` is `undefined` when unset, and a
-    // default parameter substitutes on `undefined` regardless of whether it's
-    // literal or a forwarded value - callers must pass an explicit boolean.
     followFinal: boolean | undefined,
 ): FileDataEntry {
-    return resolveEntry(parentEntry, subpath, !!followFinal, 0);
+    return resolveEntry(parentEntry, lookupPath(parentEntry, subpath), !!followFinal).entry!;
 }
 
 function getParentEntry(root: FileDataEntry, path: string): [FileDataEntry, string] {
     const segments = path.split("/").filter((segment) => segment !== "" && segment !== ".");
-    if (segments.length === 0 || segments.some((segment) => segment === "..")) {
+    const name = segments.pop();
+    if (!name || name === "..") {
         throw "invalid";
     }
-    const name = segments.pop()!;
-    let parent = root;
-    for (const segment of segments) {
-        let child = parent.dir?.[segment];
-        if (!child) {
-            throw "no-entry";
-        }
-        if (child.symlink !== undefined) {
-            child = resolveEntry(parent, child.symlink, true, 0);
-        }
-        if (!child.dir) {
-            throw "not-directory";
-        }
-        parent = child;
-    }
+    const parent = resolveEntry(root, segments.join("/"), true).entry!;
     if (!parent.dir) {
         throw "not-directory";
     }
@@ -502,17 +503,19 @@ class Descriptor implements BrowserFilesystemDescriptor {
         openFlags: OpenFlags,
         _flags: TypesNamespace.DescriptorFlags,
     ) {
-        let childEntry: FileDataEntry;
-        try {
-            childEntry = getChildEntry(this.#entry, path, pathFlags.symlinkFollow);
-            if (openFlags.create && openFlags.exclusive) {
-                throw "exist";
-            }
-        } catch (error) {
-            if (error !== "no-entry" || !openFlags.create) {
-                throw error;
-            }
-            const [parent, name] = getParentEntry(this.#entry, path);
+        const exclusiveCreate = !!(openFlags.create && openFlags.exclusive);
+        const resolved = resolveEntry(
+            this.#entry,
+            lookupPath(this.#entry, path),
+            !!pathFlags.symlinkFollow && !exclusiveCreate,
+            !!openFlags.create,
+        );
+        let childEntry = resolved.entry;
+        if (childEntry && exclusiveCreate) {
+            throw "exist";
+        }
+        if (!childEntry) {
+            const { parent, name } = resolved;
             childEntry = parent.dir![name] = openFlags.directory
                 ? { dir: {} }
                 : { source: new Uint8Array() };
@@ -542,6 +545,9 @@ class Descriptor implements BrowserFilesystemDescriptor {
         const entry = getChildEntry(this.#entry, path, false);
         if (entry.symlink === undefined) {
             throw "invalid";
+        }
+        if (entry.symlink.startsWith("/")) {
+            throw "not-permitted";
         }
         return entry.symlink;
     }

--- a/packages/preview2-shim/test/browser/filesystem-symlink-e2e.ts
+++ b/packages/preview2-shim/test/browser/filesystem-symlink-e2e.ts
@@ -1,0 +1,91 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { componentize } from "@bytecodealliance/componentize-js";
+import { transpile } from "@bytecodealliance/jco";
+import { assert, beforeAll, suite, test } from "vitest";
+
+import {
+    FIXTURES_WIT_DIR,
+    getTmpDir,
+    runBasicHarnessPageTest,
+    startTestServer,
+} from "../common.js";
+
+suite("browser filesystem symlinks from a component", () => {
+    let results: Record<string, string>;
+
+    beforeAll(async () => {
+        const outDir = await getTmpDir();
+        let harness: Awaited<ReturnType<typeof startTestServer>> | undefined;
+        try {
+            const { component } = await componentize({
+                sourcePath: fileURLToPath(
+                    new URL(
+                        "../fixtures/browser/filesystem-symlinks/component.js",
+                        import.meta.url,
+                    ),
+                ),
+                witPath: FIXTURES_WIT_DIR,
+                worldName: "browser-fs-write",
+            });
+            const { files } = await transpile(component, {
+                name: "component",
+                optimize: false,
+                outDir,
+            });
+            for (const [path, bytes] of Object.entries(files)) {
+                await mkdir(dirname(path), { recursive: true });
+                await writeFile(path, bytes);
+            }
+            // Configure the host, then let all operations and assertions cross
+            // the component boundary. In particular, do not call descriptors here.
+            await writeFile(
+                join(outDir, "configured.js"),
+                `import { _setFileData, _setCwd } from "@bytecodealliance/preview2-shim/filesystem";
+                 _setFileData({ dir: {
+                     work: { dir: {} },
+                     target: { source: "value" },
+                     absolute: { symlink: "/target" }
+                 } });
+                 _setCwd("/work");
+                 export const { test } = await import("./component.js");
+                 export { test as "tests:p2-shim/test" };`,
+            );
+            harness = await startTestServer({ transpiledOutputDir: outDir });
+            const { statusJSON } = await runBasicHarnessPageTest({
+                browser: harness.browser,
+                url: `${harness.baseURL}/index.html#transpiled:configured.js`,
+            });
+            results = JSON.parse(statusJSON.msg!);
+        } finally {
+            if (harness) {
+                await harness.cleanup();
+            } else {
+                await rm(outDir, { recursive: true, force: true });
+            }
+        }
+    }, 120_000);
+
+    for (const name of [
+        "follow and no-follow",
+        "intermediate symlink chains",
+        "directory entries and metadata",
+        "hard links and unlink",
+        "cyclic links",
+        "create dangling target",
+        "exclusive create",
+        "missing target parent",
+        "relative parent target",
+        "dot target with configured cwd",
+        "absolute preset target",
+        "readlink absolute preset target",
+        "create through relative target chain",
+        "parent-relative directory mutations",
+    ]) {
+        test.concurrent(name, () => {
+            assert.strictEqual(results[name], "ok", `${name}: ${results[name]}`);
+        });
+    }
+});

--- a/packages/preview2-shim/test/browser/filesystem-symlinks.ts
+++ b/packages/preview2-shim/test/browser/filesystem-symlinks.ts
@@ -1,0 +1,136 @@
+import { assert, test } from "vitest";
+import { InMemoryFilesystemAdapter, type FileData } from "../../src/browser/filesystem.js";
+import { _getCwd, _setCwd } from "../../src/browser/config.js";
+
+function root(data: FileData) {
+    return new InMemoryFilesystemAdapter().getRoot(data);
+}
+
+test.concurrent("create through dangling symlink preserves link and creates target", () => {
+    const dir = root({ dir: {} });
+    dir.symlinkAt("target", "link");
+    const file = dir.openAt({ symlinkFollow: true }, "link", { create: true }, { write: true });
+    file.write(new TextEncoder().encode("created"), 0n);
+    assert.strictEqual(dir.statAt({}, "link").type, "symbolic-link");
+    assert.strictEqual(dir.readlinkAt("link"), "target");
+    assert.strictEqual(dir.statAt({}, "target").type, "regular-file");
+    const target = dir.openAt({}, "target", {}, { read: true });
+    assert.strictEqual(new TextDecoder().decode(target.read(100n, 0n)[0]), "created");
+});
+
+test.concurrent("exclusive create rejects dangling link without changing entries", () => {
+    const dir = root({ dir: {} });
+    dir.symlinkAt("target", "link");
+    assert.throws(
+        () =>
+            dir.openAt(
+                { symlinkFollow: true },
+                "link",
+                { create: true, exclusive: true },
+                { write: true },
+            ),
+        "exist",
+    );
+    assert.strictEqual(dir.readlinkAt("link"), "target");
+    assert.throws(() => dir.statAt({}, "target"), "no-entry");
+});
+
+test.concurrent("relative target can traverse parent within base directory", () => {
+    const dir = root({ dir: { target: { source: "value" }, nested: { dir: {} } } });
+    dir.symlinkAt("../target", "nested/link");
+    assert.strictEqual(dir.statAt({ symlinkFollow: true }, "nested/link").type, "regular-file");
+    const nested = dir.openAt({}, "nested", { directory: true }, { read: true });
+    assert.throws(() => nested.statAt({ symlinkFollow: true }, "link"), "not-permitted");
+});
+
+test.concurrent("symlink to dot resolves to its containing directory with non-root cwd", () => {
+    const dir = root({ dir: { work: { dir: {} } } });
+    const previousCwd = _getCwd();
+    // Keep this callback synchronous so the global CWD change cannot interleave
+    // with another concurrent test, and always restore the previous value.
+    _setCwd("/work");
+    try {
+        dir.symlinkAt(".", "self");
+        assert.deepStrictEqual(
+            dir.metadataHashAt({ symlinkFollow: true }, "self"),
+            dir.metadataHash(),
+        );
+        dir.createDirectoryAt("self/created");
+        assert.strictEqual(dir.statAt({}, "created").type, "directory");
+    } finally {
+        _setCwd(previousCwd);
+    }
+});
+
+test.concurrent("preset absolute symlink cannot be followed", () => {
+    const dir = root({ dir: { file: { source: "value" }, link: { symlink: "/file" } } });
+    assert.throws(() => dir.statAt({ symlinkFollow: true }, "link"), "not-permitted");
+});
+
+test.concurrent("readlink rejects preset absolute symlink targets", () => {
+    const dir = root({ dir: { link: { symlink: "/file" } } });
+    assert.throws(() => dir.readlinkAt("link"), "not-permitted");
+});
+
+test.concurrent("symlink whose target is missing intermediate directory is not replaced", () => {
+    const dir = root({ dir: {} });
+    dir.symlinkAt("missing/target", "link");
+    assert.throws(
+        () => dir.openAt({ symlinkFollow: true }, "link", { create: true }, { write: true }),
+        "no-entry",
+    );
+    assert.strictEqual(dir.readlinkAt("link"), "missing/target");
+});
+
+test.concurrent("creation follows a relative target chain through an intermediate alias", () => {
+    const dir = root({ dir: { nested: { dir: {} } } });
+    dir.symlinkAt("nested", "alias");
+    dir.symlinkAt("../second", "nested/first");
+    dir.symlinkAt("target", "second");
+    const file = dir.openAt(
+        { symlinkFollow: true },
+        "alias/first",
+        { create: true },
+        { write: true },
+    );
+    file.write(new TextEncoder().encode("created"), 0n);
+    assert.strictEqual(dir.readlinkAt("nested/first"), "../second");
+    assert.strictEqual(dir.readlinkAt("second"), "target");
+    assert.deepStrictEqual(dir.metadataHashAt({}, "target"), file.metadataHash());
+    assert.throws(() => dir.statAt({}, "nested/target"), "no-entry");
+});
+
+test.concurrent("parent-relative directory links support mutations within the base", () => {
+    const dir = root({ dir: { nested: { dir: {} }, destination: { dir: {} } } });
+    dir.symlinkAt("../destination", "nested/alias");
+    dir.createDirectoryAt("nested/alias/child");
+    dir.symlinkAt("child", "nested/alias/link");
+    assert.strictEqual(dir.statAt({ symlinkFollow: true }, "destination/link").type, "directory");
+    dir.renameAt("nested/alias/link", dir, "nested/alias/renamed");
+    assert.strictEqual(dir.readlinkAt("destination/renamed"), "child");
+    dir.unlinkFileAt("nested/alias/renamed");
+    dir.removeDirectoryAt("nested/alias/child");
+    assert.throws(() => dir.statAt({}, "destination/child"), "no-entry");
+});
+
+test.concurrent("cyclic target creation leaves the links intact", () => {
+    const dir = root({ dir: { a: { symlink: "b" }, b: { symlink: "a" } } });
+    const before = dir.metadataHash();
+    assert.throws(
+        () => dir.openAt({ symlinkFollow: true }, "a", { create: true }, { write: true }),
+        "loop",
+    );
+    assert.strictEqual(dir.readlinkAt("a"), "b");
+    assert.strictEqual(dir.readlinkAt("b"), "a");
+    assert.deepStrictEqual(dir.metadataHash(), before);
+});
+
+test.concurrent("mutations enforce a symlink budget across all path segments", () => {
+    const dir = root({ dir: { self: { symlink: "." } } });
+    const allowed = "self/".repeat(40);
+    const excessive = "self/".repeat(41);
+    dir.createDirectoryAt(allowed + "created");
+    assert.strictEqual(dir.statAt({}, "created").type, "directory");
+    assert.throws(() => dir.symlinkAt("created", excessive + "link"), "loop");
+    assert.throws(() => dir.statAt({}, "link"), "no-entry");
+});

--- a/packages/preview2-shim/test/browser/filesystem.ts
+++ b/packages/preview2-shim/test/browser/filesystem.ts
@@ -180,6 +180,71 @@ suite("Browser filesystem", () => {
         assert.deepStrictEqual(root.metadataHashAt({}, "link"), link.metadataHash());
     });
 
+    test("symlinkAt and readlinkAt create and report symlinks", async () => {
+        const { _setFileData, preopens } = await import("../../src/browser/filesystem.js");
+        _setFileData({ dir: { file: { source: "value" }, sub: { dir: {} } } });
+        const [[root]] = preopens.getDirectories();
+
+        root.symlinkAt("file", "link");
+        assert.strictEqual(root.readlinkAt("link"), "file");
+        assert.strictEqual(root.statAt({}, "link").type, "symbolic-link");
+        assert.strictEqual(root.statAt({ symlinkFollow: true }, "link").type, "regular-file");
+
+        assert.throws(() => root.symlinkAt("/absolute", "abs-link"), "not-permitted");
+        assert.throws(() => root.symlinkAt("file", "link"), "exist");
+        assert.throws(() => root.readlinkAt("file"), "invalid");
+    });
+
+    test("openAt follows symlinks only when symlink-follow is set", async () => {
+        const { _setFileData, preopens } = await import("../../src/browser/filesystem.js");
+        _setFileData({ dir: { file: { source: "value" } } });
+        const [[root]] = preopens.getDirectories();
+        root.symlinkAt("file", "link");
+
+        const followed = root.openAt({ symlinkFollow: true }, "link", {}, { read: true });
+        assert.strictEqual(followed.getType(), "regular-file");
+
+        assert.throws(() => root.openAt({}, "link", {}, { read: true }), "loop");
+    });
+
+    test("symlinks resolve through intermediate directory components", async () => {
+        const { _setFileData, preopens } = await import("../../src/browser/filesystem.js");
+        _setFileData({
+            dir: {
+                real: { dir: { file: { source: "nested" } } },
+                alias: { symlink: "real" },
+            },
+        });
+        const [[root]] = preopens.getDirectories();
+
+        assert.strictEqual(root.statAt({}, "alias/file").type, "regular-file");
+        assert.strictEqual(root.statAt({}, "alias/file").size, 6n);
+        root.createDirectoryAt("alias/child");
+        assert.strictEqual(root.statAt({}, "real/child").type, "directory");
+    });
+
+    test("cyclic symlinks raise loop instead of recursing forever", async () => {
+        const { _setFileData, preopens } = await import("../../src/browser/filesystem.js");
+        _setFileData({ dir: { a: { symlink: "b" }, b: { symlink: "a" } } });
+        const [[root]] = preopens.getDirectories();
+
+        assert.throws(() => root.statAt({ symlinkFollow: true }, "a"), "loop");
+    });
+
+    test("linkAt honors symlink-follow for the old path", async () => {
+        const { _setFileData, preopens } = await import("../../src/browser/filesystem.js");
+        const fileData = { dir: { file: { source: "value" } } };
+        _setFileData(fileData);
+        const [[root]] = preopens.getDirectories();
+        root.symlinkAt("file", "link");
+
+        root.linkAt({}, "link", root, "unfollowed");
+        assert.strictEqual(root.statAt({}, "unfollowed").type, "symbolic-link");
+
+        root.linkAt({ symlinkFollow: true }, "link", root, "followed");
+        assert.strictEqual(root.statAt({}, "followed").type, "regular-file");
+    });
+
     test("createFilesystem isolates explicitly selected in-memory roots", async () => {
         const { createFilesystem, InMemoryFilesystemAdapter } =
             await import("../../src/browser/filesystem.js");

--- a/packages/preview2-shim/test/fixtures/browser/filesystem-symlinks/component.js
+++ b/packages/preview2-shim/test/fixtures/browser/filesystem-symlinks/component.js
@@ -1,0 +1,246 @@
+import { getDirectories } from "wasi:filesystem/preopens@0.2.8";
+
+const follow = { symlinkFollow: true };
+const dispose = (resource) => resource[Symbol.dispose || Symbol.for("dispose")]();
+
+function check(condition, message) {
+    if (!condition) {
+        throw message;
+    }
+}
+
+function expectError(operation, expected) {
+    try {
+        operation();
+    } catch (error) {
+        const actual = error.payload ?? error;
+        check(actual === expected, `expected ${expected}, received ${actual}`);
+        return;
+    }
+    throw `expected ${expected}, operation succeeded`;
+}
+
+function sameHash(left, right) {
+    return left.upper === right.upper && left.lower === right.lower;
+}
+
+function readText(file) {
+    return new TextDecoder().decode(file.read(100n, 0n)[0]);
+}
+
+export const test = {
+    run() {
+        const [[root]] = getDirectories();
+        const results = {};
+        const run = (name, operation) => {
+            try {
+                operation();
+                results[name] = "ok";
+            } catch (error) {
+                results[name] = String(error.payload ?? error);
+            }
+        };
+
+        run("follow and no-follow", () => {
+            root.symlinkAt("target", "link");
+            check(root.readlinkAt("link") === "target", "readlink changed target");
+            check(root.statAt({}, "link").type === "symbolic-link", "lstat followed link");
+            check(root.statAt(follow, "link").type === "regular-file", "stat did not follow");
+            const file = root.openAt(follow, "link", {}, { read: true });
+            check(readText(file) === "value", "wrong target contents");
+            dispose(file);
+            expectError(() => root.openAt({}, "link", {}, { read: true }), "loop");
+        });
+
+        run("intermediate symlink chains", () => {
+            root.createDirectoryAt("real");
+            root.symlinkAt("real", "alias1");
+            root.symlinkAt("alias1", "alias2");
+            const file = root.openAt({}, "alias2/file", { create: true }, { write: true });
+            file.write(new TextEncoder().encode("nested"), 0n);
+            dispose(file);
+            root.symlinkAt("file", "real/link");
+            check(root.statAt({}, "alias2/link").type === "symbolic-link", "followed final link");
+            const opened = root.openAt(follow, "alias2/link", {}, { read: true });
+            check(readText(opened) === "nested", "intermediate chain read wrong file");
+            dispose(opened);
+        });
+
+        run("directory entries and metadata", () => {
+            root.symlinkAt("target", "metadata-link");
+            const entries = root.readDirectory();
+            let found = false;
+            for (let entry; (entry = entries.readDirectoryEntry()); ) {
+                if (entry.name === "metadata-link") {
+                    check(entry.type === "symbolic-link", "wrong readdir type");
+                    found = true;
+                }
+            }
+            dispose(entries);
+            check(found, "missing directory entry");
+            const linkBefore = root.metadataHashAt({}, "metadata-link");
+            const fileBefore = root.metadataHashAt({}, "target");
+            check(
+                sameHash(root.metadataHashAt(follow, "metadata-link"), fileBefore),
+                "wrong followed hash",
+            );
+            root.setTimesAt({}, "metadata-link", { tag: "no-change" }, { tag: "now" });
+            const linkAfter = root.metadataHashAt({}, "metadata-link");
+            check(!sameHash(linkBefore, linkAfter), "link hash did not change");
+            check(
+                sameHash(fileBefore, root.metadataHashAt({}, "target")),
+                "changed target without follow",
+            );
+            root.setTimesAt(follow, "metadata-link", { tag: "no-change" }, { tag: "now" });
+            check(
+                !sameHash(fileBefore, root.metadataHashAt({}, "target")),
+                "target hash did not change",
+            );
+            check(
+                sameHash(linkAfter, root.metadataHashAt({}, "metadata-link")),
+                "changed link with follow",
+            );
+        });
+
+        run("hard links and unlink", () => {
+            root.symlinkAt("target", "hardlink-source");
+            root.linkAt({}, "hardlink-source", root, "linked-symlink");
+            root.linkAt(follow, "hardlink-source", root, "linked-file");
+            check(root.readlinkAt("linked-symlink") === "target", "did not link symlink");
+            const target = root.openAt({}, "target", {}, { read: true });
+            const linked = root.openAt({}, "linked-file", {}, { read: true });
+            check(target.isSameObject(linked), "hard link has different identity");
+            dispose(linked);
+            dispose(target);
+            root.unlinkFileAt("hardlink-source");
+            check(root.statAt({}, "target").type === "regular-file", "unlink removed target");
+        });
+
+        run("cyclic links", () => {
+            root.symlinkAt("cycle-b", "cycle-a");
+            root.symlinkAt("cycle-a", "cycle-b");
+            expectError(() => root.statAt(follow, "cycle-a"), "loop");
+        });
+
+        run("create dangling target", () => {
+            root.symlinkAt("created-target", "dangling");
+            const file = root.openAt(follow, "dangling", { create: true }, { write: true });
+            file.write(new TextEncoder().encode("created"), 0n);
+            dispose(file);
+            check(root.statAt({}, "dangling").type === "symbolic-link", "create replaced symlink");
+            check(root.readlinkAt("dangling") === "created-target", "create changed link target");
+            const target = root.openAt({}, "created-target", {}, { read: true });
+            check(readText(target) === "created", "data was not written to target");
+            dispose(target);
+        });
+
+        run("exclusive create", () => {
+            root.symlinkAt("exclusive-target", "exclusive-link");
+            expectError(() => {
+                const file = root.openAt(
+                    follow,
+                    "exclusive-link",
+                    { create: true, exclusive: true },
+                    { write: true },
+                );
+                dispose(file);
+            }, "exist");
+            check(
+                root.readlinkAt("exclusive-link") === "exclusive-target",
+                "exclusive create replaced symlink",
+            );
+            expectError(() => root.statAt({}, "exclusive-target"), "no-entry");
+        });
+
+        run("missing target parent", () => {
+            root.symlinkAt("missing/target", "missing-parent-link");
+            expectError(() => {
+                const file = root.openAt(
+                    follow,
+                    "missing-parent-link",
+                    { create: true },
+                    { write: true },
+                );
+                dispose(file);
+            }, "no-entry");
+            check(
+                root.readlinkAt("missing-parent-link") === "missing/target",
+                "failed create replaced link",
+            );
+        });
+
+        run("relative parent target", () => {
+            root.createDirectoryAt("nested");
+            root.symlinkAt("../target", "nested/parent-link");
+            const file = root.openAt(follow, "nested/parent-link", {}, { read: true });
+            check(readText(file) === "value", "relative target read wrong file");
+            dispose(file);
+            const nested = root.openAt({}, "nested", { directory: true }, { read: true });
+            expectError(() => nested.statAt(follow, "parent-link"), "not-permitted");
+            dispose(nested);
+        });
+
+        run("dot target with configured cwd", () => {
+            root.symlinkAt(".", "self");
+            check(
+                sameHash(root.metadataHashAt(follow, "self"), root.metadataHash()),
+                "dot target resolved to cwd",
+            );
+            root.createDirectoryAt("self/created-dir");
+            check(
+                root.statAt({}, "created-dir").type === "directory",
+                "created directory under cwd",
+            );
+        });
+
+        run("absolute preset target", () => {
+            expectError(() => root.statAt(follow, "absolute"), "not-permitted");
+        });
+
+        run("readlink absolute preset target", () => {
+            expectError(() => root.readlinkAt("absolute"), "not-permitted");
+        });
+
+        run("create through relative target chain", () => {
+            root.createDirectoryAt("creation-dir");
+            root.symlinkAt("creation-dir", "creation-alias");
+            root.symlinkAt("../creation-second", "creation-dir/first");
+            root.symlinkAt("creation-target", "creation-second");
+            const file = root.openAt(
+                follow,
+                "creation-alias/first",
+                { create: true },
+                { write: true },
+            );
+            file.write(new TextEncoder().encode("created through chain"), 0n);
+            dispose(file);
+            check(
+                root.readlinkAt("creation-dir/first") === "../creation-second",
+                "replaced first link",
+            );
+            check(root.readlinkAt("creation-second") === "creation-target", "replaced second link");
+            const target = root.openAt({}, "creation-target", {}, { read: true });
+            check(readText(target) === "created through chain", "created at wrong location");
+            dispose(target);
+        });
+
+        run("parent-relative directory mutations", () => {
+            root.createDirectoryAt("mutation-dir");
+            root.createDirectoryAt("mutation-target");
+            root.symlinkAt("../mutation-target", "mutation-dir/alias");
+            root.createDirectoryAt("mutation-dir/alias/child");
+            root.symlinkAt("child", "mutation-dir/alias/link");
+            root.renameAt("mutation-dir/alias/link", root, "mutation-dir/alias/renamed");
+            check(
+                root.readlinkAt("mutation-target/renamed") === "child",
+                "renamed in wrong directory",
+            );
+            root.unlinkFileAt("mutation-dir/alias/renamed");
+            root.removeDirectoryAt("mutation-dir/alias/child");
+            expectError(() => root.statAt({}, "mutation-target/child"), "no-entry");
+        });
+
+        dispose(root);
+        return JSON.stringify(results);
+    },
+};


### PR DESCRIPTION
Implements symlink-at/readlink-at in `InMemoryFilesystemAdapter`, which previously threw "unsupported" for both. Path resolution (open-at, stat-at, set-times-at, link-at, metadata-hash-at) now follows symlinks per-segment and honors path flags.symlink-follow instead of ignoring it, with cycle detection (loop error) and directory-listing/stat type reporting updated to recognize `symbolic-link` entries.

Symlink targets are always relative, resolved against the directory containing the link — this sandboxed filesystem has no host-absolute root, matching existing path-resolution and the Node backend's behavior.