### PR TITLE
feat(p2-shim): add opfs filesystem adapter

### DIFF
--- a/packages/preview2-shim/src/browser/filesystem.ts
+++ b/packages/preview2-shim/src/browser/filesystem.ts
@@ -8,6 +8,8 @@ import { _setCwd } from "./config.js";
 export { _setCwd } from "./config.js";
 export { InMemoryFilesystemAdapter } from "./in-memory-filesystem.js";
 export type { FileData, FileDataEntry } from "./in-memory-filesystem.js";
+export { OpfsFilesystemAdapter, loadOpfsCapability } from "./opfs-filesystem.js";
+export type { OpfsCapability } from "./opfs-filesystem.js";
 
 type Filesize = TypesNamespace.Filesize;
 type OpenFlags = TypesNamespace.OpenFlags;

--- a/packages/preview2-shim/src/browser/filesystem.ts
+++ b/packages/preview2-shim/src/browser/filesystem.ts
@@ -342,6 +342,27 @@ export function _addPreopen(virtualPath: string, fileData: FileData): void {
     }
 }
 
+/**
+ * Add a single preopen backed by a custom adapter (e.g. `OpfsFilesystemAdapter`) instead of the
+ * default in-memory one. Lets a host wire an alternative `BrowserFilesystemAdapter` into the
+ * top-level `wasi:filesystem/preopens` singleton that transpiled components import statically.
+ * @param virtualPath - The virtual path visible to the guest
+ * @param adapter - The adapter that will back this preopen
+ * @param capability - The adapter-specific capability to load as the preopen's root
+ */
+export function _addPreopenWithAdapter<Capability>(
+    virtualPath: string,
+    adapter: BrowserFilesystemAdapter<Capability>,
+    capability: Capability,
+): void {
+    const descriptor = descriptorCreate(adapter.getRoot(capability));
+    const entry: [Descriptor, string] = [descriptor, virtualPath];
+    _preopens.push(entry);
+    if (virtualPath === "/") {
+        _rootPreopen = entry;
+    }
+}
+
 /** Clear all preopens, giving the guest no filesystem access. */
 export function _clearPreopens(): void {
     _preopens = [];

--- a/packages/preview2-shim/src/browser/filesystem.ts
+++ b/packages/preview2-shim/src/browser/filesystem.ts
@@ -38,6 +38,18 @@ export interface BrowserFilesystemDescriptor extends Omit<
     ): BrowserFilesystemDescriptor;
     renameAt(oldPath: string, newDescriptor: BrowserFilesystemDescriptor, newPath: string): void;
     isSameObject(other: BrowserFilesystemDescriptor): boolean;
