### PR TITLE
fix(tests): make allowBuilds in the js pnpm-workspace a mapping instead of list

### DIFF
--- a/test/components/js/pnpm-workspace.yaml
+++ b/test/components/js/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 minimumReleaseAge: 10080
 blockExoticSubdeps: true
-allowBuilds: []
+allowBuilds: {}
 
 packages:
   - jco-issue-1390/callee


### PR DESCRIPTION
`allowBuilds` in `test/components/js/pnpm-workspace.yaml` is currently a list, but it is [specified to be a mapping](https://pnpm.io/10.x/settings#allowbuilds) and the current version throws an error for me when running `just build`:

```
Error:   × load configuration
  ╰─▶ Failed to parse pnpm-workspace.yaml at jco/test/components/js/pnpm-workspace.yaml: error: line 3 column 14: unexpected event: expected mapping start
       --> <input>:3:14
        |
      1 | minimumReleaseAge: 10080
      2 | blockExoticSubdeps: true
      3 | allowBuilds: []
        |              ^ unexpected event: expected mapping start
      4 |
      5 | packages:
        |
```

We could probably also just remove it, whichever.