+
+    /**
+     * Advisory locking, for host application code holding a descriptor directly
+     * (not part of the WASI guest-facing surface). Adapters that support it should
+     * implement all five; `tryLock*` return whether the lock was acquired instead
+     * of throwing.
+     */
+    lockShared?(): void;
+    lockExclusive?(): void;
+    tryLockShared?(): boolean;
+    tryLockExclusive?(): boolean;
+    unlock?(): void;
 }
 
 export interface BrowserFilesystemAdapter<Capability = unknown> {
@@ -219,6 +231,26 @@ class Descriptor implements TypesNamespace.Descriptor {
 
     metadataHashAt(pathFlags: PathFlags, path: string) {
         return this.#implementation.metadataHashAt(pathFlags, path);
+    }
+
+    lockShared() {
+        return this.#implementation.lockShared?.();
+    }
+
+    lockExclusive() {
+        return this.#implementation.lockExclusive?.();
+    }
+
+    tryLockShared() {
+        return this.#implementation.tryLockShared?.() ?? false;
+    }
+
+    tryLockExclusive() {
+        return this.#implementation.tryLockExclusive?.() ?? false;
+    }
+
+    unlock() {
+        return this.#implementation.unlock?.();
     }
 }
 

--- a/packages/preview2-shim/src/browser/in-memory-filesystem.ts
+++ b/packages/preview2-shim/src/browser/in-memory-filesystem.ts
@@ -518,7 +518,7 @@ class Descriptor implements BrowserFilesystemDescriptor {
             throw "not-permitted";
         }
         const [newParent, newName] = getParentEntry(
-            descriptorGetEntry(newDescriptor as Descriptor),
+            descriptorGetEntry(unwrapDescriptor(newDescriptor) as Descriptor),
             newPath,
         );
         if (newParent.dir![newName]) {
@@ -608,7 +608,7 @@ class Descriptor implements BrowserFilesystemDescriptor {
             throw "no-entry";
         }
         const [newParent, newName] = getParentEntry(
-            descriptorGetEntry(newDescriptor as Descriptor),
+            descriptorGetEntry(unwrapDescriptor(newDescriptor) as Descriptor),
             newPath,
         );
         const replaced = newParent.dir![newName];
@@ -667,7 +667,7 @@ class Descriptor implements BrowserFilesystemDescriptor {
     }
 
     isSameObject(other: BrowserFilesystemDescriptor) {
-        return descriptorGetEntry(other as Descriptor) === this.#entry;
+        return descriptorGetEntry(unwrapDescriptor(other) as Descriptor) === this.#entry;
     }
 
     metadataHash() {
@@ -740,6 +740,29 @@ delete Descriptor.prototype._getEntry;
 const descriptorCreate = Descriptor._create;
 // @ts-expect-error - Deleting static method
 delete Descriptor._create;
+
+/**
+ * Well-known symbol a `BrowserFilesystemDescriptor` wrapper (e.g. the cross-tab-locking
+ * `Proxy` from `OpfsFilesystemAdapter`) can implement to hand back the real descriptor it
+ * wraps. `renameAt`/`linkAt`/`isSameObject` reach into a *second* descriptor argument's
+ * private `#entry` field directly - private-field access bypasses `Proxy` traps and fails
+ * its brand check against a wrapper, so a wrapper must be unwrapped via ordinary property
+ * access (which a `Proxy` handles correctly) before that field access happens.
+ */
+export const UNWRAP_DESCRIPTOR: unique symbol = Symbol("browserFilesystemDescriptor.unwrap");
+
+function unwrapDescriptor(descriptor: BrowserFilesystemDescriptor): BrowserFilesystemDescriptor {
+    let current = descriptor;
+    for (;;) {
+        const inner = (current as unknown as Record<symbol, unknown>)[UNWRAP_DESCRIPTOR] as
+            | BrowserFilesystemDescriptor
+            | undefined;
+        if (!inner || inner === current) {
+            return current;
+        }
+        current = inner;
+    }
+}
 
 /** Explicit ephemeral storage adapter for browser applications and tests. */
 export class InMemoryFilesystemAdapter implements BrowserFilesystemAdapter<FileData> {

--- a/packages/preview2-shim/src/browser/in-memory-filesystem.ts
+++ b/packages/preview2-shim/src/browser/in-memory-filesystem.ts
@@ -211,6 +211,22 @@ function metadata(entry: FileDataEntry): EntryMetadata {
     return value;
 }
 
+interface LockState {
+    exclusiveHolder: Descriptor | null;
+    sharedHolders: Set<Descriptor>;
+}
+
+const fileLocks = new WeakMap<FileDataEntry, LockState>();
+
+function lockState(entry: FileDataEntry): LockState {
+    let state = fileLocks.get(entry);
+    if (!state) {
+        state = { exclusiveHolder: null, sharedHolders: new Set() };
+        fileLocks.set(entry, state);
+    }
+    return state;
+}
+
 function touch(entry: FileDataEntry): void {
     metadata(entry).version++;
 }
@@ -646,6 +662,59 @@ class Descriptor implements BrowserFilesystemDescriptor {
     metadataHashAt(pathFlags: PathFlags, path: string) {
         const value = metadata(getChildEntry(this.#entry, path, pathFlags.symlinkFollow));
         return { upper: value.id, lower: value.version };
+    }
+
+    /**
+     * Default advisory-locking implementation: a same-process reader/writer lock
+     * keyed on the underlying entry. There's no real contention to wait out in a
+     * single-threaded environment, so `lockShared`/`lockExclusive` don't block -
+     * they throw `would-block` immediately when the lock isn't free, same as the
+     * `tryLock*` variants report `false`.
+     */
+    tryLockShared(): boolean {
+        const state = lockState(this.#entry);
+        if (state.exclusiveHolder && state.exclusiveHolder !== this) {
+            return false;
+        }
+        state.sharedHolders.add(this);
+        return true;
+    }
+
+    tryLockExclusive(): boolean {
+        const state = lockState(this.#entry);
+        if (state.exclusiveHolder && state.exclusiveHolder !== this) {
+            return false;
+        }
+        const otherReaders = state.sharedHolders.size - (state.sharedHolders.has(this) ? 1 : 0);
+        if (otherReaders > 0) {
+            return false;
+        }
+        state.sharedHolders.delete(this);
+        state.exclusiveHolder = this;
+        return true;
+    }
+
+    lockShared(): void {
+        if (!this.tryLockShared()) {
+            throw "would-block";
+        }
+    }
+
+    lockExclusive(): void {
+        if (!this.tryLockExclusive()) {
+            throw "would-block";
+        }
+    }
+
+    unlock(): void {
+        const state = fileLocks.get(this.#entry);
+        if (!state) {
+            return;
+        }
+        state.sharedHolders.delete(this);
+        if (state.exclusiveHolder === this) {
+            state.exclusiveHolder = null;
+        }
     }
 }
 

--- a/packages/preview2-shim/src/browser/in-memory-filesystem.ts
+++ b/packages/preview2-shim/src/browser/in-memory-filesystem.ts
@@ -227,8 +227,24 @@ function lockState(entry: FileDataEntry): LockState {
     return state;
 }
 
+const touchListeners = new Set<(entry: FileDataEntry) => void>();
+
+/**
+ * Subscribe to every mutation across every in-memory tree (regardless of which
+ * adapter loaded it). Lets a persistence layer (e.g. `OpfsFilesystemAdapter`)
+ * react to writes without wrapping every mutating method individually. Returns
+ * an unsubscribe function.
+ */
+export function _onTouch(listener: (entry: FileDataEntry) => void): () => void {
+    touchListeners.add(listener);
+    return () => touchListeners.delete(listener);
+}
+
 function touch(entry: FileDataEntry): void {
     metadata(entry).version++;
+    for (const listener of touchListeners) {
+        listener(entry);
+    }
 }
 
 function getFileWriteBuffer(

--- a/packages/preview2-shim/src/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/src/browser/opfs-filesystem.ts
@@ -1,5 +1,5 @@
 import type { BrowserFilesystemAdapter, BrowserFilesystemDescriptor } from "./filesystem.js";
-import { InMemoryFilesystemAdapter, _onTouch } from "./in-memory-filesystem.js";
+import { InMemoryFilesystemAdapter, UNWRAP_DESCRIPTOR, _onTouch } from "./in-memory-filesystem.js";
 import type { FileData, FileDataEntry } from "./in-memory-filesystem.js";
 
 /**
@@ -218,6 +218,9 @@ function withCrossTabLocking(
 
     return new Proxy(descriptor, {
         get(target, prop, receiver) {
+            if (prop === UNWRAP_DESCRIPTOR) {
+                return target;
+            }
             const value = Reflect.get(target, prop, receiver);
             if (prop === "openAt") {
                 return (...args: Parameters<BrowserFilesystemDescriptor["openAt"]>) => {

--- a/packages/preview2-shim/src/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/src/browser/opfs-filesystem.ts
@@ -19,9 +19,79 @@ type IterableDirectoryHandle = FileSystemDirectoryHandle & {
     entries(): AsyncIterableIterator<[string, FileSystemFileHandle | FileSystemDirectoryHandle]>;
 };
 
+// OPFS has no native symlink concept. All symlinks under a root are recorded in a
+// single hidden sidecar file at that root, keyed by their path relative to it, so
+// they survive a flush + reload instead of only living for the lifetime of one
+// capability.
+const SYMLINKS_FILE = ".__wasi_symlinks__.json";
+
+async function readSymlinksFile(handle: FileSystemDirectoryHandle): Promise<Record<string, string>> {
+    try {
+        const fileHandle = await handle.getFileHandle(SYMLINKS_FILE);
+        const file = await fileHandle.getFile();
+        return JSON.parse(await file.text());
+    } catch {
+        return {};
+    }
+}
+
+async function writeSymlinksFile(
+    handle: FileSystemDirectoryHandle,
+    symlinks: Record<string, string>,
+): Promise<void> {
+    if (Object.keys(symlinks).length === 0) {
+        try {
+            await handle.removeEntry(SYMLINKS_FILE);
+        } catch {
+            // no sidecar to remove
+        }
+        return;
+    }
+    const fileHandle = await handle.getFileHandle(SYMLINKS_FILE, { create: true });
+    const writable = await fileHandle.createWritable();
+    await writable.write(JSON.stringify(symlinks));
+    await writable.close();
+}
+
+/** Collect every symlink under `dir` into a flat path -> target map, relative to `dir` itself. */
+function collectSymlinks(dir: Record<string, FileDataEntry>, prefix: string, out: Record<string, string>): void {
+    for (const [name, entry] of Object.entries(dir)) {
+        const path = prefix ? `${prefix}/${name}` : name;
+        if (entry.symlink !== undefined) {
+            out[path] = entry.symlink;
+        } else if (entry.dir) {
+            collectSymlinks(entry.dir, path, out);
+        }
+    }
+}
+
+/** Place each recorded symlink back into the tree at its path, skipping any path whose parent is missing. */
+function injectSymlinks(root: Record<string, FileDataEntry>, symlinks: Record<string, string>): void {
+    for (const [path, target] of Object.entries(symlinks)) {
+        const parts = path.split("/").filter(Boolean);
+        const name = parts.pop();
+        if (!name) {
+            continue;
+        }
+        let dir: Record<string, FileDataEntry> | undefined = root;
+        for (const part of parts) {
+            dir = dir[part]?.dir;
+            if (!dir) {
+                break;
+            }
+        }
+        if (dir && !(name in dir)) {
+            dir[name] = { symlink: target };
+        }
+    }
+}
+
 async function readEntries(handle: FileSystemDirectoryHandle): Promise<Record<string, FileDataEntry>> {
     const dir: Record<string, FileDataEntry> = {};
     for await (const [name, child] of (handle as IterableDirectoryHandle).entries()) {
+        if (name === SYMLINKS_FILE) {
+            continue;
+        }
         if (child.kind === "directory") {
             dir[name] = { dir: await readEntries(child) };
         } else {
@@ -34,6 +104,7 @@ async function readEntries(handle: FileSystemDirectoryHandle): Promise<Record<st
 
 async function writeEntries(handle: FileSystemDirectoryHandle, dir: Record<string, FileDataEntry>): Promise<void> {
     const seen = new Set(Object.keys(dir));
+    seen.add(SYMLINKS_FILE);
     for await (const [name] of (handle as IterableDirectoryHandle).entries()) {
         if (!seen.has(name)) {
             await handle.removeEntry(name, { recursive: true });
@@ -41,8 +112,7 @@ async function writeEntries(handle: FileSystemDirectoryHandle, dir: Record<strin
     }
     for (const [name, entry] of Object.entries(dir)) {
         if (entry.symlink !== undefined) {
-            // OPFS has no native symlink concept; symlinks stay in-memory only
-            // for the lifetime of this capability.
+            // Recorded separately in the root's symlink sidecar file.
             continue;
         }
         if (entry.dir) {
@@ -60,16 +130,20 @@ async function writeEntries(handle: FileSystemDirectoryHandle, dir: Record<strin
 
 /** Load an OPFS directory into an in-memory tree, ready to hand to `OpfsFilesystemAdapter.getRoot`. */
 export async function loadOpfsCapability(handle: FileSystemDirectoryHandle): Promise<OpfsCapability> {
-    return { handle, data: { dir: await readEntries(handle) } };
+    const dir = await readEntries(handle);
+    injectSymlinks(dir, await readSymlinksFile(handle));
+    return { handle, data: { dir } };
 }
 
 /**
  * Browser filesystem adapter backed by the Origin Private File System.
  *
- * Every guest-facing `Descriptor` operation is delegated to `InMemoryFilesystemAdapter`
- * and stays synchronous. Persistence to OPFS only happens at the edges: load the
- * tree once via `loadOpfsCapability`, then call `flush()` (or `dispose()`) to write
- * the accumulated in-memory changes back out.
+ * Every guest-facing `Descriptor` operation - including advisory locking, which
+ * comes for free as `InMemoryFilesystemAdapter`'s same-process reader/writer lock -
+ * is delegated to `InMemoryFilesystemAdapter` and stays synchronous. Persistence to
+ * OPFS only happens at the edges: load the tree once via `loadOpfsCapability`, then
+ * call `flush()` (or `dispose()`) to write the accumulated in-memory changes back
+ * out, including symlinks via a single hidden sidecar file at each root.
  */
 export class OpfsFilesystemAdapter implements BrowserFilesystemAdapter<OpfsCapability> {
     #inMemory = new InMemoryFilesystemAdapter();
@@ -82,7 +156,15 @@ export class OpfsFilesystemAdapter implements BrowserFilesystemAdapter<OpfsCapab
 
     /** Persist every loaded root's current in-memory state back to OPFS. */
     async flush(): Promise<void> {
-        await Promise.all(this.#roots.map((root) => writeEntries(root.handle, root.data.dir ?? {})));
+        await Promise.all(
+            this.#roots.map(async (root) => {
+                const dir = root.data.dir ?? {};
+                await writeEntries(root.handle, dir);
+                const symlinks: Record<string, string> = {};
+                collectSymlinks(dir, "", symlinks);
+                await writeSymlinksFile(root.handle, symlinks);
+            }),
+        );
     }
 
     dispose(): void {

--- a/packages/preview2-shim/src/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/src/browser/opfs-filesystem.ts
@@ -151,7 +151,6 @@ export async function loadOpfsCapability(
     return { handle, data: { dir } };
 }
 
-type LockMode = "shared" | "exclusive";
 const LOCK_METHODS = new Set([
     "lockShared",
     "lockExclusive",
@@ -180,20 +179,16 @@ function joinLockPath(base: string, segment: string): string {
     return path;
 }
 
-/** The slice of `navigator.locks` this adapter needs - narrow enough to fake in tests or other hosts. */
-export interface NavigatorLocks {
-    locks: {
-        request(
-            name: string,
-            options: { mode: "shared" | "exclusive" },
-            callback: () => Promise<void>,
-        ): Promise<void>;
-    };
-}
+/**
+ * The slice of `LockManager` this adapter needs - narrow enough to fake in tests or other hosts.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/LockManager
+ */
+export interface BrowserLockManager extends Omit<LockManager, "query"> {}
 
 /**
  * Wrap a descriptor so its advisory locking also makes a best-effort request against
- * `navigator.locks`, in addition to the default same-process reader/writer lock.
+ * `BrowserLockManager`, in addition to the default same-process reader/writer lock.
  * The Web Locks request is fire-and-forget - there's no way to block a synchronous
  * `lockExclusive()` on a cross-tab grant without JSPI, so this only coordinates
  * tabs that are already idle/cooperating.
@@ -201,15 +196,15 @@ export interface NavigatorLocks {
 function withCrossTabLocking(
     descriptor: BrowserFilesystemDescriptor,
     lockName: string,
-    navigator: NavigatorLocks | undefined,
+    lockManager: BrowserLockManager | undefined,
 ): BrowserFilesystemDescriptor {
     let release: (() => void) | null = null;
 
     function requestCrossTabLock(mode: LockMode): void {
-        if (!navigator?.locks) {
+        if (!lockManager) {
             return;
         }
-        navigator.locks
+        lockManager
             .request(lockName, { mode }, () => new Promise<void>((resolve) => (release = resolve)))
             .catch(() => {
                 // best-effort only; local same-process locking already enforced correctness
@@ -234,7 +229,7 @@ function withCrossTabLocking(
                     return withCrossTabLocking(
                         child as BrowserFilesystemDescriptor,
                         joinLockPath(lockName, args[1]),
-                        navigator,
+                        lockManager,
                     );
                 };
             }
@@ -261,17 +256,12 @@ function withCrossTabLocking(
 export interface OpfsFilesystemAdapterOptions {
     /**
      * Also make advisory locks (`lockShared`/`lockExclusive`/`tryLock*`/`unlock`) request a
-     * matching `navigator.locks` lock, so tabs sharing the same OPFS root get best-effort
-     * cross-tab coordination on top of the default same-process reader/writer lock.
-     * Off by default.
+     * matching lock from the given `BrowserLockManager` (usually the global `navigator.locks`,
+     * or a fake in tests), so tabs sharing the same OPFS root get best-effort cross-tab
+     * coordination on top of the default same-process reader/writer lock. Omit to keep locking
+     * same-process only - off by default.
      */
-    crossTabLocking?: boolean;
-    /**
-     * The `navigator` to request cross-tab locks against when `crossTabLocking` is enabled.
-     * Defaults to the global `navigator`. Overriding this is mainly useful for tests, since
-     * a real browser only ever has one.
-     */
-    navigator?: NavigatorLocks;
+    lockManager?: BrowserLockManager;
 }
 
 /**
@@ -283,27 +273,26 @@ export interface OpfsFilesystemAdapterOptions {
  * OPFS happens automatically shortly after any mutation (debounced to a microtask,
  * so a burst of writes only triggers one round-trip); `flush()`/`dispose()` remain
  * available to force it explicitly, e.g. before navigating away.
+ *
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system
  */
 export class OpfsFilesystemAdapter implements BrowserFilesystemAdapter<OpfsCapability> {
     #inMemory = new InMemoryFilesystemAdapter();
     #roots: OpfsCapability[] = [];
-    #crossTabLocking: boolean;
-    #navigator: NavigatorLocks | undefined;
+    #lockManager: BrowserLockManager | undefined;
     #flushScheduled = false;
     #unsubscribeTouch: () => void;
 
     constructor(options: OpfsFilesystemAdapterOptions = {}) {
-        this.#crossTabLocking = options.crossTabLocking ?? false;
-        this.#navigator =
-            options.navigator ?? (typeof navigator === "undefined" ? undefined : navigator);
+        this.#lockManager = options.lockManager;
         this.#unsubscribeTouch = _onTouch(() => this.#scheduleFlush());
     }
 
     getRoot(capability: OpfsCapability): BrowserFilesystemDescriptor {
         this.#roots.push(capability);
         const descriptor = this.#inMemory.getRoot(capability.data);
-        return this.#crossTabLocking
-            ? withCrossTabLocking(descriptor, capability.handle.name, this.#navigator)
+        return this.#lockManager
+            ? withCrossTabLocking(descriptor, capability.handle.name, this.#lockManager)
             : descriptor;
     }
 

--- a/packages/preview2-shim/src/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/src/browser/opfs-filesystem.ts
@@ -25,7 +25,9 @@ type IterableDirectoryHandle = FileSystemDirectoryHandle & {
 // capability.
 const SYMLINKS_FILE = ".__wasi_symlinks__.json";
 
-async function readSymlinksFile(handle: FileSystemDirectoryHandle): Promise<Record<string, string>> {
+async function readSymlinksFile(
+    handle: FileSystemDirectoryHandle,
+): Promise<Record<string, string>> {
     try {
         const fileHandle = await handle.getFileHandle(SYMLINKS_FILE);
         const file = await fileHandle.getFile();
@@ -54,7 +56,11 @@ async function writeSymlinksFile(
 }
 
 /** Collect every symlink under `dir` into a flat path -> target map, relative to `dir` itself. */
-function collectSymlinks(dir: Record<string, FileDataEntry>, prefix: string, out: Record<string, string>): void {
+function collectSymlinks(
+    dir: Record<string, FileDataEntry>,
+    prefix: string,
+    out: Record<string, string>,
+): void {
     for (const [name, entry] of Object.entries(dir)) {
         const path = prefix ? `${prefix}/${name}` : name;
         if (entry.symlink !== undefined) {
@@ -66,7 +72,10 @@ function collectSymlinks(dir: Record<string, FileDataEntry>, prefix: string, out
 }
 
 /** Place each recorded symlink back into the tree at its path, skipping any path whose parent is missing. */
-function injectSymlinks(root: Record<string, FileDataEntry>, symlinks: Record<string, string>): void {
+function injectSymlinks(
+    root: Record<string, FileDataEntry>,
+    symlinks: Record<string, string>,
+): void {
     for (const [path, target] of Object.entries(symlinks)) {
         const parts = path.split("/").filter(Boolean);
         const name = parts.pop();
@@ -86,7 +95,9 @@ function injectSymlinks(root: Record<string, FileDataEntry>, symlinks: Record<st
     }
 }
 
-async function readEntries(handle: FileSystemDirectoryHandle): Promise<Record<string, FileDataEntry>> {
+async function readEntries(
+    handle: FileSystemDirectoryHandle,
+): Promise<Record<string, FileDataEntry>> {
     const dir: Record<string, FileDataEntry> = {};
     for await (const [name, child] of (handle as IterableDirectoryHandle).entries()) {
         if (name === SYMLINKS_FILE) {
@@ -102,7 +113,10 @@ async function readEntries(handle: FileSystemDirectoryHandle): Promise<Record<st
     return dir;
 }
 
-async function writeEntries(handle: FileSystemDirectoryHandle, dir: Record<string, FileDataEntry>): Promise<void> {
+async function writeEntries(
+    handle: FileSystemDirectoryHandle,
+    dir: Record<string, FileDataEntry>,
+): Promise<void> {
     const seen = new Set(Object.keys(dir));
     seen.add(SYMLINKS_FILE);
     for await (const [name] of (handle as IterableDirectoryHandle).entries()) {
@@ -129,14 +143,22 @@ async function writeEntries(handle: FileSystemDirectoryHandle, dir: Record<strin
 }
 
 /** Load an OPFS directory into an in-memory tree, ready to hand to `OpfsFilesystemAdapter.getRoot`. */
-export async function loadOpfsCapability(handle: FileSystemDirectoryHandle): Promise<OpfsCapability> {
+export async function loadOpfsCapability(
+    handle: FileSystemDirectoryHandle,
+): Promise<OpfsCapability> {
     const dir = await readEntries(handle);
     injectSymlinks(dir, await readSymlinksFile(handle));
     return { handle, data: { dir } };
 }
 
 type LockMode = "shared" | "exclusive";
-const LOCK_METHODS = new Set(["lockShared", "lockExclusive", "tryLockShared", "tryLockExclusive", "unlock"]);
+const LOCK_METHODS = new Set([
+    "lockShared",
+    "lockExclusive",
+    "tryLockShared",
+    "tryLockExclusive",
+    "unlock",
+]);
 
 function lockModeOf(prop: string): LockMode {
     return prop.endsWith("Exclusive") ? "exclusive" : "shared";
@@ -158,6 +180,17 @@ function joinLockPath(base: string, segment: string): string {
     return path;
 }
 
+/** The slice of `navigator.locks` this adapter needs - narrow enough to fake in tests or other hosts. */
+export interface NavigatorLocks {
+    locks: {
+        request(
+            name: string,
+            options: { mode: "shared" | "exclusive" },
+            callback: () => Promise<void>,
+        ): Promise<void>;
+    };
+}
+
 /**
  * Wrap a descriptor so its advisory locking also makes a best-effort request against
  * `navigator.locks`, in addition to the default same-process reader/writer lock.
@@ -165,11 +198,15 @@ function joinLockPath(base: string, segment: string): string {
  * `lockExclusive()` on a cross-tab grant without JSPI, so this only coordinates
  * tabs that are already idle/cooperating.
  */
-function withCrossTabLocking(descriptor: BrowserFilesystemDescriptor, lockName: string): BrowserFilesystemDescriptor {
+function withCrossTabLocking(
+    descriptor: BrowserFilesystemDescriptor,
+    lockName: string,
+    navigator: NavigatorLocks | undefined,
+): BrowserFilesystemDescriptor {
     let release: (() => void) | null = null;
 
     function requestCrossTabLock(mode: LockMode): void {
-        if (typeof navigator === "undefined" || !navigator.locks) {
+        if (!navigator?.locks) {
             return;
         }
         navigator.locks
@@ -189,10 +226,15 @@ function withCrossTabLocking(descriptor: BrowserFilesystemDescriptor, lockName: 
             const value = Reflect.get(target, prop, receiver);
             if (prop === "openAt") {
                 return (...args: Parameters<BrowserFilesystemDescriptor["openAt"]>) => {
-                    const child = Reflect.apply(value as (...a: unknown[]) => unknown, target, args);
+                    const child = Reflect.apply(
+                        value as (...a: unknown[]) => unknown,
+                        target,
+                        args,
+                    );
                     return withCrossTabLocking(
                         child as BrowserFilesystemDescriptor,
                         joinLockPath(lockName, args[1]),
+                        navigator,
                     );
                 };
             }
@@ -224,6 +266,12 @@ export interface OpfsFilesystemAdapterOptions {
      * Off by default.
      */
     crossTabLocking?: boolean;
+    /**
+     * The `navigator` to request cross-tab locks against when `crossTabLocking` is enabled.
+     * Defaults to the global `navigator`. Overriding this is mainly useful for tests, since
+     * a real browser only ever has one.
+     */
+    navigator?: NavigatorLocks;
 }
 
 /**
@@ -240,18 +288,23 @@ export class OpfsFilesystemAdapter implements BrowserFilesystemAdapter<OpfsCapab
     #inMemory = new InMemoryFilesystemAdapter();
     #roots: OpfsCapability[] = [];
     #crossTabLocking: boolean;
+    #navigator: NavigatorLocks | undefined;
     #flushScheduled = false;
     #unsubscribeTouch: () => void;
 
     constructor(options: OpfsFilesystemAdapterOptions = {}) {
         this.#crossTabLocking = options.crossTabLocking ?? false;
+        this.#navigator =
+            options.navigator ?? (typeof navigator === "undefined" ? undefined : navigator);
         this.#unsubscribeTouch = _onTouch(() => this.#scheduleFlush());
     }
 
     getRoot(capability: OpfsCapability): BrowserFilesystemDescriptor {
         this.#roots.push(capability);
         const descriptor = this.#inMemory.getRoot(capability.data);
-        return this.#crossTabLocking ? withCrossTabLocking(descriptor, capability.handle.name) : descriptor;
+        return this.#crossTabLocking
+            ? withCrossTabLocking(descriptor, capability.handle.name, this.#navigator)
+            : descriptor;
     }
 
     #scheduleFlush(): void {

--- a/packages/preview2-shim/src/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/src/browser/opfs-filesystem.ts
@@ -1,5 +1,5 @@
 import type { BrowserFilesystemAdapter, BrowserFilesystemDescriptor } from "./filesystem.js";
-import { InMemoryFilesystemAdapter } from "./in-memory-filesystem.js";
+import { InMemoryFilesystemAdapter, _onTouch } from "./in-memory-filesystem.js";
 import type { FileData, FileDataEntry } from "./in-memory-filesystem.js";
 
 /**
@@ -135,23 +135,134 @@ export async function loadOpfsCapability(handle: FileSystemDirectoryHandle): Pro
     return { handle, data: { dir } };
 }
 
+type LockMode = "shared" | "exclusive";
+const LOCK_METHODS = new Set(["lockShared", "lockExclusive", "tryLockShared", "tryLockExclusive", "unlock"]);
+
+function lockModeOf(prop: string): LockMode {
+    return prop.endsWith("Exclusive") ? "exclusive" : "shared";
+}
+
+/** Join an OPFS-relative path onto an existing one, for naming a cross-tab lock. */
+function joinLockPath(base: string, segment: string): string {
+    let path = base;
+    for (const part of segment.split("/")) {
+        if (part === "" || part === ".") {
+            continue;
+        }
+        if (part === "..") {
+            path = path.slice(0, path.lastIndexOf("/"));
+            continue;
+        }
+        path = path ? `${path}/${part}` : part;
+    }
+    return path;
+}
+
+/**
+ * Wrap a descriptor so its advisory locking also makes a best-effort request against
+ * `navigator.locks`, in addition to the default same-process reader/writer lock.
+ * The Web Locks request is fire-and-forget - there's no way to block a synchronous
+ * `lockExclusive()` on a cross-tab grant without JSPI, so this only coordinates
+ * tabs that are already idle/cooperating.
+ */
+function withCrossTabLocking(descriptor: BrowserFilesystemDescriptor, lockName: string): BrowserFilesystemDescriptor {
+    let release: (() => void) | null = null;
+
+    function requestCrossTabLock(mode: LockMode): void {
+        if (typeof navigator === "undefined" || !navigator.locks) {
+            return;
+        }
+        navigator.locks
+            .request(lockName, { mode }, () => new Promise<void>((resolve) => (release = resolve)))
+            .catch(() => {
+                // best-effort only; local same-process locking already enforced correctness
+            });
+    }
+
+    function releaseCrossTabLock(): void {
+        release?.();
+        release = null;
+    }
+
+    return new Proxy(descriptor, {
+        get(target, prop, receiver) {
+            const value = Reflect.get(target, prop, receiver);
+            if (prop === "openAt") {
+                return (...args: Parameters<BrowserFilesystemDescriptor["openAt"]>) => {
+                    const child = Reflect.apply(value as (...a: unknown[]) => unknown, target, args);
+                    return withCrossTabLocking(
+                        child as BrowserFilesystemDescriptor,
+                        joinLockPath(lockName, args[1]),
+                    );
+                };
+            }
+            if (typeof prop === "string" && LOCK_METHODS.has(prop) && typeof value === "function") {
+                return (...args: unknown[]) => {
+                    const result = Reflect.apply(value, target, args);
+                    if (prop === "unlock") {
+                        releaseCrossTabLock();
+                    } else if (prop.startsWith("tryLock")) {
+                        if (result) {
+                            requestCrossTabLock(lockModeOf(prop));
+                        }
+                    } else {
+                        requestCrossTabLock(lockModeOf(prop));
+                    }
+                    return result;
+                };
+            }
+            return typeof value === "function" ? value.bind(target) : value;
+        },
+    });
+}
+
+export interface OpfsFilesystemAdapterOptions {
+    /**
+     * Also make advisory locks (`lockShared`/`lockExclusive`/`tryLock*`/`unlock`) request a
+     * matching `navigator.locks` lock, so tabs sharing the same OPFS root get best-effort
+     * cross-tab coordination on top of the default same-process reader/writer lock.
+     * Off by default.
+     */
+    crossTabLocking?: boolean;
+}
+
 /**
  * Browser filesystem adapter backed by the Origin Private File System.
  *
  * Every guest-facing `Descriptor` operation - including advisory locking, which
  * comes for free as `InMemoryFilesystemAdapter`'s same-process reader/writer lock -
  * is delegated to `InMemoryFilesystemAdapter` and stays synchronous. Persistence to
- * OPFS only happens at the edges: load the tree once via `loadOpfsCapability`, then
- * call `flush()` (or `dispose()`) to write the accumulated in-memory changes back
- * out, including symlinks via a single hidden sidecar file at each root.
+ * OPFS happens automatically shortly after any mutation (debounced to a microtask,
+ * so a burst of writes only triggers one round-trip); `flush()`/`dispose()` remain
+ * available to force it explicitly, e.g. before navigating away.
  */
 export class OpfsFilesystemAdapter implements BrowserFilesystemAdapter<OpfsCapability> {
     #inMemory = new InMemoryFilesystemAdapter();
     #roots: OpfsCapability[] = [];
+    #crossTabLocking: boolean;
+    #flushScheduled = false;
+    #unsubscribeTouch: () => void;
+
+    constructor(options: OpfsFilesystemAdapterOptions = {}) {
+        this.#crossTabLocking = options.crossTabLocking ?? false;
+        this.#unsubscribeTouch = _onTouch(() => this.#scheduleFlush());
+    }
 
     getRoot(capability: OpfsCapability): BrowserFilesystemDescriptor {
         this.#roots.push(capability);
-        return this.#inMemory.getRoot(capability.data);
+        const descriptor = this.#inMemory.getRoot(capability.data);
+        return this.#crossTabLocking ? withCrossTabLocking(descriptor, capability.handle.name) : descriptor;
+    }
+
+    #scheduleFlush(): void {
+        if (this.#flushScheduled) {
+            return;
+        }
+        this.#flushScheduled = true;
+        queueMicrotask(() => {
+            this.#flushScheduled = false;
+            void this.flush();
+        });
     }
 
     /** Persist every loaded root's current in-memory state back to OPFS. */
@@ -168,6 +279,7 @@ export class OpfsFilesystemAdapter implements BrowserFilesystemAdapter<OpfsCapab
     }
 
     dispose(): void {
+        this.#unsubscribeTouch();
         void this.flush();
     }
 }

--- a/packages/preview2-shim/src/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/src/browser/opfs-filesystem.ts
@@ -1,0 +1,91 @@
+import type { BrowserFilesystemAdapter, BrowserFilesystemDescriptor } from "./filesystem.js";
+import { InMemoryFilesystemAdapter } from "./in-memory-filesystem.js";
+import type { FileData, FileDataEntry } from "./in-memory-filesystem.js";
+
+/**
+ * A directory handle paired with the in-memory tree it was loaded into.
+ * `getRoot` hands the `data` half straight to `InMemoryFilesystemAdapter`, so every
+ * guest-visible filesystem operation stays fully synchronous; only the initial load
+ * and the explicit `flush`/`dispose` round-trip to OPFS are async.
+ */
+export interface OpfsCapability {
+    handle: FileSystemDirectoryHandle;
+    data: FileData;
+}
+
+// FileSystemDirectoryHandle is async-iterable per spec, but TypeScript's DOM lib
+// doesn't declare `entries()` yet.
+type IterableDirectoryHandle = FileSystemDirectoryHandle & {
+    entries(): AsyncIterableIterator<[string, FileSystemFileHandle | FileSystemDirectoryHandle]>;
+};
+
+async function readEntries(handle: FileSystemDirectoryHandle): Promise<Record<string, FileDataEntry>> {
+    const dir: Record<string, FileDataEntry> = {};
+    for await (const [name, child] of (handle as IterableDirectoryHandle).entries()) {
+        if (child.kind === "directory") {
+            dir[name] = { dir: await readEntries(child) };
+        } else {
+            const file = await (child as FileSystemFileHandle).getFile();
+            dir[name] = { source: new Uint8Array(await file.arrayBuffer()) };
+        }
+    }
+    return dir;
+}
+
+async function writeEntries(handle: FileSystemDirectoryHandle, dir: Record<string, FileDataEntry>): Promise<void> {
+    const seen = new Set(Object.keys(dir));
+    for await (const [name] of (handle as IterableDirectoryHandle).entries()) {
+        if (!seen.has(name)) {
+            await handle.removeEntry(name, { recursive: true });
+        }
+    }
+    for (const [name, entry] of Object.entries(dir)) {
+        if (entry.symlink !== undefined) {
+            // OPFS has no native symlink concept; symlinks stay in-memory only
+            // for the lifetime of this capability.
+            continue;
+        }
+        if (entry.dir) {
+            await writeEntries(await handle.getDirectoryHandle(name, { create: true }), entry.dir);
+            continue;
+        }
+        const fileHandle = await handle.getFileHandle(name, { create: true });
+        const writable = await fileHandle.createWritable();
+        const source = entry.source ?? new Uint8Array();
+        const bytes = typeof source === "string" ? new TextEncoder().encode(source) : source;
+        await writable.write(bytes.slice());
+        await writable.close();
+    }
+}
+
+/** Load an OPFS directory into an in-memory tree, ready to hand to `OpfsFilesystemAdapter.getRoot`. */
+export async function loadOpfsCapability(handle: FileSystemDirectoryHandle): Promise<OpfsCapability> {
+    return { handle, data: { dir: await readEntries(handle) } };
+}
+
+/**
+ * Browser filesystem adapter backed by the Origin Private File System.
+ *
+ * Every guest-facing `Descriptor` operation is delegated to `InMemoryFilesystemAdapter`
+ * and stays synchronous. Persistence to OPFS only happens at the edges: load the
+ * tree once via `loadOpfsCapability`, then call `flush()` (or `dispose()`) to write
+ * the accumulated in-memory changes back out.
+ */
+export class OpfsFilesystemAdapter implements BrowserFilesystemAdapter<OpfsCapability> {
+    #inMemory = new InMemoryFilesystemAdapter();
+    #roots: OpfsCapability[] = [];
+
+    getRoot(capability: OpfsCapability): BrowserFilesystemDescriptor {
+        this.#roots.push(capability);
+        return this.#inMemory.getRoot(capability.data);
+    }
+
+    /** Persist every loaded root's current in-memory state back to OPFS. */
+    async flush(): Promise<void> {
+        await Promise.all(this.#roots.map((root) => writeEntries(root.handle, root.data.dir ?? {})));
+    }
+
+    dispose(): void {
+        void this.flush();
+    }
+}

--- a/packages/preview2-shim/test/browser/filesystem.ts
+++ b/packages/preview2-shim/test/browser/filesystem.ts
@@ -299,11 +299,14 @@ suite("Browser filesystem", () => {
         assert.deepStrictEqual(calls, ["openAt", "advise", "syncData", "sync"]);
     });
 
-    test("advisory locking: shared locks stack, exclusive locks are exclusive", async () => {
-        const { _setFileData, preopens } = await import("../../src/browser/filesystem.js");
-        _setFileData({ dir: { file: { source: new Uint8Array([1, 2, 3]) } } });
-
-        const [[root]] = preopens.getDirectories();
+    test.concurrent("advisory locking: shared locks stack, exclusive locks are exclusive", async () => {
+        const { createFilesystem, InMemoryFilesystemAdapter } =
+            await import("../../src/browser/filesystem.js");
+        const filesystem = createFilesystem({
+            adapter: new InMemoryFilesystemAdapter(),
+            preopens: { "/": { dir: { file: { source: new Uint8Array([1, 2, 3]) } } } },
+        });
+        const [[root]] = filesystem.preopens.getDirectories();
         const a = root.openAt({}, "file", {}, { read: true }) as any;
         const b = root.openAt({}, "file", {}, { read: true }) as any;
 
@@ -319,11 +322,14 @@ suite("Browser filesystem", () => {
         assert.strictEqual(b.tryLockShared(), true);
     });
 
-    test("advisory locking: lockShared/lockExclusive throw would-block instead of waiting", async () => {
-        const { _setFileData, preopens } = await import("../../src/browser/filesystem.js");
-        _setFileData({ dir: { file: { source: new Uint8Array([1, 2, 3]) } } });
-
-        const [[root]] = preopens.getDirectories();
+    test.concurrent("advisory locking: lockShared/lockExclusive throw would-block instead of waiting", async () => {
+        const { createFilesystem, InMemoryFilesystemAdapter } =
+            await import("../../src/browser/filesystem.js");
+        const filesystem = createFilesystem({
+            adapter: new InMemoryFilesystemAdapter(),
+            preopens: { "/": { dir: { file: { source: new Uint8Array([1, 2, 3]) } } } },
+        });
+        const [[root]] = filesystem.preopens.getDirectories();
         const a = root.openAt({}, "file", {}, { read: true }) as any;
         const b = root.openAt({}, "file", {}, { read: true }) as any;
 

--- a/packages/preview2-shim/test/browser/filesystem.ts
+++ b/packages/preview2-shim/test/browser/filesystem.ts
@@ -298,4 +298,39 @@ suite("Browser filesystem", () => {
 
         assert.deepStrictEqual(calls, ["openAt", "advise", "syncData", "sync"]);
     });
+
+    test("advisory locking: shared locks stack, exclusive locks are exclusive", async () => {
+        const { _setFileData, preopens } = await import("../../src/browser/filesystem.js");
+        _setFileData({ dir: { file: { source: new Uint8Array([1, 2, 3]) } } });
+
+        const [[root]] = preopens.getDirectories();
+        const a = root.openAt({}, "file", {}, { read: true }) as any;
+        const b = root.openAt({}, "file", {}, { read: true }) as any;
+
+        assert.strictEqual(a.tryLockShared(), true);
+        assert.strictEqual(b.tryLockShared(), true);
+        assert.strictEqual(a.tryLockExclusive(), false);
+
+        b.unlock();
+        assert.strictEqual(a.tryLockExclusive(), true);
+        assert.strictEqual(b.tryLockShared(), false);
+
+        a.unlock();
+        assert.strictEqual(b.tryLockShared(), true);
+    });
+
+    test("advisory locking: lockShared/lockExclusive throw would-block instead of waiting", async () => {
+        const { _setFileData, preopens } = await import("../../src/browser/filesystem.js");
+        _setFileData({ dir: { file: { source: new Uint8Array([1, 2, 3]) } } });
+
+        const [[root]] = preopens.getDirectories();
+        const a = root.openAt({}, "file", {}, { read: true }) as any;
+        const b = root.openAt({}, "file", {}, { read: true }) as any;
+
+        a.lockExclusive();
+        assert.throws(() => b.lockShared(), "would-block");
+        assert.throws(() => b.lockExclusive(), "would-block");
+        a.unlock();
+        assert.doesNotThrow(() => b.lockExclusive());
+    });
 });

--- a/packages/preview2-shim/test/browser/opfs-filesystem-e2e.ts
+++ b/packages/preview2-shim/test/browser/opfs-filesystem-e2e.ts
@@ -1,0 +1,112 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { componentize } from "@bytecodealliance/componentize-js";
+import { transpile } from "@bytecodealliance/jco";
+import { assert, beforeAll, suite, test } from "vitest";
+
+import {
+    FIXTURES_WIT_DIR,
+    getTmpDir,
+    runBasicHarnessPageTest,
+    startTestServer,
+} from "../common.js";
+
+suite("browser OPFS filesystem adapter from a component", () => {
+    let results: { writeResult: string; readResult: string };
+
+    beforeAll(async () => {
+        const outDir = await getTmpDir();
+        let harness: Awaited<ReturnType<typeof startTestServer>> | undefined;
+        try {
+            const { component } = await componentize({
+                sourcePath: fileURLToPath(
+                    new URL("../fixtures/browser/opfs-filesystem/component.js", import.meta.url),
+                ),
+                witPath: FIXTURES_WIT_DIR,
+                worldName: "browser-fs-write",
+            });
+            const { files } = await transpile(component, {
+                name: "component",
+                optimize: false,
+                outDir,
+            });
+            for (const [path, bytes] of Object.entries(files)) {
+                await mkdir(dirname(path), { recursive: true });
+                await writeFile(path, bytes);
+            }
+            // Runs the component's `run()` once against a live `OpfsFilesystemAdapter` to
+            // create content, flushes it to real OPFS storage, then reloads that same OPFS
+            // directory into a brand new adapter and runs `run()` again - proving writes and
+            // symlinks made across the component boundary actually survive in OPFS itself,
+            // rather than only in one adapter's in-memory tree.
+            await writeFile(
+                join(outDir, "configured.js"),
+                `import { _addPreopenWithAdapter, _clearPreopens, _setCwd, loadOpfsCapability, OpfsFilesystemAdapter } from "@bytecodealliance/preview2-shim/filesystem";
+                 import { test as component } from "./component.js";
+
+                 const SCRATCH_DIR = "opfs-e2e-scratch";
+
+                 async function loadPreopen(dirHandle) {
+                     _clearPreopens();
+                     const capability = await loadOpfsCapability(dirHandle);
+                     const adapter = new OpfsFilesystemAdapter();
+                     _addPreopenWithAdapter("/", adapter, capability);
+                     _setCwd("/");
+                     return adapter;
+                 }
+
+                 export const test = {
+                     async run() {
+                         const opfsRoot = await navigator.storage.getDirectory();
+                         try {
+                             await opfsRoot.removeEntry(SCRATCH_DIR, { recursive: true });
+                         } catch {
+                             // nothing to clean up from a previous run
+                         }
+                         const dirHandle = await opfsRoot.getDirectoryHandle(SCRATCH_DIR, { create: true });
+
+                         try {
+                             const adapter = await loadPreopen(dirHandle);
+                             const writeResult = component.run();
+                             // Let the debounced automatic flush (scheduled on a microtask by the
+                             // writes above) settle before also flushing explicitly - otherwise the
+                             // two race against each other on the same OPFS handles.
+                             await new Promise((resolve) => setTimeout(resolve, 0));
+                             await adapter.flush();
+
+                             await loadPreopen(dirHandle);
+                             const readResult = component.run();
+
+                             return JSON.stringify({ writeResult, readResult });
+                         } finally {
+                             await opfsRoot.removeEntry(SCRATCH_DIR, { recursive: true });
+                         }
+                     },
+                 };
+                 export { test as "tests:p2-shim/test" };`,
+            );
+            harness = await startTestServer({ transpiledOutputDir: outDir });
+            const { statusJSON } = await runBasicHarnessPageTest({
+                browser: harness.browser,
+                url: `${harness.baseURL}/index.html#transpiled:configured.js`,
+            });
+            results = JSON.parse(statusJSON.msg!);
+        } finally {
+            if (harness) {
+                await harness.cleanup();
+            } else {
+                await rm(outDir, { recursive: true, force: true });
+            }
+        }
+    }, 120_000);
+
+    test.concurrent("first run creates files, symlinks, and a marker under OPFS", () => {
+        assert.strictEqual(results.writeResult, "write:ok");
+    });
+
+    test.concurrent("second run confirms writes and symlinks survived a flush + reload", () => {
+        assert.strictEqual(results.readResult, "read:ok");
+    });
+});

--- a/packages/preview2-shim/test/browser/opfs-filesystem-e2e.ts
+++ b/packages/preview2-shim/test/browser/opfs-filesystem-e2e.ts
@@ -1,5 +1,5 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
+import { copyFile, mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { componentize } from "@bytecodealliance/componentize-js";
@@ -13,6 +13,10 @@ import {
     startTestServer,
 } from "../common.js";
 
+const OPFS_FIXTURES_DIR = fileURLToPath(
+    new URL("../fixtures/browser/opfs-filesystem/", import.meta.url),
+);
+
 suite("browser OPFS filesystem adapter from a component", () => {
     let results: { writeResult: string; readResult: string };
 
@@ -21,9 +25,7 @@ suite("browser OPFS filesystem adapter from a component", () => {
         let harness: Awaited<ReturnType<typeof startTestServer>> | undefined;
         try {
             const { component } = await componentize({
-                sourcePath: fileURLToPath(
-                    new URL("../fixtures/browser/opfs-filesystem/component.js", import.meta.url),
-                ),
+                sourcePath: `${OPFS_FIXTURES_DIR}component.js`,
                 witPath: FIXTURES_WIT_DIR,
                 worldName: "browser-fs-write",
             });
@@ -36,57 +38,11 @@ suite("browser OPFS filesystem adapter from a component", () => {
                 await mkdir(dirname(path), { recursive: true });
                 await writeFile(path, bytes);
             }
-            // Runs the component's `run()` once against a live `OpfsFilesystemAdapter` to
-            // create content, flushes it to real OPFS storage, then reloads that same OPFS
-            // directory into a brand new adapter and runs `run()` again - proving writes and
-            // symlinks made across the component boundary actually survive in OPFS itself,
-            // rather than only in one adapter's in-memory tree.
-            await writeFile(
-                join(outDir, "configured.js"),
-                `import { _addPreopenWithAdapter, _clearPreopens, _setCwd, loadOpfsCapability, OpfsFilesystemAdapter } from "@bytecodealliance/preview2-shim/filesystem";
-                 import { test as component } from "./component.js";
-
-                 const SCRATCH_DIR = "opfs-e2e-scratch";
-
-                 async function loadPreopen(dirHandle) {
-                     _clearPreopens();
-                     const capability = await loadOpfsCapability(dirHandle);
-                     const adapter = new OpfsFilesystemAdapter();
-                     _addPreopenWithAdapter("/", adapter, capability);
-                     _setCwd("/");
-                     return adapter;
-                 }
-
-                 export const test = {
-                     async run() {
-                         const opfsRoot = await navigator.storage.getDirectory();
-                         try {
-                             await opfsRoot.removeEntry(SCRATCH_DIR, { recursive: true });
-                         } catch {
-                             // nothing to clean up from a previous run
-                         }
-                         const dirHandle = await opfsRoot.getDirectoryHandle(SCRATCH_DIR, { create: true });
-
-                         try {
-                             const adapter = await loadPreopen(dirHandle);
-                             const writeResult = component.run();
-                             // Let the debounced automatic flush (scheduled on a microtask by the
-                             // writes above) settle before also flushing explicitly - otherwise the
-                             // two race against each other on the same OPFS handles.
-                             await new Promise((resolve) => setTimeout(resolve, 0));
-                             await adapter.flush();
-
-                             await loadPreopen(dirHandle);
-                             const readResult = component.run();
-
-                             return JSON.stringify({ writeResult, readResult });
-                         } finally {
-                             await opfsRoot.removeEntry(SCRATCH_DIR, { recursive: true });
-                         }
-                     },
-                 };
-                 export { test as "tests:p2-shim/test" };`,
+            await copyFile(
+                `${OPFS_FIXTURES_DIR}persistence-configured.js`,
+                `${outDir}/configured.js`,
             );
+
             harness = await startTestServer({ transpiledOutputDir: outDir });
             const { statusJSON } = await runBasicHarnessPageTest({
                 browser: harness.browser,
@@ -108,5 +64,48 @@ suite("browser OPFS filesystem adapter from a component", () => {
 
     test.concurrent("second run confirms writes and symlinks survived a flush + reload", () => {
         assert.strictEqual(results.readResult, "read:ok");
+    });
+});
+
+suite("browser OPFS cross-tab locking via real navigator.locks", () => {
+    let results: { localResultB: boolean; queuedWhileHeld: boolean; grantedAfterRelease: boolean };
+
+    beforeAll(async () => {
+        // No wasm component is involved here - this exercises the shim's browser API
+        // (OpfsFilesystemAdapter, real navigator.locks/OPFS) directly, rather than the
+        // wasi:filesystem ABI, which the suite above already covers.
+        const outDir = await getTmpDir();
+        let harness: Awaited<ReturnType<typeof startTestServer>> | undefined;
+        try {
+            await copyFile(
+                `${OPFS_FIXTURES_DIR}cross-tab-locking-configured.js`,
+                `${outDir}/configured.js`,
+            );
+
+            harness = await startTestServer({ transpiledOutputDir: outDir });
+            const { statusJSON } = await runBasicHarnessPageTest({
+                browser: harness.browser,
+                url: `${harness.baseURL}/index.html#transpiled:configured.js`,
+            });
+            results = JSON.parse(statusJSON.msg!);
+        } finally {
+            if (harness) {
+                await harness.cleanup();
+            } else {
+                await rm(outDir, { recursive: true, force: true });
+            }
+        }
+    }, 60_000);
+
+    test.concurrent("adapter B's local lock check succeeds independently of adapter A", () => {
+        assert.strictEqual(results.localResultB, true);
+    });
+
+    test.concurrent("adapter B's real cross-tab request queues while adapter A holds the lock", () => {
+        assert.strictEqual(results.queuedWhileHeld, true);
+    });
+
+    test.concurrent("adapter B's real cross-tab request is granted after adapter A unlocks", () => {
+        assert.strictEqual(results.grantedAfterRelease, true);
     });
 });

--- a/packages/preview2-shim/test/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/test/browser/opfs-filesystem.ts
@@ -11,14 +11,17 @@ class FakeFileHandle {
 
     async getFile() {
         const bytes = this.#bytes;
-        return { arrayBuffer: async () => bytes.buffer } as unknown as File;
+        return {
+            arrayBuffer: async () => bytes.buffer,
+            text: async () => new TextDecoder().decode(bytes),
+        } as unknown as File;
     }
 
     async createWritable() {
         const chunks: Uint8Array[] = [];
         return {
-            write: async (chunk: Uint8Array) => {
-                chunks.push(chunk);
+            write: async (chunk: Uint8Array | string) => {
+                chunks.push(typeof chunk === "string" ? new TextEncoder().encode(chunk) : chunk);
             },
             close: async () => {
                 this.#bytes = chunks[0] ?? new Uint8Array();
@@ -107,5 +110,73 @@ suite("Browser OPFS filesystem adapter", () => {
         const persistedFile = await persistedDir.getFileHandle("todo.txt");
         const buffer = await (await persistedFile.getFile()).arrayBuffer();
         assert.strictEqual(new TextDecoder().decode(buffer), "buy milk");
+    });
+
+    test("symlinks survive a flush + reload via the sidecar metadata file", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
+            "../../src/browser/opfs-filesystem.js"
+        );
+        const root = new FakeDirectoryHandle();
+        root.entriesMap.set("target.txt", new FakeFileHandle(new TextEncoder().encode("hello")));
+
+        const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+        const adapter = new OpfsFilesystemAdapter();
+        const descriptor = adapter.getRoot(capability);
+        descriptor.symlinkAt("target.txt", "link.txt");
+
+        await adapter.flush();
+
+        // The sidecar file isn't surfaced as a regular guest-visible entry.
+        await root.getFileHandle(".__wasi_symlinks__.json");
+        const reloaded = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+        const reloadedAdapter = new OpfsFilesystemAdapter();
+        const reloadedDescriptor = reloadedAdapter.getRoot(reloaded);
+
+        assert.strictEqual(reloadedDescriptor.readlinkAt("link.txt"), "target.txt");
+        assert.strictEqual(reloadedDescriptor.statAt({}, "link.txt").type, "symbolic-link");
+        assert.strictEqual(reloadedDescriptor.statAt({ symlinkFollow: true }, "link.txt").size, 5n);
+
+        // Removing the last symlink drops the now-empty sidecar file too.
+        reloadedDescriptor.unlinkFileAt("link.txt");
+        await reloadedAdapter.flush();
+        let sidecarStillExists = true;
+        try {
+            await root.getFileHandle(".__wasi_symlinks__.json");
+        } catch {
+            sidecarStillExists = false;
+        }
+        assert.strictEqual(sidecarStillExists, false);
+    });
+
+    test("nested symlinks are recorded in a single root-level sidecar file, not one per directory", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
+            "../../src/browser/opfs-filesystem.js"
+        );
+        const root = new FakeDirectoryHandle();
+        root.entriesMap.set("target.txt", new FakeFileHandle(new TextEncoder().encode("hello")));
+
+        const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+        const adapter = new OpfsFilesystemAdapter();
+        const descriptor = adapter.getRoot(capability);
+        descriptor.createDirectoryAt("nested");
+        const nested = descriptor.openAt({}, "nested", { directory: true }, { read: true });
+        nested.symlinkAt("../target.txt", "link.txt");
+
+        await adapter.flush();
+
+        // No sidecar leaked into the nested directory itself.
+        const nestedHandle = await root.getDirectoryHandle("nested");
+        assert.strictEqual(nestedHandle.entriesMap.has(".__wasi_symlinks__.json"), false);
+
+        const sidecar = await root.getFileHandle(".__wasi_symlinks__.json");
+        const recorded = JSON.parse(await (await sidecar.getFile()).text());
+        assert.deepStrictEqual(recorded, { "nested/link.txt": "../target.txt" });
+
+        const reloaded = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+        const reloadedAdapter = new OpfsFilesystemAdapter();
+        const reloadedDescriptor = reloadedAdapter.getRoot(reloaded);
+        const reloadedNested = reloadedDescriptor.openAt({}, "nested", { directory: true }, { read: true });
+        assert.strictEqual(reloadedNested.readlinkAt("link.txt"), "../target.txt");
+        assert.strictEqual(reloadedDescriptor.statAt({ symlinkFollow: true }, "nested/link.txt").size, 5n);
     });
 });

--- a/packages/preview2-shim/test/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/test/browser/opfs-filesystem.ts
@@ -1,4 +1,5 @@
 import { suite, test, assert } from "vitest";
+import { BrowserLockManager } from "../../src/browser/opfs-filesystem.js";
 
 /** Minimal in-memory stand-in for the OPFS FileSystemDirectoryHandle/FileSystemFileHandle API. */
 class FakeFileHandle {
@@ -217,32 +218,23 @@ suite("Browser OPFS filesystem adapter", () => {
             await import("../../src/browser/opfs-filesystem.js");
         const requests: Array<{ name: string; mode: string }> = [];
         const fakeNavigator = {
-            locks: {
-                request: (
-                    name: string,
-                    options: { mode: string },
-                    callback: () => Promise<void>,
-                ) => {
-                    requests.push({ name, mode: options.mode });
-                    return Promise.resolve(callback());
-                },
+            request: (name: string, options: { mode: string }, callback: () => Promise<void>) => {
+                requests.push({ name, mode: options.mode });
+                return Promise.resolve(callback());
             },
-        };
+        } as BrowserLockManager;
 
         const root = new FakeDirectoryHandle("sandbox");
         root.entriesMap.set("file.txt", new FakeFileHandle());
         const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
 
-        const defaultAdapter = new OpfsFilesystemAdapter({ navigator: fakeNavigator });
+        const defaultAdapter = new OpfsFilesystemAdapter();
         const defaultDescriptor = defaultAdapter.getRoot(capability) as any;
         defaultDescriptor.openAt({}, "file.txt", {}, { read: true }).tryLockShared();
         assert.strictEqual(requests.length, 0);
 
         const optedIn = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
-        const lockingAdapter = new OpfsFilesystemAdapter({
-            crossTabLocking: true,
-            navigator: fakeNavigator,
-        });
+        const lockingAdapter = new OpfsFilesystemAdapter({ lockManager: fakeNavigator });
         const lockingDescriptor = lockingAdapter.getRoot(optedIn) as any;
         const opened = lockingDescriptor.openAt({}, "file.txt", {}, { read: true });
         assert.strictEqual(opened.tryLockExclusive(), true);

--- a/packages/preview2-shim/test/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/test/browser/opfs-filesystem.ts
@@ -79,10 +79,9 @@ class FakeDirectoryHandle {
 }
 
 suite("Browser OPFS filesystem adapter", () => {
-    test("loads OPFS content into a synchronous in-memory tree", async () => {
-        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
-            "../../src/browser/opfs-filesystem.js"
-        );
+    test.concurrent("loads OPFS content into a synchronous in-memory tree", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } =
+            await import("../../src/browser/opfs-filesystem.js");
         const root = new FakeDirectoryHandle();
         root.entriesMap.set("greeting.txt", new FakeFileHandle(new TextEncoder().encode("hi")));
 
@@ -93,10 +92,9 @@ suite("Browser OPFS filesystem adapter", () => {
         assert.strictEqual(descriptor.statAt({}, "greeting.txt").size, 2n);
     });
 
-    test("flush persists in-memory writes back to OPFS", async () => {
-        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
-            "../../src/browser/opfs-filesystem.js"
-        );
+    test.concurrent("flush persists in-memory writes back to OPFS", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } =
+            await import("../../src/browser/opfs-filesystem.js");
         const root = new FakeDirectoryHandle();
 
         const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
@@ -117,10 +115,9 @@ suite("Browser OPFS filesystem adapter", () => {
         assert.strictEqual(new TextDecoder().decode(buffer), "buy milk");
     });
 
-    test("symlinks survive a flush + reload via the sidecar metadata file", async () => {
-        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
-            "../../src/browser/opfs-filesystem.js"
-        );
+    test.concurrent("symlinks survive a flush + reload via the sidecar metadata file", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } =
+            await import("../../src/browser/opfs-filesystem.js");
         const root = new FakeDirectoryHandle();
         root.entriesMap.set("target.txt", new FakeFileHandle(new TextEncoder().encode("hello")));
 
@@ -153,10 +150,9 @@ suite("Browser OPFS filesystem adapter", () => {
         assert.strictEqual(sidecarStillExists, false);
     });
 
-    test("nested symlinks are recorded in a single root-level sidecar file, not one per directory", async () => {
-        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
-            "../../src/browser/opfs-filesystem.js"
-        );
+    test.concurrent("nested symlinks are recorded in a single root-level sidecar file, not one per directory", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } =
+            await import("../../src/browser/opfs-filesystem.js");
         const root = new FakeDirectoryHandle();
         root.entriesMap.set("target.txt", new FakeFileHandle(new TextEncoder().encode("hello")));
 
@@ -180,15 +176,22 @@ suite("Browser OPFS filesystem adapter", () => {
         const reloaded = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
         const reloadedAdapter = new OpfsFilesystemAdapter();
         const reloadedDescriptor = reloadedAdapter.getRoot(reloaded);
-        const reloadedNested = reloadedDescriptor.openAt({}, "nested", { directory: true }, { read: true });
+        const reloadedNested = reloadedDescriptor.openAt(
+            {},
+            "nested",
+            { directory: true },
+            { read: true },
+        );
         assert.strictEqual(reloadedNested.readlinkAt("link.txt"), "../target.txt");
-        assert.strictEqual(reloadedDescriptor.statAt({ symlinkFollow: true }, "nested/link.txt").size, 5n);
+        assert.strictEqual(
+            reloadedDescriptor.statAt({ symlinkFollow: true }, "nested/link.txt").size,
+            5n,
+        );
     });
 
-    test("mutations persist to OPFS automatically without an explicit flush() call", async () => {
-        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
-            "../../src/browser/opfs-filesystem.js"
-        );
+    test.concurrent("mutations persist to OPFS automatically without an explicit flush() call", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } =
+            await import("../../src/browser/opfs-filesystem.js");
         const root = new FakeDirectoryHandle();
 
         const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
@@ -209,48 +212,43 @@ suite("Browser OPFS filesystem adapter", () => {
         assert.strictEqual(new TextDecoder().decode(buffer), "auto");
     });
 
-    test("cross-tab locking is off by default and opt-in via navigator.locks", async () => {
-        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
-            "../../src/browser/opfs-filesystem.js"
-        );
+    test.concurrent("cross-tab locking is off by default and opt-in via navigator.locks", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } =
+            await import("../../src/browser/opfs-filesystem.js");
         const requests: Array<{ name: string; mode: string }> = [];
-        const fakeLocks = {
-            request: (name: string, options: { mode: string }, callback: () => Promise<void>) => {
-                requests.push({ name, mode: options.mode });
-                return Promise.resolve(callback());
+        const fakeNavigator = {
+            locks: {
+                request: (
+                    name: string,
+                    options: { mode: string },
+                    callback: () => Promise<void>,
+                ) => {
+                    requests.push({ name, mode: options.mode });
+                    return Promise.resolve(callback());
+                },
             },
         };
-        const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
-        Object.defineProperty(globalThis, "navigator", {
-            value: { locks: fakeLocks },
-            configurable: true,
+
+        const root = new FakeDirectoryHandle("sandbox");
+        root.entriesMap.set("file.txt", new FakeFileHandle());
+        const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+
+        const defaultAdapter = new OpfsFilesystemAdapter({ navigator: fakeNavigator });
+        const defaultDescriptor = defaultAdapter.getRoot(capability) as any;
+        defaultDescriptor.openAt({}, "file.txt", {}, { read: true }).tryLockShared();
+        assert.strictEqual(requests.length, 0);
+
+        const optedIn = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+        const lockingAdapter = new OpfsFilesystemAdapter({
+            crossTabLocking: true,
+            navigator: fakeNavigator,
         });
+        const lockingDescriptor = lockingAdapter.getRoot(optedIn) as any;
+        const opened = lockingDescriptor.openAt({}, "file.txt", {}, { read: true });
+        assert.strictEqual(opened.tryLockExclusive(), true);
 
-        try {
-            const root = new FakeDirectoryHandle("sandbox");
-            root.entriesMap.set("file.txt", new FakeFileHandle());
-            const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
-
-            const defaultAdapter = new OpfsFilesystemAdapter();
-            const defaultDescriptor = defaultAdapter.getRoot(capability) as any;
-            defaultDescriptor.openAt({}, "file.txt", {}, { read: true }).tryLockShared();
-            assert.strictEqual(requests.length, 0);
-
-            const optedIn = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
-            const lockingAdapter = new OpfsFilesystemAdapter({ crossTabLocking: true });
-            const lockingDescriptor = lockingAdapter.getRoot(optedIn) as any;
-            const opened = lockingDescriptor.openAt({}, "file.txt", {}, { read: true });
-            assert.strictEqual(opened.tryLockExclusive(), true);
-
-            assert.strictEqual(requests.length, 1);
-            assert.strictEqual(requests[0].mode, "exclusive");
-            assert.strictEqual(requests[0].name, "sandbox/file.txt");
-        } finally {
-            if (originalNavigator) {
-                Object.defineProperty(globalThis, "navigator", originalNavigator);
-            } else {
-                delete (globalThis as any).navigator;
-            }
-        }
+        assert.strictEqual(requests.length, 1);
+        assert.strictEqual(requests[0].mode, "exclusive");
+        assert.strictEqual(requests[0].name, "sandbox/file.txt");
     });
 });

--- a/packages/preview2-shim/test/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/test/browser/opfs-filesystem.ts
@@ -33,6 +33,11 @@ class FakeFileHandle {
 class FakeDirectoryHandle {
     kind = "directory" as const;
     entriesMap = new Map<string, FakeFileHandle | FakeDirectoryHandle>();
+    name: string;
+
+    constructor(name = "") {
+        this.name = name;
+    }
 
     async *entries(): AsyncIterableIterator<[string, FakeFileHandle | FakeDirectoryHandle]> {
         yield* this.entriesMap.entries();
@@ -178,5 +183,74 @@ suite("Browser OPFS filesystem adapter", () => {
         const reloadedNested = reloadedDescriptor.openAt({}, "nested", { directory: true }, { read: true });
         assert.strictEqual(reloadedNested.readlinkAt("link.txt"), "../target.txt");
         assert.strictEqual(reloadedDescriptor.statAt({ symlinkFollow: true }, "nested/link.txt").size, 5n);
+    });
+
+    test("mutations persist to OPFS automatically without an explicit flush() call", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
+            "../../src/browser/opfs-filesystem.js"
+        );
+        const root = new FakeDirectoryHandle();
+
+        const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+        const adapter = new OpfsFilesystemAdapter();
+        const descriptor = adapter.getRoot(capability);
+
+        const file = descriptor.openAt({}, "note.txt", { create: true }, { write: true });
+        const stream = file.writeViaStream(0n);
+        stream.checkWrite();
+        stream.write(new TextEncoder().encode("auto"));
+
+        // No explicit flush()/dispose() call - persistence is scheduled on a microtask;
+        // yield to a macrotask so the async write chain it kicks off can finish.
+        await new Promise((resolve) => setTimeout(resolve, 0));
+
+        const persisted = await root.getFileHandle("note.txt");
+        const buffer = await (await persisted.getFile()).arrayBuffer();
+        assert.strictEqual(new TextDecoder().decode(buffer), "auto");
+    });
+
+    test("cross-tab locking is off by default and opt-in via navigator.locks", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
+            "../../src/browser/opfs-filesystem.js"
+        );
+        const requests: Array<{ name: string; mode: string }> = [];
+        const fakeLocks = {
+            request: (name: string, options: { mode: string }, callback: () => Promise<void>) => {
+                requests.push({ name, mode: options.mode });
+                return Promise.resolve(callback());
+            },
+        };
+        const originalNavigator = Object.getOwnPropertyDescriptor(globalThis, "navigator");
+        Object.defineProperty(globalThis, "navigator", {
+            value: { locks: fakeLocks },
+            configurable: true,
+        });
+
+        try {
+            const root = new FakeDirectoryHandle("sandbox");
+            root.entriesMap.set("file.txt", new FakeFileHandle());
+            const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+
+            const defaultAdapter = new OpfsFilesystemAdapter();
+            const defaultDescriptor = defaultAdapter.getRoot(capability) as any;
+            defaultDescriptor.openAt({}, "file.txt", {}, { read: true }).tryLockShared();
+            assert.strictEqual(requests.length, 0);
+
+            const optedIn = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+            const lockingAdapter = new OpfsFilesystemAdapter({ crossTabLocking: true });
+            const lockingDescriptor = lockingAdapter.getRoot(optedIn) as any;
+            const opened = lockingDescriptor.openAt({}, "file.txt", {}, { read: true });
+            assert.strictEqual(opened.tryLockExclusive(), true);
+
+            assert.strictEqual(requests.length, 1);
+            assert.strictEqual(requests[0].mode, "exclusive");
+            assert.strictEqual(requests[0].name, "sandbox/file.txt");
+        } finally {
+            if (originalNavigator) {
+                Object.defineProperty(globalThis, "navigator", originalNavigator);
+            } else {
+                delete (globalThis as any).navigator;
+            }
+        }
     });
 });

--- a/packages/preview2-shim/test/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/test/browser/opfs-filesystem.ts
@@ -243,4 +243,55 @@ suite("Browser OPFS filesystem adapter", () => {
         assert.strictEqual(requests[0].mode, "exclusive");
         assert.strictEqual(requests[0].name, "sandbox/file.txt");
     });
+
+    // Regression coverage for a bug found while integrating this adapter into application:
+    // `withCrossTabLocking` wraps every descriptor returned by a cross-tab-locking-enabled
+    // adapter in a `Proxy`. `InMemoryFilesystemAdapter#renameAt`/`#isSameObject` reach into a
+    // *second* descriptor argument with raw private-field access (`descriptor.#entry`), which
+    // bypasses `Proxy` traps and fails its brand check - throwing a `TypeError` instead of
+    // renaming/comparing. In the real component this surfaced as a silently hung `mv` command
+    // (the guest's rename call never returned), not a catchable error.
+    test.concurrent("renameAt works when the destination descriptor is lock-wrapped", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } =
+            await import("../../src/browser/opfs-filesystem.js");
+        const fakeNavigator = {
+            request: (_name: string, _options: { mode: string }, callback: () => Promise<void>) =>
+                Promise.resolve(callback()),
+        } as BrowserLockManager;
+
+        const root = new FakeDirectoryHandle("sandbox");
+        root.entriesMap.set("old.txt", new FakeFileHandle(new TextEncoder().encode("hi")));
+        const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+
+        const adapter = new OpfsFilesystemAdapter({ lockManager: fakeNavigator });
+        const cwd = adapter.getRoot(capability) as any;
+        // Two separate lock-wrapped handles onto the same directory, as a guest issuing
+        // `mv old.txt new.txt` would produce (one descriptor to resolve each path against).
+        const sourceDir = cwd.openAt({}, ".", { directory: true }, {});
+        const destDir = cwd.openAt({}, ".", { directory: true }, {});
+
+        sourceDir.renameAt("old.txt", destDir, "new.txt");
+
+        assert.strictEqual(cwd.statAt({}, "new.txt").size, 2n);
+    });
+
+    test.concurrent("isSameObject works when comparing lock-wrapped descriptors", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } =
+            await import("../../src/browser/opfs-filesystem.js");
+        const fakeNavigator = {
+            request: (_name: string, _options: { mode: string }, callback: () => Promise<void>) =>
+                Promise.resolve(callback()),
+        } as BrowserLockManager;
+
+        const root = new FakeDirectoryHandle("sandbox");
+        root.entriesMap.set("file.txt", new FakeFileHandle());
+        const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+
+        const adapter = new OpfsFilesystemAdapter({ lockManager: fakeNavigator });
+        const cwd = adapter.getRoot(capability) as any;
+        const a = cwd.openAt({}, "file.txt", {}, { read: true });
+        const b = cwd.openAt({}, "file.txt", {}, { read: true });
+
+        assert.strictEqual(a.isSameObject(b), true);
+    });
 });

--- a/packages/preview2-shim/test/browser/opfs-filesystem.ts
+++ b/packages/preview2-shim/test/browser/opfs-filesystem.ts
@@ -1,0 +1,111 @@
+import { suite, test, assert } from "vitest";
+
+/** Minimal in-memory stand-in for the OPFS FileSystemDirectoryHandle/FileSystemFileHandle API. */
+class FakeFileHandle {
+    kind = "file" as const;
+    #bytes: Uint8Array;
+
+    constructor(bytes: Uint8Array = new Uint8Array()) {
+        this.#bytes = bytes;
+    }
+
+    async getFile() {
+        const bytes = this.#bytes;
+        return { arrayBuffer: async () => bytes.buffer } as unknown as File;
+    }
+
+    async createWritable() {
+        const chunks: Uint8Array[] = [];
+        return {
+            write: async (chunk: Uint8Array) => {
+                chunks.push(chunk);
+            },
+            close: async () => {
+                this.#bytes = chunks[0] ?? new Uint8Array();
+            },
+        };
+    }
+}
+
+class FakeDirectoryHandle {
+    kind = "directory" as const;
+    entriesMap = new Map<string, FakeFileHandle | FakeDirectoryHandle>();
+
+    async *entries(): AsyncIterableIterator<[string, FakeFileHandle | FakeDirectoryHandle]> {
+        yield* this.entriesMap.entries();
+    }
+
+    async getDirectoryHandle(name: string, options?: { create?: boolean }) {
+        let handle = this.entriesMap.get(name);
+        if (!handle) {
+            if (!options?.create) {
+                throw new DOMException("not found", "NotFoundError");
+            }
+            handle = new FakeDirectoryHandle();
+            this.entriesMap.set(name, handle);
+        }
+        if (!(handle instanceof FakeDirectoryHandle)) {
+            throw new Error(`"${name}" is not a directory`);
+        }
+        return handle;
+    }
+
+    async getFileHandle(name: string, options?: { create?: boolean }) {
+        let handle = this.entriesMap.get(name);
+        if (!handle) {
+            if (!options?.create) {
+                throw new DOMException("not found", "NotFoundError");
+            }
+            handle = new FakeFileHandle();
+            this.entriesMap.set(name, handle);
+        }
+        if (!(handle instanceof FakeFileHandle)) {
+            throw new Error(`"${name}" is not a file`);
+        }
+        return handle;
+    }
+
+    async removeEntry(name: string) {
+        this.entriesMap.delete(name);
+    }
+}
+
+suite("Browser OPFS filesystem adapter", () => {
+    test("loads OPFS content into a synchronous in-memory tree", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
+            "../../src/browser/opfs-filesystem.js"
+        );
+        const root = new FakeDirectoryHandle();
+        root.entriesMap.set("greeting.txt", new FakeFileHandle(new TextEncoder().encode("hi")));
+
+        const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+        const adapter = new OpfsFilesystemAdapter();
+        const descriptor = adapter.getRoot(capability);
+
+        assert.strictEqual(descriptor.statAt({}, "greeting.txt").size, 2n);
+    });
+
+    test("flush persists in-memory writes back to OPFS", async () => {
+        const { loadOpfsCapability, OpfsFilesystemAdapter } = await import(
+            "../../src/browser/opfs-filesystem.js"
+        );
+        const root = new FakeDirectoryHandle();
+
+        const capability = await loadOpfsCapability(root as unknown as FileSystemDirectoryHandle);
+        const adapter = new OpfsFilesystemAdapter();
+        const descriptor = adapter.getRoot(capability);
+
+        descriptor.createDirectoryAt("notes");
+        const file = descriptor.openAt({}, "notes/todo.txt", { create: true }, { write: true });
+        const stream = file.writeViaStream(0n);
+        stream.checkWrite();
+        stream.write(new TextEncoder().encode("buy milk"));
+
+        await adapter.flush();
+
+        const persistedDir = await root.getDirectoryHandle("notes");
+        const persistedFile = await persistedDir.getFileHandle("todo.txt");
+        const buffer = await (await persistedFile.getFile()).arrayBuffer();
+        assert.strictEqual(new TextDecoder().decode(buffer), "buy milk");
+    });
+});

--- a/packages/preview2-shim/test/fixtures/browser/opfs-filesystem/component.js
+++ b/packages/preview2-shim/test/fixtures/browser/opfs-filesystem/component.js
@@ -1,0 +1,68 @@
+import { getDirectories } from "wasi:filesystem/preopens@0.2.8";
+
+const dispose = (resource) => resource[Symbol.dispose || Symbol.for("dispose")]();
+
+function check(condition, message) {
+    if (!condition) {
+        throw message;
+    }
+}
+
+function readText(file) {
+    return new TextDecoder().decode(file.read(200n, 0n)[0]);
+}
+
+function exists(root, path) {
+    try {
+        root.statAt({}, path);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
+// Called twice by the host, against the same OPFS directory: once against a live
+// `OpfsFilesystemAdapter` to create content, and once more after a flush + reload into a
+// fresh adapter, to confirm the writes and symlink actually persisted to OPFS storage
+// rather than just living in that first adapter's in-memory tree.
+export const test = {
+    run() {
+        const [[root]] = getDirectories();
+
+        if (!exists(root, "marker.txt")) {
+            root.createDirectoryAt("notes");
+            const file = root.openAt({}, "notes/todo.txt", { create: true }, { write: true });
+            file.write(new TextEncoder().encode("buy milk"), 0n);
+            dispose(file);
+
+            root.symlinkAt("notes/todo.txt", "todo-link.txt");
+
+            const marker = root.openAt({}, "marker.txt", { create: true }, { write: true });
+            marker.write(new TextEncoder().encode("written"), 0n);
+            dispose(marker);
+
+            dispose(root);
+            return "write:ok";
+        }
+
+        try {
+            check(
+                root.readlinkAt("todo-link.txt") === "notes/todo.txt",
+                "symlink target did not survive reload",
+            );
+            const linked = root.openAt(
+                { symlinkFollow: true },
+                "todo-link.txt",
+                {},
+                { read: true },
+            );
+            check(readText(linked) === "buy milk", "file contents did not survive reload");
+            dispose(linked);
+            dispose(root);
+            return "read:ok";
+        } catch (error) {
+            dispose(root);
+            throw error.payload ?? error;
+        }
+    },
+};

--- a/packages/preview2-shim/test/fixtures/browser/opfs-filesystem/cross-tab-locking-configured.js
+++ b/packages/preview2-shim/test/fixtures/browser/opfs-filesystem/cross-tab-locking-configured.js
@@ -1,0 +1,98 @@
+import {
+    loadOpfsCapability,
+    OpfsFilesystemAdapter,
+} from "@bytecodealliance/preview2-shim/filesystem";
+
+const SCRATCH_DIR = "opfs-cross-tab-e2e-scratch";
+
+function check(condition, message) {
+    if (!condition) {
+        throw message;
+    }
+}
+
+async function waitUntil(predicate, { timeout = 5000, interval = 20 } = {}) {
+    const deadline = performance.now() + timeout;
+    while (performance.now() < deadline) {
+        if (await predicate()) {
+            return true;
+        }
+        await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+    return false;
+}
+
+async function isHeldExclusive(lockName) {
+    const { held } = await navigator.locks.query();
+    return held.some((lock) => lock.name === lockName && lock.mode === "exclusive");
+}
+
+async function isPending(lockName) {
+    const { pending } = await navigator.locks.query();
+    return pending.some((lock) => lock.name === lockName);
+}
+
+export const test = {
+    async run() {
+        const opfsRoot = await navigator.storage.getDirectory();
+        try {
+            await opfsRoot.removeEntry(SCRATCH_DIR, { recursive: true });
+        } catch {
+            // nothing to clean up from a previous run
+        }
+        const dirHandle = await opfsRoot.getDirectoryHandle(SCRATCH_DIR, { create: true });
+
+        try {
+            // Two independent adapters/trees over the same OPFS directory, simulating two
+            // tabs: each has its own same-process lock domain, coordinated only through the
+            // real navigator.locks, which a browser shares across same-origin tabs (and,
+            // here, contexts).
+            const capabilityA = await loadOpfsCapability(dirHandle);
+            const adapterA = new OpfsFilesystemAdapter({ lockManager: navigator.locks });
+            const rootA = adapterA.getRoot(capabilityA);
+            const setup = rootA.openAt({}, "shared.txt", { create: true }, { write: true });
+            setup.write(new TextEncoder().encode("x"), 0n);
+            // Let the debounced automatic flush (scheduled on a microtask by the write
+            // above) settle before also flushing explicitly - otherwise the two race on the
+            // same OPFS handles - then await the explicit flush itself, so no write is
+            // still in flight when cleanup below removes the scratch directory (which OPFS
+            // rejects).
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            await adapterA.flush();
+
+            const lockName = `${dirHandle.name}/shared.txt`;
+            const fileA = rootA.openAt({}, "shared.txt", {}, { read: true });
+            check(fileA.tryLockExclusive() === true, "adapter A failed its local lock check");
+
+            check(
+                await waitUntil(() => isHeldExclusive(lockName)),
+                "real navigator.locks grant for adapter A never appeared",
+            );
+
+            // Adapter B doesn't share adapter A's same-process lock state, so its *local*
+            // check succeeds immediately...
+            const capabilityB = await loadOpfsCapability(dirHandle);
+            const adapterB = new OpfsFilesystemAdapter({ lockManager: navigator.locks });
+            const rootB = adapterB.getRoot(capabilityB);
+            const fileB = rootB.openAt({}, "shared.txt", {}, { read: true });
+            const localResultB = fileB.tryLockExclusive();
+
+            // ...but its real cross-tab request queues behind adapter A's, because the
+            // browser's navigator.locks is shared by both.
+            const queuedWhileHeld = await waitUntil(() => isPending(lockName));
+
+            fileA.unlock();
+
+            const grantedAfterRelease = await waitUntil(
+                async () => !(await isPending(lockName)) && (await isHeldExclusive(lockName)),
+            );
+
+            fileB.unlock();
+
+            return JSON.stringify({ localResultB, queuedWhileHeld, grantedAfterRelease });
+        } finally {
+            await opfsRoot.removeEntry(SCRATCH_DIR, { recursive: true });
+        }
+    },
+};
+export { test as "tests:p2-shim/test" };

--- a/packages/preview2-shim/test/fixtures/browser/opfs-filesystem/persistence-configured.js
+++ b/packages/preview2-shim/test/fixtures/browser/opfs-filesystem/persistence-configured.js
@@ -1,0 +1,54 @@
+import {
+    _addPreopenWithAdapter,
+    _clearPreopens,
+    _setCwd,
+    loadOpfsCapability,
+    OpfsFilesystemAdapter,
+} from "@bytecodealliance/preview2-shim/filesystem";
+import { test as component } from "./component.js";
+
+const SCRATCH_DIR = "opfs-e2e-scratch";
+
+async function loadPreopen(dirHandle) {
+    _clearPreopens();
+    const capability = await loadOpfsCapability(dirHandle);
+    const adapter = new OpfsFilesystemAdapter();
+    _addPreopenWithAdapter("/", adapter, capability);
+    _setCwd("/");
+    return adapter;
+}
+
+// Runs the component's `run()` once against a live `OpfsFilesystemAdapter` to create
+// content, flushes it to real OPFS storage, then reloads that same OPFS directory into a
+// brand new adapter and runs `run()` again - proving writes and symlinks made across the
+// component boundary actually survive in OPFS itself, rather than only in one adapter's
+// in-memory tree.
+export const test = {
+    async run() {
+        const opfsRoot = await navigator.storage.getDirectory();
+        try {
+            await opfsRoot.removeEntry(SCRATCH_DIR, { recursive: true });
+        } catch {
+            // nothing to clean up from a previous run
+        }
+        const dirHandle = await opfsRoot.getDirectoryHandle(SCRATCH_DIR, { create: true });
+
+        try {
+            const adapter = await loadPreopen(dirHandle);
+            const writeResult = component.run();
+            // Let the debounced automatic flush (scheduled on a microtask by the writes
+            // above) settle before also flushing explicitly - otherwise the two race
+            // against each other on the same OPFS handles.
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            await adapter.flush();
+
+            await loadPreopen(dirHandle);
+            const readResult = component.run();
+
+            return JSON.stringify({ writeResult, readResult });
+        } finally {
+            await opfsRoot.removeEntry(SCRATCH_DIR, { recursive: true });
+        }
+    },
+};
+export { test as "tests:p2-shim/test" };


### PR DESCRIPTION
Adds a first-party [OPFS](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system)-backed filesystem adapter for `preview2-shim`'s browser `wasi:filesystem` implementation, plus two non-JSPI improvement candidates (advisory locking, in-memory symlink support).

- **`OpfsFilesystemAdapter`** (`src/browser/opfs-filesystem.ts`) - loads a preopened OPFS directory into an in-memory tree once (`loadOpfsCapability()`), so every `Descriptor` op stays fully synchronous - no JSPI required. Mutations flush back to OPFS automatically (debounced to a microtask); `flush()`/`dispose()` force it explicitly.
- **Symlinks** survive a flush + reload via a hidden sidecar file (`.__wasi_symlinks__.json`) per root, since OPFS has no native symlink concept.
- **Advisory locking** (`lockShared`/`lockExclusive`/`tryLock*`/`unlock`) on `BrowserFilesystemDescriptor`, backed by a same-process reader/writer lock in `InMemoryFilesystemAdapter`. `new OpfsFilesystemAdapter({ lockManager: navigator.locks })` opts into best-effort cross-tab coordination via the Web Locks API - off by default. `lockManager` takes a narrow `BrowserLockManager` interface rather than the global `navigator` directly, so it's easy to fake in tests.
- **`_addPreopenWithAdapter`** (`src/browser/filesystem.ts`) lets a host wire a custom adapter into the top-level `wasi:filesystem/preopens` singleton that transpiled components import statically.

Related to: #144 